### PR TITLE
get_keyboard_layouts should return three values

### DIFF
--- a/src/resources/lib/modules/system.py
+++ b/src/resources/lib/modules/system.py
@@ -506,7 +506,7 @@ class system:
                 arrTypes = None
             else:
                 self.oe.dbg_log('system::get_keyboard_layouts', 'exit_function (no keyboard layouts found)', 0)
-                return (None, None)
+                return (None, None, None)
             self.oe.dbg_log('system::get_keyboard_layouts', 'exit_function', 0)
             return (
                 arrLayouts,


### PR DESCRIPTION
This isn't really needed as we should always have keymaps installed, but I noticed it in my dev environment where I didn't have any keymaps.