### PR TITLE
Only use non-empty values for global timeservers

### DIFF
--- a/src/resources/lib/modules/connman.py
+++ b/src/resources/lib/modules/connman.py
@@ -911,9 +911,10 @@ class connman:
                 self.set_value(kwargs['listItem'])
             self.oe.dbg_log('connman::set_timeservers', 'enter_function', 0)
             self.clock = dbus.Interface(self.oe.dbusSystemBus.get_object('net.connman', '/'), 'net.connman.Clock')
-            timeservers = []
+            timeservers = dbus.Array([], signature=dbus.Signature('s'), variant_level=1)
             for setting in sorted(self.struct['Timeservers']['settings']):
-                timeservers.append(self.struct['Timeservers']['settings'][setting]['value'])
+                if self.struct['Timeservers']['settings'][setting]['value'] != '':
+                    timeservers.append(self.struct['Timeservers']['settings'][setting]['value'])
             self.clock.SetProperty(dbus.String('Timeservers'), timeservers)
             self.oe.dbg_log('connman::set_timeservers', 'exit_function', 0)
             self.oe.set_busy(0)


### PR DESCRIPTION
This PR prevents empty timeserver values from being saved to connman's global settings, fixes:

A default Timeservers property for a connman service:
```Timeservers = [ 0.pool.ntp.org, 1.pool.ntp.org, 2.pool.ntp.org, 3.pool.ntp.org ]```

After one of the `Network -> NTP Servers -> Timeserver` settings has been opened and closed without entering any value:
```Timeservers = [ , 0.pool.ntp.org, 1.pool.ntp.org, 2.pool.ntp.org, 3.pool.ntp.org ]```

The empty value prevents the remaining fallback timeservers from being used.