### PR TITLE
Rework bluetooth pairing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,14 +39,14 @@ all: $(BUILDDIR)/$(ADDON_NAME)
 addon: $(BUILDDIR)/$(ADDON_NAME)-$(ADDON_VERSION).zip
 
 install: $(BUILDDIR)/$(ADDON_NAME)
-	mkdir -p $(DESTDIR)/$(ADDONDIR)
-	cp -R $(BUILDDIR)/$(ADDON_NAME) $(DESTDIR)/$(ADDONDIR)
+	mkdir -p $(DESTDIR)$(ADDONDIR)
+	cp -R $(BUILDDIR)/$(ADDON_NAME) $(DESTDIR)$(ADDONDIR)
 
 clean:
 	rm -rf $(BUILDDIR)
 
 uninstall:
-	rm -rf $(DESTDIR)/$(ADDONDIR)/$(ADDON_NAME)
+	rm -rf $(DESTDIR)$(ADDONDIR)/$(ADDON_NAME)
 
 $(BUILDDIR)/$(ADDON_NAME): $(BUILDDIR)/$(ADDON_NAME)/resources
 	mkdir -p $(BUILDDIR)/$(ADDON_NAME)

--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -408,6 +408,10 @@ msgctxt "#32144"
 msgid "Connect"
 msgstr ""
 
+msgctxt "#32145"
+msgid "Pair"
+msgstr ""
+
 msgctxt "#32146"
 msgid "Hidden Network Name"
 msgstr ""

--- a/src/oe.py
+++ b/src/oe.py
@@ -157,7 +157,7 @@ def enable_service(service):
             pass
         service_file = '%s/services/%s' % (CONFIG_CACHE, service)
     except Exception, e:
-        dbg_log('oe::set_service_cmd', 'ERROR: (' + repr(e) + ')')
+        dbg_log('oe::enable_service', 'ERROR: (' + repr(e) + ')')
 
 
 def set_service_option(service, option, value):
@@ -211,7 +211,7 @@ def get_service_state(service):
 
 def set_service(service, options, state):
     try:
-        dbg_log('oe::set_service', 'enter_function')
+        dbg_log('oe::set_service', 'enter_function', 0)
         config = {}
         changed = False
 
@@ -244,9 +244,9 @@ def set_service(service, options, state):
             if service in defaults._services:
                 for svc in defaults._services[service]:
                     execute('systemctl restart %s' % svc)
-        dbg_log('oe::set_service', 'exit_function')
+        dbg_log('oe::set_service', 'exit_function', 0)
     except Exception, e:
-        dbg_log('oe::set_service_option', 'ERROR: (' + repr(e) + ')')
+        dbg_log('oe::set_service', 'ERROR: (' + repr(e) + ')')
 
 
 def load_file(filename):

--- a/src/oe.py
+++ b/src/oe.py
@@ -212,6 +212,9 @@ def get_service_state(service):
 def set_service(service, options, state):
     try:
         dbg_log('oe::set_service', 'enter_function', 0)
+        dbg_log('oe::set_service::service', repr(service), 0)
+        dbg_log('oe::set_service::options', repr(options), 0)
+        dbg_log('oe::set_service::state', repr(state), 0)
         config = {}
         changed = False
 

--- a/src/oe.py
+++ b/src/oe.py
@@ -108,10 +108,11 @@ def _(code):
 
 
 def dbg_log(source, text, level=4):
-    if os.environ.get('DEBUG', 'no') == 'no':
+    if level == 0 and os.environ.get('DEBUG', 'no') == 'no':
         return
     xbmc.log('## LibreELEC Addon ## ' + source + ' ## ' + text, level)
-    xbmc.log(traceback.format_exc())
+    if level == 4:
+        xbmc.log(traceback.format_exc(), level)
 
 
 def notify(title, message, icon='icon'):

--- a/src/resources/lib/modules/bluetooth.py
+++ b/src/resources/lib/modules/bluetooth.py
@@ -235,7 +235,9 @@ class bluetooth:
         try:
             self.oe.dbg_log('bluetooth::enable_device_standby', 'exit_function', 0)
             devices = self.oe.read_setting('bluetooth', 'standby')
-            if devices == None:
+            if not devices == None:
+                devices = devices.split(',')
+            else:
                 devices = []
             if not listItem.getProperty('entry') in devices:
                 devices.append(listItem.getProperty('entry'))
@@ -250,8 +252,10 @@ class bluetooth:
             devices = self.oe.read_setting('bluetooth', 'standby')
             if not devices == None:
                 devices = devices.split(',')
-                if listItem.getProperty('entry') in devices:
-                    devices.remove(listItem.getProperty('entry'))
+            else:
+                devices = []
+            if listItem.getProperty('entry') in devices:
+                devices.remove(listItem.getProperty('entry'))
             self.oe.write_setting('bluetooth', 'standby', ','.join(devices))
             self.oe.dbg_log('bluetooth::disable_device_standby', 'exit_function', 0)
         except Exception, e:

--- a/src/resources/lib/modules/bluetooth.py
+++ b/src/resources/lib/modules/bluetooth.py
@@ -128,6 +128,8 @@ class bluetooth:
     def adapter_powered(self, adapter, state=1):
         try:
             self.oe.dbg_log('bluetooth::adapter_powered', 'enter_function', 0)
+            self.oe.dbg_log('bluetooth::adapter_powered::adapter', repr(adapter), 0)
+            self.oe.dbg_log('bluetooth::adapter_powered::state', repr(state), 0)
             if int(self.adapter_info(self.dbusBluezAdapter, 'Powered')) != state:
                 self.oe.dbg_log('bluetooth::adapter_powered', 'set state (' + unicode(state) + ')', 0)
                 adapter_interface = dbus.Interface(self.oe.dbusSystemBus.get_object('org.bluez', adapter.object_path),
@@ -141,10 +143,12 @@ class bluetooth:
     def adapter_info(self, adapter, name):
         try:
             self.oe.dbg_log('bluetooth::adapter_info', 'enter_function', 0)
+            self.oe.dbg_log('bluetooth::adapter_info::adapter', repr(adapter), 0)
+            self.oe.dbg_log('bluetooth::adapter_info::name', repr(name), 0)
             adapter_interface = dbus.Interface(self.oe.dbusSystemBus.get_object('org.bluez', adapter.object_path),
                                                'org.freedesktop.DBus.Properties')
-            self.oe.dbg_log('bluetooth::adapter_info', 'exit_function', 0)
             return adapter_interface.Get('org.bluez.Adapter1', name)
+            self.oe.dbg_log('bluetooth::adapter_info', 'exit_function', 0)
         except Exception, e:
             self.oe.dbg_log('bluetooth::adapter_info', 'ERROR: (' + repr(e) + ')', 4)
 
@@ -256,6 +260,7 @@ class bluetooth:
     def pair_device(self, path):
         try:
             self.oe.dbg_log('bluetooth::pair_device', 'enter_function', 0)
+            self.oe.dbg_log('bluetooth::pair_device::path', repr(path), 0)
             self.oe.set_busy(1)
             device = dbus.Interface(self.oe.dbusSystemBus.get_object('org.bluez', path), 'org.bluez.Device1')
             device.Pair(reply_handler=self.pair_reply_handler, error_handler=self.dbus_error_handler)
@@ -282,11 +287,12 @@ class bluetooth:
     def trust_device(self, path):
         try:
             self.oe.dbg_log('bluetooth::trust_device', 'enter_function', 0)
+            self.oe.dbg_log('bluetooth::trust_device::path', repr(path), 0)
             self.oe.set_busy(1)
             prop = dbus.Interface(self.oe.dbusSystemBus.get_object('org.bluez', path), 'org.freedesktop.DBus.Properties')
             prop.Set('org.bluez.Device1', 'Trusted', True)
-            self.oe.dbg_log('bluetooth::trust_device', 'exit_function', 0)
             self.oe.set_busy(0)
+            self.oe.dbg_log('bluetooth::trust_device', 'exit_function', 0)
         except Exception, e:
             self.oe.set_busy(0)
             self.oe.dbg_log('bluetooth::trust_device', 'ERROR: (' + repr(e) + ')', 4)
@@ -294,6 +300,7 @@ class bluetooth:
     def connect_device(self, path):
         try:
             self.oe.dbg_log('bluetooth::connect_device', 'enter_function', 0)
+            self.oe.dbg_log('bluetooth::connect_device::path', repr(path), 0)
             self.oe.set_busy(1)
             device = dbus.Interface(self.oe.dbusSystemBus.get_object('org.bluez', path), 'org.bluez.Device1')
             device.Connect(reply_handler=self.connect_reply_handler, error_handler=self.dbus_error_handler)
@@ -347,8 +354,8 @@ class bluetooth:
             self.dbusBluezAdapter.RemoveDevice(path)
             self.disable_device_standby(listItem)
             self.menu_connections(None)
-            self.oe.dbg_log('bluetooth::remove_device', 'exit_function', 0)
             self.oe.set_busy(0)
+            self.oe.dbg_log('bluetooth::remove_device', 'exit_function', 0)
         except Exception, e:
             self.oe.set_busy(0)
             self.oe.dbg_log('bluetooth::remove_device', 'ERROR: (' + repr(e) + ')', 4)
@@ -360,6 +367,7 @@ class bluetooth:
     def dbus_error_handler(self, error):
         try:
             self.oe.dbg_log('bluetooth::dbus_error_handler', 'enter_function', 0)
+            self.oe.dbg_log('bluetooth::dbus_error_handler::error', repr(error), 0)
             self.oe.set_busy(0)
             err_message = error.get_dbus_message()
             self.oe.notify('Bluetooth error', err_message.split('.')[-1], 'bt')
@@ -636,6 +644,9 @@ class bluetooth:
                                              dbus_interface='org.freedesktop.DBus.ObjectManager', signal_name='InterfacesAdded'))
                 self.signal_receivers.append(self.oe.dbusSystemBus.add_signal_receiver(self.InterfacesRemoved, bus_name='org.bluez',
                                              dbus_interface='org.freedesktop.DBus.ObjectManager', signal_name='InterfacesRemoved'))
+                self.signal_receivers.append(self.oe.dbusSystemBus.add_signal_receiver(self.AdapterChanged,
+                                             dbus_interface='org.freedesktop.DBus.Properties', signal_name='PropertiesChanged',
+                                             arg0='org.bluez.Adapter1', path_keyword='path'))
                 self.signal_receivers.append(self.oe.dbusSystemBus.add_signal_receiver(self.PropertiesChanged,
                                              dbus_interface='org.freedesktop.DBus.Properties', signal_name='PropertiesChanged',
                                              arg0='org.bluez.Device1', path_keyword='path'))
@@ -785,6 +796,17 @@ class bluetooth:
             except Exception, e:
                 self.oe.dbg_log('bluetooth::monitor::InterfacesRemoved', 'ERROR: (' + repr(e) + ')', 4)
 
+        def AdapterChanged(self, interface, changed, invalidated, path):
+            try:
+                self.oe.dbg_log('bluetooth::monitor::AdapterChanged', 'enter_function', 0)
+                self.oe.dbg_log('bluetooth::monitor::AdapterChanged::interface', repr(interface), 0)
+                self.oe.dbg_log('bluetooth::monitor::AdapterChanged::changed', repr(changed), 0)
+                self.oe.dbg_log('bluetooth::monitor::AdapterChanged::invalidated', repr(invalidated), 0)
+                self.oe.dbg_log('bluetooth::monitor::AdapterChanged::path', repr(path), 0)
+                self.oe.dbg_log('bluetooth::monitor::AdapterChanged', 'exit_function', 0)
+            except Exception, e:
+                self.oe.dbg_log('bluetooth::monitor::AdapterChanged', 'ERROR: (' + repr(e) + ')', 4)
+
         def PropertiesChanged(self, interface, changed, invalidated, path):
             try:
                 self.oe.dbg_log('bluetooth::monitor::PropertiesChanged', 'enter_function', 0)
@@ -816,8 +838,9 @@ class bluetooth:
         def TransferChanged(self, path, interface, dummy):
             try:
                 self.oe.dbg_log('bluetooth::monitor::TransferChanged', 'enter_function', 0)
-                self.oe.dbg_log('bluetooth::monitor::TransferChanged::interface', repr(interface), 0)
                 self.oe.dbg_log('bluetooth::monitor::TransferChanged::path', repr(path), 0)
+                self.oe.dbg_log('bluetooth::monitor::TransferChanged::interface', repr(interface), 0)
+                self.oe.dbg_log('bluetooth::monitor::TransferChanged::dummy', repr(dummy), 0)
                 if 'Status' in interface:
                     if interface['Status'] == 'active':
                         self.parent.download_start = time.time()
@@ -918,11 +941,12 @@ class bluetoothAgent(dbus.service.Object):
             self.oe.dbg_log('bluetooth::btAgent::AuthorizeService::uuid=', repr(uuid), 0)
             xbmcDialog = xbmcgui.Dialog()
             answer = xbmcDialog.yesno('LibreELEC Bluetooth', 'AuthorizeService')
+            self.oe.dbg_log('bluetooth::btAgent::AuthorizeService::answer=', repr(answer), 0)
+            self.oe.dbg_log('bluetooth::btAgent::AuthorizeService', 'exit_function', 0)
             if answer == 1:
                 self.oe.dictModules['bluetooth'].trust_device(device)
                 return
             raise Rejected('Connection rejected!')
-            self.oe.dbg_log('bluetooth::btAgent::AuthorizeService', 'exit_function', 0)
         except Exception, e:
             self.oe.dbg_log('bluetooth::btAgent::AuthorizeService', 'ERROR: (' + repr(e) + ')', 4)
 
@@ -952,7 +976,7 @@ class bluetoothAgent(dbus.service.Object):
             xbmcKeyboard = xbmc.Keyboard('', 'RequestPasskey')
             xbmcKeyboard.doModal()
             passkey = xbmcKeyboard.getText()
-            self.oe.dbg_log('bluetooth::btAgent::RequestPasskey', 'return->' + passkey, 0)
+            self.oe.dbg_log('bluetooth::btAgent::RequestPasskey::passkey=', repr(passkey), 0)
             self.oe.dbg_log('bluetooth::btAgent::RequestPasskey', 'exit_function', 0)
             return dbus.UInt32(passkey)
         except Exception, e:
@@ -1000,6 +1024,7 @@ class bluetoothAgent(dbus.service.Object):
             xbmcDialog = xbmcgui.Dialog()
             answer = xbmcDialog.yesno('LibreELEC Bluetooth', 'RequestConfirmation', unicode(passkey))
             self.oe.dbg_log('bluetooth::btAgent::RequestConfirmation::answer=', repr(answer), 0)
+            self.oe.dbg_log('bluetooth::btAgent::RequestConfirmation', 'exit_function', 0)
             if answer == 1:
                 self.oe.dictModules['bluetooth'].trust_device(device)
                 return
@@ -1017,6 +1042,7 @@ class bluetoothAgent(dbus.service.Object):
             if hasattr(self.parent, 'pinkey_window'):
                 if device == self.parent.pinkey_window.device:
                     self.parent.close_pinkey_window()
+            self.oe.dbg_log('bluetooth::btAgent::RequestAuthorization::answer=', repr(answer), 0)
             self.oe.dbg_log('bluetooth::btAgent::RequestAuthorization', 'exit_function', 0)
             if answer == 1:
                 self.oe.dictModules['bluetooth'].trust_device(device)
@@ -1040,14 +1066,24 @@ class bluetoothAgent(dbus.service.Object):
 
 class obexAgent(dbus.service.Object):
 
+    @dbus.service.method('org.bluez.obex.Agent1', in_signature='', out_signature='')
+    def Release(self):
+        try:
+            self.oe.dbg_log('bluetooth::obexAgent::Release', 'enter_function', 0)
+            self.oe.dbg_log('bluetooth::obexAgent::Release', 'exit_function', 0)
+        except Exception, e:
+            self.oe.dbg_log('bluetooth::obexAgent::Release', 'ERROR: (' + repr(e) + ')', 4)
+
     @dbus.service.method('org.bluez.obex.Agent1', in_signature='o', out_signature='s')
     def AuthorizePush(self, path):
         try:
             self.oe.dbg_log('bluetooth::obexAgent::AuthorizePush', 'enter_function', 0)
+            self.oe.dbg_log('bluetooth::obexAgent::AuthorizePush::path=', repr(path), 0)
             transfer = dbus.Interface(self.oe.dbusSystemBus.get_object('org.bluez.obex', path), 'org.freedesktop.DBus.Properties')
             properties = transfer.GetAll('org.bluez.obex.Transfer1')
             xbmcDialog = xbmcgui.Dialog()
             answer = xbmcDialog.yesno('LibreELEC Bluetooth', self.oe._(32381), properties['Name'])
+            self.oe.dbg_log('bluetooth::obexAgent::AuthorizePush::answer=', repr(answer), 0)
             if answer != 1:
                 raise dbus.DBusException('org.bluez.obex.Error.Rejected: Not Authorized')
                 return
@@ -1065,7 +1101,11 @@ class obexAgent(dbus.service.Object):
 
     @dbus.service.method('org.bluez.obex.Agent1', in_signature='', out_signature='')
     def Cancel(self):
-        print('Authorization Canceled')
+        try:
+            self.oe.dbg_log('bluetooth::obexAgent::Cancel', 'enter_function', 0)
+            self.oe.dbg_log('bluetooth::obexAgent::Cancel', 'exit_function', 0)
+        except Exception, e:
+            self.oe.dbg_log('bluetooth::obexAgent::Cancel', 'ERROR: (' + repr(e) + ')', 4)
 
 
 class discoveryThread(threading.Thread):

--- a/src/resources/lib/modules/bluetooth.py
+++ b/src/resources/lib/modules/bluetooth.py
@@ -591,7 +591,7 @@ class bluetooth:
                 del self.pinkey_window
             self.oe.dbg_log('bluetooth::close_pinkey_window', 'exit_function', 0)
         except Exception, e:
-            self.oe.dbg_log('bluetooth::open_pinkey_window', 'ERROR: (' + repr(e) + ')', 4)
+            self.oe.dbg_log('bluetooth::close_pinkey_window', 'ERROR: (' + repr(e) + ')', 4)
 
     def standby_devices(self):
         try:
@@ -916,7 +916,6 @@ class bluetoothAgent(dbus.service.Object):
             xbmc.executebuiltin('Dialog.Close(busydialog)')
             self.oe.dbg_log('bluetooth::btAgent::AuthorizeService::device=', repr(device), 0)
             self.oe.dbg_log('bluetooth::btAgent::AuthorizeService::uuid=', repr(uuid), 0)
-            self.oe.dbg_log('bluetooth::btAgent::AuthorizeService', 'enter_function', 0)
             xbmcDialog = xbmcgui.Dialog()
             answer = xbmcDialog.yesno('LibreELEC Bluetooth', 'AuthorizeService')
             if answer == 1:
@@ -988,7 +987,7 @@ class bluetoothAgent(dbus.service.Object):
             self.parent.open_pinkey_window(runtime=20)
             self.parent.pinkey_window.device = device
             self.parent.pinkey_window.set_label2(pincode)
-            self.oe.dbg_log('bluetooth::btAgent::DisplayPinCode', 'enter_function', 0)
+            self.oe.dbg_log('bluetooth::btAgent::DisplayPinCode', 'exit_function', 0)
         except Exception, e:
             self.oe.dbg_log('bluetooth::btAgent::DisplayPinCode', 'ERROR: (' + repr(e) + ')', 4)
 
@@ -996,7 +995,7 @@ class bluetoothAgent(dbus.service.Object):
     def RequestConfirmation(self, device, passkey):
         try:
             self.oe.dbg_log('bluetooth::btAgent::RequestConfirmation', 'enter_function', 0)
-            self.oe.dbg_log('bluetooth::btAgent::RequestConfirmation::device=', device, 0)
+            self.oe.dbg_log('bluetooth::btAgent::RequestConfirmation::device=', repr(device), 0)
             self.oe.dbg_log('bluetooth::btAgent::RequestConfirmation::passkey=', repr(passkey), 0)
             xbmcDialog = xbmcgui.Dialog()
             answer = xbmcDialog.yesno('LibreELEC Bluetooth', 'RequestConfirmation', unicode(passkey))
@@ -1012,7 +1011,7 @@ class bluetoothAgent(dbus.service.Object):
     def RequestAuthorization(self, device):
         try:
             self.oe.dbg_log('bluetooth::btAgent::RequestAuthorization', 'enter_function', 0)
-            self.oe.dbg_log('bluetooth::btAgent::RequestAuthorization::device=', device, 0)
+            self.oe.dbg_log('bluetooth::btAgent::RequestAuthorization::device=', repr(device), 0)
             xbmcDialog = xbmcgui.Dialog()
             answer = xbmcDialog.yesno('LibreELEC Bluetooth', 'RequestAuthorization')
             if hasattr(self.parent, 'pinkey_window'):
@@ -1030,7 +1029,7 @@ class bluetoothAgent(dbus.service.Object):
     def Cancel(self):
         try:
             self.oe.dbg_log('bluetooth::btAgent::Cancel', 'enter_function', 0)
-            self.oe.dbg_log('bluetooth::btAgent::Cancel', 'enter_function', 0)
+            self.oe.dbg_log('bluetooth::btAgent::Cancel', 'exit_function', 0)
         except Exception, e:
             self.oe.dbg_log('bluetooth::btAgent::Cancel', 'ERROR: (' + repr(e) + ')', 4)
 
@@ -1044,7 +1043,7 @@ class obexAgent(dbus.service.Object):
     @dbus.service.method('org.bluez.obex.Agent1', in_signature='o', out_signature='s')
     def AuthorizePush(self, path):
         try:
-            self.oe.dbg_log('bluetooth::obexAgent::Cancel', 'enter_function', 0)
+            self.oe.dbg_log('bluetooth::obexAgent::AuthorizePush', 'enter_function', 0)
             transfer = dbus.Interface(self.oe.dbusSystemBus.get_object('org.bluez.obex', path), 'org.freedesktop.DBus.Properties')
             properties = transfer.GetAll('org.bluez.obex.Transfer1')
             xbmcDialog = xbmcgui.Dialog()
@@ -1059,8 +1058,8 @@ class obexAgent(dbus.service.Object):
                 self.parent.download_type = properties['Type']
             else:
                 self.parent.download_type = None
-            self.oe.dbg_log('bluetooth::obexAgent::Cancel', 'enter_function', 0)
             return properties['Name']
+            self.oe.dbg_log('bluetooth::obexAgent::AuthorizePush', 'exit_function', 0)
         except Exception, e:
             self.oe.dbg_log('bluetooth::obexAgent::AuthorizePush', 'ERROR: (' + repr(e) + ')', 4)
 

--- a/src/resources/lib/modules/bluetooth.py
+++ b/src/resources/lib/modules/bluetooth.py
@@ -55,7 +55,6 @@ class bluetooth:
             self.oe = oeMain
             self.visible = False
             self.listItems = {}
-            self.update_menu = False
             self.dbusBluezAdapter = None
             self.oe.dbg_log('bluetooth::__init__', 'exit_function', 0)
         except Exception, e:
@@ -212,7 +211,6 @@ class bluetooth:
                 self.connect_device(listItem.getProperty('entry'))
             self.oe.dbg_log('bluetooth::init_device', 'exit_function', 0)
         except Exception, e:
-            self.oe.set_busy(0)
             self.oe.dbg_log('bluetooth::init_device', 'ERROR: (' + repr(e) + ')', 4)
 
     def trust_connect_device(self, listItem=None):
@@ -288,7 +286,6 @@ class bluetooth:
             self.menu_connections()
             self.oe.dbg_log('bluetooth::pair_reply_handler', 'exit_function', 0)
         except Exception, e:
-            self.oe.set_busy(0)
             self.oe.dbg_log('bluetooth::pair_reply_handler', 'ERROR: (' + repr(e) + ')', 4)
 
     def trust_device(self, path):
@@ -335,16 +332,19 @@ class bluetooth:
                 listItem = self.oe.winOeMain.getControl(self.oe.listObject['btlist']).getSelectedItem()
             if listItem is None:
                 return
+            self.oe.set_busy(1)
             device = dbus.Interface(self.oe.dbusSystemBus.get_object('org.bluez', listItem.getProperty('entry')), 'org.bluez.Device1')
             device.Disconnect(reply_handler=self.disconnect_reply_handler, error_handler=self.dbus_error_handler)
             device = None
             self.oe.dbg_log('bluetooth::disconnect_device', 'exit_function', 0)
         except Exception, e:
+            self.oe.set_busy(0)
             self.oe.dbg_log('bluetooth::disconnect_device', 'ERROR: (' + repr(e) + ')', 4)
 
     def disconnect_reply_handler(self):
         try:
             self.oe.dbg_log('bluetooth::disconnect_reply_handler', 'enter_function', 0)
+            self.oe.set_busy(0)
             self.menu_connections()
             self.oe.dbg_log('bluetooth::disconnect_reply_handler', 'exit_function', 0)
         except Exception, e:
@@ -354,11 +354,11 @@ class bluetooth:
     def remove_device(self, listItem=None):
         try:
             self.oe.dbg_log('bluetooth::remove_device', 'enter_function', 0)
-            self.oe.set_busy(1)
             if listItem is None:
                 listItem = self.oe.winOeMain.getControl(self.oe.listObject['btlist']).getSelectedItem()
             if listItem is None:
                 return
+            self.oe.set_busy(1)
             self.oe.dbg_log('bluetooth::remove_device->entry::', listItem.getProperty('entry'), 0)
             path = listItem.getProperty('entry')
             self.dbusBluezAdapter.RemoveDevice(path)
@@ -380,7 +380,8 @@ class bluetooth:
             self.oe.dbg_log('bluetooth::dbus_error_handler::error', repr(error), 0)
             self.oe.set_busy(0)
             err_message = error.get_dbus_message()
-            self.oe.notify('Bluetooth error', err_message.split('.')[-1], 'bt')
+            self.oe.dbg_log('bluetooth::dbus_error_handler::err_message', repr(err_message), 0)
+            self.oe.notify('Bluetooth error', err_message.split('.')[0], 'bt')
             if hasattr(self, 'pinkey_window'):
                 self.close_pinkey_window()
             self.oe.dbg_log('bluetooth::dbus_error_handler', 'ERROR: (' + err_message + ')', 4)
@@ -521,10 +522,8 @@ class bluetooth:
                         self.listItems[dbusDevice].setLabel(apName)
                         for dictProperty in dictProperties:
                             self.listItems[dbusDevice].setProperty(dictProperty, dictProperties[dictProperty])
-            self.update_menu = False
             self.oe.dbg_log('bluetooth::menu_connections', 'exit_function', 0)
         except Exception, e:
-            self.update_menu = False
             self.oe.dbg_log('bluetooth::menu_connections', 'ERROR: (' + repr(e) + ')', 4)
 
     def open_context_menu(self, listItem):
@@ -533,8 +532,18 @@ class bluetooth:
             values = {}
             if listItem is None:
                 listItem = self.oe.winOeMain.getControl(self.oe.listObject['btlist']).getSelectedItem()
-            if listItem.getProperty('Connected') == '1':
+            if listItem.getProperty('Paired') != '1':
                 values[1] = {
+                    'text': self.oe._(32145),
+                    'action': 'init_device',
+                    }
+                if listItem.getProperty('Trusted') != '1':
+                    values[2] = {
+                        'text': self.oe._(32358),
+                        'action': 'trust_connect_device',
+                        }
+            if listItem.getProperty('Connected') == '1':
+                values[3] = {
                     'text': self.oe._(32143),
                     'action': 'disconnect_device',
                     }
@@ -544,29 +553,25 @@ class bluetooth:
                 else:
                     devices = []
                 if listItem.getProperty('entry') in devices:
-                    values[5] = {
+                    values[4] = {
                         'text': self.oe._(32389),
                         'action': 'disable_device_standby',
                         }
                 else:
-                    values[5] = {
+                    values[4] = {
                         'text': self.oe._(32388),
                         'action': 'enable_device_standby',
                         }
-            else:
+            elif listItem.getProperty('Paired') == '1':
                 values[1] = {
                     'text': self.oe._(32144),
                     'action': 'init_device',
                     }
-                values[2] = {
-                    'text': self.oe._(32358),
-                    'action': 'trust_connect_device',
-                    }
-            values[3] = {
+            values[5] = {
                 'text': self.oe._(32141),
                 'action': 'remove_device',
                 }
-            values[4] = {
+            values[6] = {
                 'text': self.oe._(32142),
                 'action': 'menu_connections',
                 }
@@ -839,7 +844,6 @@ class bluetooth:
                         for prop in changed:
                             if prop in properties:
                                 self.parent.listItems[path].setProperty(unicode(prop), unicode(changed[prop]))
-                                self.forceRender()
                     else:
                         self.parent.menu_connections()
                 self.oe.dbg_log('bluetooth::monitor::PropertiesChanged', 'exit_function', 0)
@@ -856,7 +860,7 @@ class bluetooth:
                     if interface['Status'] == 'active':
                         self.parent.download_start = time.time()
                         self.parent.download = xbmcgui.DialogProgress()
-                        self.parent.download.create('LibreELEC Bluetooth Filetransfer', '%s: %s' % (self.oe._(32181).encode('utf-8'),
+                        self.parent.download.create('Bluetooth Filetransfer', '%s: %s' % (self.oe._(32181).encode('utf-8'),
                                                     self.parent.download_file), '', '')
                     else:
                         if hasattr(self.parent, 'download'):
@@ -867,7 +871,7 @@ class bluetooth:
                             del self.parent.download_start
                         if interface['Status'] == 'complete':
                             xbmcDialog = xbmcgui.Dialog()
-                            answer = xbmcDialog.yesno('LibreELEC Bluetooth Filetransfer', self.oe._(32383).encode('utf-8'))
+                            answer = xbmcDialog.yesno('Bluetooth Filetransfer', self.oe._(32383).encode('utf-8'))
                             if answer == 1:
                                 fil = '%s/%s' % (self.oe.DOWNLOAD_DIR, self.parent.download_file)
                                 if 'image' in self.parent.download_type:
@@ -893,16 +897,6 @@ class bluetooth:
             except Exception, e:
                 self.oe.dbg_log('bluetooth::monitor::TransferChanged', 'ERROR: (' + repr(e) + ')', 4)
 
-        def forceRender(self):
-            try:
-                self.oe.dbg_log('bluetooth::monitor::forceRender', 'enter_function', 0)
-                focusId = self.oe.winOeMain.getFocusId()
-                self.oe.winOeMain.setFocusId(self.oe.listObject['btlist'])
-                self.oe.winOeMain.setFocusId(focusId)
-                self.oe.dbg_log('bluetooth::monitor::forceRender', 'exit_function', 0)
-            except Exception, e:
-                self.oe.dbg_log('bluetooth::monitor::forceRender', 'ERROR: (' + repr(e) + ')', 4)
-
 
 ####################################################################
 ## Bluetooth Agent class
@@ -915,24 +909,10 @@ class Rejected(dbus.DBusException):
 
 class bluetoothAgent(dbus.service.Object):
 
-    exit_on_release = True
-
-    def set_exit_on_release(self, exit_on_release):
-        self.exit_on_release = exit_on_release
-
     def busy(self):
         self.oe.input_request = False
         if self.oe.__busy__ > 0:
             xbmc.executebuiltin('ActivateWindow(busydialog)')
-
-    def set_trusted(self, path):
-        try:
-            self.oe.dbg_log('bluetooth::btAgent::set_trusted', 'enter_function', 0)
-            props = dbus.Interface(self.oe.dbusSystemBus.get_object('org.bluez', path), 'org.freedesktop.DBus.Properties')
-            props.Set('org.bluez.Device1', 'Trusted', True)
-            self.oe.dbg_log('bluetooth::btAgent::set_trusted', 'exit_function', 0)
-        except Exception, e:
-            self.oe.dbg_log('bluetooth::btAgent::set_trusted', 'ERROR: (' + repr(e) + ')', 4)
 
     @dbus.service.method('org.bluez.Agent1', in_signature='', out_signature='')
     def Release(self):
@@ -946,13 +926,14 @@ class bluetoothAgent(dbus.service.Object):
     def AuthorizeService(self, device, uuid):
         try:
             self.oe.dbg_log('bluetooth::btAgent::AuthorizeService', 'enter_function', 0)
-            self.oe.input_request = True
-            xbmc.executebuiltin('Dialog.Close(busydialog)')
             self.oe.dbg_log('bluetooth::btAgent::AuthorizeService::device=', repr(device), 0)
             self.oe.dbg_log('bluetooth::btAgent::AuthorizeService::uuid=', repr(uuid), 0)
+            self.oe.input_request = True
+            xbmc.executebuiltin('Dialog.Close(busydialog)')
             xbmcDialog = xbmcgui.Dialog()
-            answer = xbmcDialog.yesno('LibreELEC Bluetooth', 'AuthorizeService')
+            answer = xbmcDialog.yesno('Bluetooth', 'Authorize service', 'Authorize service %s?' % (uuid))
             self.oe.dbg_log('bluetooth::btAgent::AuthorizeService::answer=', repr(answer), 0)
+            self.busy()
             self.oe.dbg_log('bluetooth::btAgent::AuthorizeService', 'exit_function', 0)
             if answer == 1:
                 self.oe.dictModules['bluetooth'].trust_device(device)
@@ -968,9 +949,10 @@ class bluetoothAgent(dbus.service.Object):
             self.oe.dbg_log('bluetooth::btAgent::RequestPinCode::device=', repr(device), 0)
             self.oe.input_request = True
             xbmc.executebuiltin('Dialog.Close(busydialog)')
-            xbmcKeyboard = xbmc.Keyboard('', 'RequestPinCode')
+            xbmcKeyboard = xbmc.Keyboard('', 'Enter PIN code')
             xbmcKeyboard.doModal()
             pincode = xbmcKeyboard.getText()
+            self.busy()
             self.oe.dbg_log('bluetooth::btAgent::RequestPinCode', 'return->' + pincode, 0)
             self.oe.dbg_log('bluetooth::btAgent::RequestPinCode', 'exit_function', 0)
             return dbus.String(pincode)
@@ -984,10 +966,10 @@ class bluetoothAgent(dbus.service.Object):
             self.oe.dbg_log('bluetooth::btAgent::RequestPasskey::device=', repr(device), 0)
             self.oe.input_request = True
             xbmc.executebuiltin('Dialog.Close(busydialog)')
-            xbmcKeyboard = xbmc.Keyboard('', 'RequestPasskey')
-            xbmcKeyboard.doModal()
-            passkey = xbmcKeyboard.getText()
+            xbmcDialog = xbmcgui.Dialog()
+            passkey = int(xbmcDialog.numeric(0, 'Enter passkey (number in 0-999999)', '0'))
             self.oe.dbg_log('bluetooth::btAgent::RequestPasskey::passkey=', repr(passkey), 0)
+            self.busy()
             self.oe.dbg_log('bluetooth::btAgent::RequestPasskey', 'exit_function', 0)
             return dbus.UInt32(passkey)
         except Exception, e:
@@ -1002,11 +984,8 @@ class bluetoothAgent(dbus.service.Object):
             self.oe.dbg_log('bluetooth::btAgent::DisplayPasskey::entered=', repr(entered), 0)
             if not hasattr(self.parent, 'pinkey_window'):
                 self.parent.open_pinkey_window()
-                self.parent.pinkey_window.set_label1(passkey)
-            else:
-                self.parent.pinkey_window.append_label3(entered)
-            if self.parent.pinkey_window.get_label3_len() == len(unicode(passkey)):
-                self.parent.close_pinkey_window()
+                self.parent.pinkey_window.device = device
+                self.parent.pinkey_window.set_label1('Passkey: %06u' % (passkey))
             self.oe.dbg_log('bluetooth::btAgent::DisplayPasskey', 'exit_function', 0)
         except Exception, e:
             self.oe.dbg_log('bluetooth::btAgent::DisplayPasskey', 'ERROR: (' + repr(e) + ')', 4)
@@ -1019,9 +998,9 @@ class bluetoothAgent(dbus.service.Object):
             self.oe.dbg_log('bluetooth::btAgent::DisplayPinCode::pincode=', repr(pincode), 0)
             if hasattr(self.parent, 'pinkey_window'):
                 self.parent.close_pinkey_window()
-            self.parent.open_pinkey_window(runtime=20)
+            self.parent.open_pinkey_window(runtime=30)
             self.parent.pinkey_window.device = device
-            self.parent.pinkey_window.set_label2(pincode)
+            self.parent.pinkey_window.set_label1('PIN code: %s' % (pincode))
             self.oe.dbg_log('bluetooth::btAgent::DisplayPinCode', 'exit_function', 0)
         except Exception, e:
             self.oe.dbg_log('bluetooth::btAgent::DisplayPinCode', 'ERROR: (' + repr(e) + ')', 4)
@@ -1032,9 +1011,12 @@ class bluetoothAgent(dbus.service.Object):
             self.oe.dbg_log('bluetooth::btAgent::RequestConfirmation', 'enter_function', 0)
             self.oe.dbg_log('bluetooth::btAgent::RequestConfirmation::device=', repr(device), 0)
             self.oe.dbg_log('bluetooth::btAgent::RequestConfirmation::passkey=', repr(passkey), 0)
+            self.oe.input_request = True
+            xbmc.executebuiltin('Dialog.Close(busydialog)')
             xbmcDialog = xbmcgui.Dialog()
-            answer = xbmcDialog.yesno('LibreELEC Bluetooth', 'RequestConfirmation', unicode(passkey))
+            answer = xbmcDialog.yesno('Bluetooth', 'Request confirmation', 'Confirm passkey %06u' % (passkey))
             self.oe.dbg_log('bluetooth::btAgent::RequestConfirmation::answer=', repr(answer), 0)
+            self.busy()
             self.oe.dbg_log('bluetooth::btAgent::RequestConfirmation', 'exit_function', 0)
             if answer == 1:
                 self.oe.dictModules['bluetooth'].trust_device(device)
@@ -1048,12 +1030,12 @@ class bluetoothAgent(dbus.service.Object):
         try:
             self.oe.dbg_log('bluetooth::btAgent::RequestAuthorization', 'enter_function', 0)
             self.oe.dbg_log('bluetooth::btAgent::RequestAuthorization::device=', repr(device), 0)
+            self.oe.input_request = True
+            xbmc.executebuiltin('Dialog.Close(busydialog)')
             xbmcDialog = xbmcgui.Dialog()
-            answer = xbmcDialog.yesno('LibreELEC Bluetooth', 'RequestAuthorization')
-            if hasattr(self.parent, 'pinkey_window'):
-                if device == self.parent.pinkey_window.device:
-                    self.parent.close_pinkey_window()
+            answer = xbmcDialog.yesno('Bluetooth', 'Request authorization', 'Accept pairing?')
             self.oe.dbg_log('bluetooth::btAgent::RequestAuthorization::answer=', repr(answer), 0)
+            self.busy()
             self.oe.dbg_log('bluetooth::btAgent::RequestAuthorization', 'exit_function', 0)
             if answer == 1:
                 self.oe.dictModules['bluetooth'].trust_device(device)
@@ -1066,6 +1048,8 @@ class bluetoothAgent(dbus.service.Object):
     def Cancel(self):
         try:
             self.oe.dbg_log('bluetooth::btAgent::Cancel', 'enter_function', 0)
+            if hasattr(self.parent, 'pinkey_window'):
+                self.parent.close_pinkey_window()
             self.oe.dbg_log('bluetooth::btAgent::Cancel', 'exit_function', 0)
         except Exception, e:
             self.oe.dbg_log('bluetooth::btAgent::Cancel', 'ERROR: (' + repr(e) + ')', 4)
@@ -1076,6 +1060,11 @@ class bluetoothAgent(dbus.service.Object):
 ####################################################################
 
 class obexAgent(dbus.service.Object):
+
+    def busy(self):
+        self.oe.input_request = False
+        if self.oe.__busy__ > 0:
+            xbmc.executebuiltin('ActivateWindow(busydialog)')
 
     @dbus.service.method('org.bluez.obex.Agent1', in_signature='', out_signature='')
     def Release(self):
@@ -1092,9 +1081,12 @@ class obexAgent(dbus.service.Object):
             self.oe.dbg_log('bluetooth::obexAgent::AuthorizePush::path=', repr(path), 0)
             transfer = dbus.Interface(self.oe.dbusSystemBus.get_object('org.bluez.obex', path), 'org.freedesktop.DBus.Properties')
             properties = transfer.GetAll('org.bluez.obex.Transfer1')
+            self.oe.input_request = True
+            xbmc.executebuiltin('Dialog.Close(busydialog)')
             xbmcDialog = xbmcgui.Dialog()
-            answer = xbmcDialog.yesno('LibreELEC Bluetooth', self.oe._(32381), properties['Name'])
+            answer = xbmcDialog.yesno('Bluetooth', self.oe._(32381), properties['Name'])
             self.oe.dbg_log('bluetooth::obexAgent::AuthorizePush::answer=', repr(answer), 0)
+            self.busy()
             if answer != 1:
                 properties = None
                 transfer = None

--- a/src/resources/lib/modules/bluetooth.py
+++ b/src/resources/lib/modules/bluetooth.py
@@ -117,8 +117,8 @@ class bluetooth:
                 if self.dbusBluezAdapter != None:
                     self.dbusBluezAdapter = dbus.Interface(self.oe.dbusSystemBus.get_object('org.bluez', path), 'org.bluez.Adapter1')
                     break
-            dbusBluezManager = None
             dbusManagedObjects = None
+            dbusBluezManager = None
             if self.dbusBluezAdapter != None:
                 self.adapter_powered(self.dbusBluezAdapter, 1)
             self.oe.dbg_log('bluetooth::init_adapter', 'exit_function', 0)
@@ -136,6 +136,7 @@ class bluetooth:
                                                    'org.freedesktop.DBus.Properties')
                 adapter_interface.Set('org.bluez.Adapter1', 'Alias', dbus.String(os.environ.get('HOSTNAME', 'libreelec')))
                 adapter_interface.Set('org.bluez.Adapter1', 'Powered', dbus.Boolean(state))
+                adapter_interface = None
             self.oe.dbg_log('bluetooth::adapter_powered', 'exit_function', 0)
         except Exception, e:
             self.oe.dbg_log('bluetooth::adapter_powered', 'ERROR: (' + repr(e) + ')', 4)
@@ -148,6 +149,7 @@ class bluetooth:
             adapter_interface = dbus.Interface(self.oe.dbusSystemBus.get_object('org.bluez', adapter.object_path),
                                                'org.freedesktop.DBus.Properties')
             return adapter_interface.Get('org.bluez.Adapter1', name)
+            adapter_interface = None
             self.oe.dbg_log('bluetooth::adapter_info', 'exit_function', 0)
         except Exception, e:
             self.oe.dbg_log('bluetooth::adapter_info', 'ERROR: (' + repr(e) + ')', 4)
@@ -268,6 +270,7 @@ class bluetooth:
             self.oe.set_busy(1)
             device = dbus.Interface(self.oe.dbusSystemBus.get_object('org.bluez', path), 'org.bluez.Device1')
             device.Pair(reply_handler=self.pair_reply_handler, error_handler=self.dbus_error_handler)
+            device = None
             self.oe.dbg_log('bluetooth::pair_device', 'exit_function', 0)
         except Exception, e:
             self.oe.set_busy(0)
@@ -294,7 +297,8 @@ class bluetooth:
             self.oe.dbg_log('bluetooth::trust_device::path', repr(path), 0)
             self.oe.set_busy(1)
             prop = dbus.Interface(self.oe.dbusSystemBus.get_object('org.bluez', path), 'org.freedesktop.DBus.Properties')
-            prop.Set('org.bluez.Device1', 'Trusted', True)
+            prop.Set('org.bluez.Device1', 'Trusted', dbus.Boolean(1))
+            prop = None
             self.oe.set_busy(0)
             self.oe.dbg_log('bluetooth::trust_device', 'exit_function', 0)
         except Exception, e:
@@ -308,6 +312,7 @@ class bluetooth:
             self.oe.set_busy(1)
             device = dbus.Interface(self.oe.dbusSystemBus.get_object('org.bluez', path), 'org.bluez.Device1')
             device.Connect(reply_handler=self.connect_reply_handler, error_handler=self.dbus_error_handler)
+            device = None
             self.oe.dbg_log('bluetooth::connect_device', 'exit_function', 0)
         except Exception, e:
             self.oe.set_busy(0)
@@ -332,6 +337,7 @@ class bluetooth:
                 return
             device = dbus.Interface(self.oe.dbusSystemBus.get_object('org.bluez', listItem.getProperty('entry')), 'org.bluez.Device1')
             device.Disconnect(reply_handler=self.disconnect_reply_handler, error_handler=self.dbus_error_handler)
+            device = None
             self.oe.dbg_log('bluetooth::disconnect_device', 'exit_function', 0)
         except Exception, e:
             self.oe.dbg_log('bluetooth::disconnect_device', 'ERROR: (' + repr(e) + ')', 4)
@@ -634,6 +640,7 @@ class bluetooth:
                 self.oe = oeMain
                 self.signal_receivers = []
                 self.NameOwnerWatch = None
+                self.ObexNameOwnerWatch = None
                 self.btAgentPath = '/LibreELEC/bt_agent'
                 self.obAgentPath = '/LibreELEC/ob_agent'
                 self.parent = parent
@@ -966,7 +973,7 @@ class bluetoothAgent(dbus.service.Object):
             pincode = xbmcKeyboard.getText()
             self.oe.dbg_log('bluetooth::btAgent::RequestPinCode', 'return->' + pincode, 0)
             self.oe.dbg_log('bluetooth::btAgent::RequestPinCode', 'exit_function', 0)
-            return pincode
+            return dbus.String(pincode)
         except Exception, e:
             self.oe.dbg_log('bluetooth::btAgent::RequestPinCode', 'ERROR: (' + repr(e) + ')', 4)
 
@@ -1089,6 +1096,8 @@ class obexAgent(dbus.service.Object):
             answer = xbmcDialog.yesno('LibreELEC Bluetooth', self.oe._(32381), properties['Name'])
             self.oe.dbg_log('bluetooth::obexAgent::AuthorizePush::answer=', repr(answer), 0)
             if answer != 1:
+                properties = None
+                transfer = None
                 raise dbus.DBusException('org.bluez.obex.Error.Rejected: Not Authorized')
                 return
             self.parent.download_path = path
@@ -1099,6 +1108,8 @@ class obexAgent(dbus.service.Object):
             else:
                 self.parent.download_type = None
             return properties['Name']
+            properties = None
+            transfer = None
             self.oe.dbg_log('bluetooth::obexAgent::AuthorizePush', 'exit_function', 0)
         except Exception, e:
             self.oe.dbg_log('bluetooth::obexAgent::AuthorizePush', 'ERROR: (' + repr(e) + ')', 4)

--- a/src/resources/lib/modules/services.py
+++ b/src/resources/lib/modules/services.py
@@ -261,10 +261,10 @@ class services:
 
     def stop_service(self):
         try:
-            self.oe.dbg_log('service::stop_service', 'enter_function', 0)
-            self.oe.dbg_log('service::stop_service', 'exit_function', 0)
+            self.oe.dbg_log('services::stop_service', 'enter_function', 0)
+            self.oe.dbg_log('services::stop_service', 'exit_function', 0)
         except Exception, e:
-            self.oe.dbg_log('service::stop_service', 'ERROR: (' + repr(e) + ')')
+            self.oe.dbg_log('services::stop_service', 'ERROR: (' + repr(e) + ')')
 
     def do_init(self):
         try:
@@ -278,9 +278,9 @@ class services:
         try:
             self.oe.dbg_log('services::set_value', 'enter_function', 0)
             self.struct[listItem.getProperty('category')]['settings'][listItem.getProperty('entry')]['value'] = listItem.getProperty('value')
-            self.oe.dbg_log('system::set_value', 'exit_function', 0)
+            self.oe.dbg_log('services::set_value', 'exit_function', 0)
         except Exception, e:
-            self.oe.dbg_log('system::set_value', 'ERROR: (' + repr(e) + ')')
+            self.oe.dbg_log('services::set_value', 'ERROR: (' + repr(e) + ')')
 
     def load_menu(self, focusItem):
         try:

--- a/src/resources/lib/modules/system.py
+++ b/src/resources/lib/modules/system.py
@@ -333,7 +333,7 @@ class system:
             self.oe.winOeMain.build_menu(self.struct)
             self.oe.dbg_log('system::load_menu', 'exit_function', 0)
         except Exception, e:
-            self.oe.dbg_log('system::loadSysMenu', 'ERROR: (' + repr(e) + ')')
+            self.oe.dbg_log('system::load_menu', 'ERROR: (' + repr(e) + ')')
 
     def set_value(self, listItem):
         try:
@@ -636,7 +636,7 @@ class system:
                     return 1
                 else:
                     return 0
-            self.oe.dbg_log('system::reset_oeask_sure_reset', 'exit_function', 0)
+            self.oe.dbg_log('system::ask_sure_reset', 'exit_function', 0)
         except Exception, e:
             self.oe.set_busy(0)
             self.oe.dbg_log('system::ask_sure_reset', 'ERROR: (' + repr(e) + ')', 4)

--- a/src/resources/lib/modules/system.py
+++ b/src/resources/lib/modules/system.py
@@ -657,7 +657,7 @@ class system:
 
             xbmcDialog = xbmcgui.Dialog()
             bckDir = xbmcDialog.browse( 0, 
-                                        self.oe._(32392).encode('utf-8'), 
+                                        self.oe._(32371).encode('utf-8'),
                                         'files', 
                                         '', 
                                         False, 
@@ -700,7 +700,7 @@ class system:
             copy_success = 0
             xbmcDialog = xbmcgui.Dialog()
             restore_file_path = xbmcDialog.browse( 1, 
-                                              self.oe._(32393).encode('utf-8'), 
+                                              self.oe._(32373).encode('utf-8'),
                                               'files', 
                                               '??????????????.tar', 
                                               False, 

--- a/src/resources/lib/modules/system.py
+++ b/src/resources/lib/modules/system.py
@@ -595,7 +595,7 @@ class system:
     def reset_xbmc(self, listItem=None):
         try:
             self.oe.dbg_log('system::reset_xbmc', 'enter_function', 0)
-            if self.ask_sure_reset('XBMC') == 1:
+            if self.ask_sure_reset('Soft') == 1:
                 self.oe.set_busy(1)
                 reset_file = open(self.XBMC_RESET_FILE, 'w')
                 reset_file.write('reset')
@@ -612,7 +612,7 @@ class system:
     def reset_oe(self, listItem=None):
         try:
             self.oe.dbg_log('system::reset_oe', 'enter_function', 0)
-            if self.ask_sure_reset('LibreELEC') == 1:
+            if self.ask_sure_reset('Hard') == 1:
                 self.oe.set_busy(1)
                 reset_file = open(self.LIBREELEC_RESET_FILE, 'w')
                 reset_file.write('reset')
@@ -630,7 +630,7 @@ class system:
         try:
             self.oe.dbg_log('system::ask_sure_reset', 'enter_function', 0)
             xbmcDialog = xbmcgui.Dialog()
-            answer = xbmcDialog.yesno(part + ' reset', self.oe._(32326).encode('utf-8'), self.oe._(32328).encode('utf-8'))
+            answer = xbmcDialog.yesno(part + ' Reset', self.oe._(32326).encode('utf-8'), self.oe._(32328).encode('utf-8'))
             if answer == 1:
                 if self.oe.reboot_counter(30, self.oe._(32323)) == 1:
                     return 1


### PR DESCRIPTION
This PR contains changes to bluetooth pairing and some minor fixes we have been using in RasPlex for some time
- Adds a new 'Pair' context menu entry for bluetooth devices that is dependent on bluez's 'Paired' property
- Slight modification to the authorize, pin and passkey dialogs and when the busy dialog is shown
- Non-debug log entries is always logged
- Use existing language for backup/restore dialogs
- Changes title on soft/hard reset dialog