### PR TITLE
system update - fix cross-device linking

### DIFF
--- a/src/resources/lib/modules/system.py
+++ b/src/resources/lib/modules/system.py
@@ -36,6 +36,7 @@ import tarfile
 import oeWindows
 import threading
 import subprocess
+import shutil
 from xml.dom import minidom
 
 
@@ -771,7 +772,7 @@ class system:
                     self.update_file = self.update_file.split('/')[-1]
                     if self.struct['update']['settings']['UpdateNotify']['value'] == '1':
                         self.oe.notify(self.oe._(32363), self.oe._(32366))
-                    os.rename(self.oe.TEMP + 'update_file', self.LOCAL_UPDATE_DIR + self.update_file)
+                    shutil.move(self.oe.TEMP + 'update_file', self.LOCAL_UPDATE_DIR + self.update_file)
                     subprocess.call('sync', shell=True, stdin=None, stdout=None, stderr=None)
                     if silent == False:
                         self.oe.winOeMain.close()


### PR DESCRIPTION
See: http://forum.kodi.tv/showthread.php?tid=269815&pid=2437666#pid2437666

`shutil.move()` will perform an `os.rename()` when the source and destination file systems are the same, and a copy and delete when different.