### PR TITLE
actually fix the about window without breaking info text

### DIFF
--- a/language/Bulgarian/strings.po
+++ b/language/Bulgarian/strings.po
@@ -60,10 +60,6 @@ msgctxt "#610"
 msgid "[B]Support:[/B][CR]Web: http://libreelec.tv[CR]Forum: http://forum.libreelec.tv/[CR]Wiki: http://wiki.libreelec.tv[CR][CR][B]Social Media:[/B][CR]IRC: #libreelec on freenode.net (web-based chat is also available from the website)[CR]Twitter: https://twitter.com/libreelec[CR]Facebook: http://www.facebook.com/LibreELEC[CR]Google+: https://plus.google.com/+libreelec"
 msgstr "[B]Поддръжка:[/B][CR]Уеб сайт: www.libreelec.tv[CR]Форум: www.libreelec.tv/forum[CR]Уики: www.wiki.libreelec.tv[CR][CR][B]Социални мрежи:[/B][CR]IRC: #libreelec в freenode.net (уеб базиран чат е наличен на уеб сайта)[CR]Twitter: www.twitter.com/libreelec[CR]Facebook: www.facebook.com/LibreELEC[CR]Google+: www.plus.google.com/+libreelec"
 
-msgctxt "#611"
-msgid "The LibreELEC project runs on goodwill, love, and your donations. If you would like to contribute to the project you can donate using PayPal, Flattr or Bitcoin. Making a donation is easy and takes only a couple of minutes. http://libreelec.tv/donate"
-msgstr "LibreELEC се развива на доброволни начала и чрез дарения. Ако желаете да допринесете можете да дарите чрез PayPal, Flattr или Bitcoin. Процеса е лесен и отнема няколко минути. www.libreelec.tv/donate"
-
 msgctxt "#700"
 msgid "Configure a hostname, keyboard type, perform a reset, update, or backups and restores"
 msgstr "Задайте име на устройството, тип на клавиатурата, нулирайте, актуализирайте, направете резервно копие или възстановете"

--- a/language/Catalan/strings.po
+++ b/language/Catalan/strings.po
@@ -56,10 +56,6 @@ msgctxt "#610"
 msgid "[B]Support:[/B][CR]Web: http://libreelec.tv[CR]Forum: http://forum.libreelec.tv/[CR]Wiki: http://wiki.libreelec.tv[CR][CR][B]Social Media:[/B][CR]IRC: #libreelec on freenode.net (web-based chat is also available from the website)[CR]Twitter: https://twitter.com/libreelec[CR]Facebook: http://www.facebook.com/LibreELEC[CR]Google+: https://plus.google.com/+libreelec"
 msgstr "[B]Suport:[/B][CR]Web: http://libreelec.tv[CR]Fòrum: http://forum.libreelec.tv/[CR]Wiki: http://wiki.libreelec.tv[CR][CR][B]Xarxes Socials:[/B][CR]IRC: #LibreELEC a freenode.net (xat-web també disponible a la pàgina web)[CR]Twitter: https://twitter.com/libreelec[CR]Facebook: http://www.facebook.com/LibreELEC[CR]Google+: https://plus.google.com/+libreelec"
 
-msgctxt "#611"
-msgid "The LibreELEC project runs on goodwill, love, and your donations. If you would like to contribute to the project you can donate using PayPal, Flattr or Bitcoin. Making a donation is easy and takes only a couple of minutes. http://libreelec.tv/donate"
-msgstr "El projecte LibreELEC funciona per la bona voluntat, l'amor i les vostres donacions. Si voleu contribuir al projecte podeu donar a través de PayPal, Flattr o Bitcoin. Fer una donació és fàcil i només calen un parell de minuts. http://libreelec.tv/donate"
-
 msgctxt "#700"
 msgid "Configure a hostname, keyboard type, perform a reset, update, or backups and restores"
 msgstr "Configura el nom dels servidor, tipus de teclat, feu un reinicii, actualitzeu o copies i restauracions"

--- a/language/Chinese (Simple)/strings.po
+++ b/language/Chinese (Simple)/strings.po
@@ -60,10 +60,6 @@ msgctxt "#610"
 msgid "[B]Support:[/B][CR]Web: http://libreelec.tv[CR]Forum: http://forum.libreelec.tv/[CR]Wiki: http://wiki.libreelec.tv[CR][CR][B]Social Media:[/B][CR]IRC: #libreelec on freenode.net (web-based chat is also available from the website)[CR]Twitter: https://twitter.com/libreelec[CR]Facebook: http://www.facebook.com/LibreELEC[CR]Google+: https://plus.google.com/+libreelec"
 msgstr "[B]支持：[/B][CR]网址：http://libreelec.tv[CR]论坛：http://forum.libreelec.tv/[CR]Wiki：http://wiki.libreelec.tv[CR][CR][B]社交媒体：[/B][CR]IRC：freenode.net 上的 #libreelec（支持 web 方式的聊天服务）[CR]Twitter：https://twitter.com/libreelec[CR]Facebook：http://www.facebook.com/LibreELEC[CR]Google+：https://plus.google.com/+libreelec"
 
-msgctxt "#611"
-msgid "The LibreELEC project runs on goodwill, love, and your donations. If you would like to contribute to the project you can donate using PayPal, Flattr or Bitcoin. Making a donation is easy and takes only a couple of minutes. http://libreelec.tv/donate"
-msgstr "LibreELEC 项目的运作有赖于爱心、奉献和你的捐助支持。你可以通过PayPal、flattr或比特币进行捐助，捐助简单易行，详情见 http://libreelec.tv/donate"
-
 msgctxt "#700"
 msgid "Configure a hostname, keyboard type, perform a reset, update, or backups and restores"
 msgstr "配置主机名、键盘类型，进行系统重置、更新或者备份和恢复。"

--- a/language/Croatian/strings.po
+++ b/language/Croatian/strings.po
@@ -60,10 +60,6 @@ msgctxt "#610"
 msgid "[B]Support:[/B][CR]Web: http://libreelec.tv[CR]Forum: http://forum.libreelec.tv/[CR]Wiki: http://wiki.libreelec.tv[CR][CR][B]Social Media:[/B][CR]IRC: #libreelec on freenode.net (web-based chat is also available from the website)[CR]Twitter: https://twitter.com/libreelec[CR]Facebook: http://www.facebook.com/LibreELEC[CR]Google+: https://plus.google.com/+libreelec"
 msgstr "[B]Podrška:[/B][CR]Web stranica: http://libreelec.tv[CR]Forum: http://forum.libreelec.tv/[CR]Wiki: http://wiki.libreelec.tv[CR][CR][B]Društveni mediji:[/B][CR]IRC: #libreelec na freenode.net (web-temeljeno čavrljanje je isto dostupno sa web stranice)[CR]Twitter: https://twitter.com/libreelec[CR]Facebook: http://www.facebook.com/LibreELEC[CR]Google+: https://plus.google.com/+libreelec"
 
-msgctxt "#611"
-msgid "The LibreELEC project runs on goodwill, love, and your donations. If you would like to contribute to the project you can donate using PayPal, Flattr or Bitcoin. Making a donation is easy and takes only a couple of minutes. http://libreelec.tv/donate"
-msgstr "LibreELEC projekt pokreće dobra volja, ljubav i vaše donacije. Ako želite pridonijeti projektu možete donirati koristeći PayPal, Flattr ili Bitcoin. Doniranje je lagano i traje samo nekoliko minuta. http://libreelec.tv/donate"
-
 msgctxt "#700"
 msgid "Configure a hostname, keyboard type, perform a reset, update, or backups and restores"
 msgstr "Podesite naziv računala, vrstu tipkovnice, ponovno pokrenite, ažurirajte ili sigurnosno kopirajte i obnovite"

--- a/language/Czech/strings.po
+++ b/language/Czech/strings.po
@@ -60,10 +60,6 @@ msgctxt "#610"
 msgid "[B]Support:[/B][CR]Web: http://libreelec.tv[CR]Forum: http://forum.libreelec.tv/[CR]Wiki: http://wiki.libreelec.tv[CR][CR][B]Social Media:[/B][CR]IRC: #libreelec on freenode.net (web-based chat is also available from the website)[CR]Twitter: https://twitter.com/libreelec[CR]Facebook: http://www.facebook.com/LibreELEC[CR]Google+: https://plus.google.com/+libreelec"
 msgstr "[B]Podpora:[/B][CR]Web: http://libreelec.tv[CR]Fórum: http://forum.libreelec.tv/[CR]Wiki: http://wiki.libreelec.tv[CR][CR][B]Sociál Média:[/B][CR]IRC: #libreelec na freenode.net (webový chat je k dispozici také na internetových stránkách)[CR]Twitter: https://twitter.com/libreelec[CR]Facebook: http://www.facebook.com/LibreELEC[CR]Google+: https://plus.google.com/+libreelec"
 
-msgctxt "#611"
-msgid "The LibreELEC project runs on goodwill, love, and your donations. If you would like to contribute to the project you can donate using PayPal, Flattr or Bitcoin. Making a donation is easy and takes only a couple of minutes. http://libreelec.tv/donate"
-msgstr "Projekt LibreELEC funguje díky dobré vůli, lásce, a vašim darům. Pokud byste chtěli přispět na projekt, můžete něco darovat přes PayPal, Flattr nebo Bitcoin. Poskytnutí daru je snadné a trvá jen pár minut. http://libreelec.tv/donate"
-
 msgctxt "#700"
 msgid "Configure a hostname, keyboard type, perform a reset, update, or backups and restores"
 msgstr "Konfigurace názvu zařízení, tytpu klávesnice, provedení resetu, aktualizací nebo zálohování a obnovení"

--- a/language/Danish/strings.po
+++ b/language/Danish/strings.po
@@ -56,10 +56,6 @@ msgctxt "#610"
 msgid "[B]Support:[/B][CR]Web: http://libreelec.tv[CR]Forum: http://forum.libreelec.tv/[CR]Wiki: http://wiki.libreelec.tv[CR][CR][B]Social Media:[/B][CR]IRC: #libreelec on freenode.net (web-based chat is also available from the website)[CR]Twitter: https://twitter.com/libreelec[CR]Facebook: http://www.facebook.com/LibreELEC[CR]Google+: https://plus.google.com/+libreelec"
 msgstr "[B]Support:[/B][CR]Web: http://libreelec.tv[CR]Forum: http://forum.libreelec.tv/[CR]Wiki: http://wiki.libreelec.tv[CR][CR][B]Sociale Medier:[/B][CR]IRC: #libreelec on freenode.net (web-baseret chat er også tilgængelig fra hjemmesiden)[CR]Twitter: https://twitter.com/libreelec[CR]Facebook: http://www.facebook.com/LibreELEC[CR]Google+: https://plus.google.com/+libreelec"
 
-msgctxt "#611"
-msgid "The LibreELEC project runs on goodwill, love, and your donations. If you would like to contribute to the project you can donate using PayPal, Flattr or Bitcoin. Making a donation is easy and takes only a couple of minutes. http://libreelec.tv/donate"
-msgstr "LibreELEC-projektet kører på goodwill, kærlighed, og dine donationer. Hvis du gerne vil bidrage til projektet, kan du donere ved hjælp af PayPal, Flattr eller Bitcoin. Det er nemt at lave en donation og tager kun et par minutter. http://libreelec.tv/donate"
-
 msgctxt "#700"
 msgid "Configure a hostname, keyboard type, perform a reset, update, or backups and restores"
 msgstr "Konfigurer et hostname, keyboardtype, udfør en nulstilling, opdatering eller sikkerhedskopier og gendannelser"

--- a/language/Dutch/strings.po
+++ b/language/Dutch/strings.po
@@ -60,10 +60,6 @@ msgctxt "#610"
 msgid "[B]Support:[/B][CR]Web: http://libreelec.tv[CR]Forum: http://forum.libreelec.tv/[CR]Wiki: http://wiki.libreelec.tv[CR][CR][B]Social Media:[/B][CR]IRC: #libreelec on freenode.net (web-based chat is also available from the website)[CR]Twitter: https://twitter.com/libreelec[CR]Facebook: http://www.facebook.com/LibreELEC[CR]Google+: https://plus.google.com/+libreelec"
 msgstr "[B]Ondersteuning:[/B][CR]Web: http://libreelec.tv[CR]Forum: http://forum.libreelec.tv/[CR]Wiki: http://wiki.libreelec.tv[CR][CR][B]Sociale media:[/B][CR]IRC: #libreelec op freenode.net (webgebaseerde chat is ook beschikbaar vanaf de website)[CR]Twitter: https://twitter.com/libreelec[CR]Facebook: http://www.facebook.com/LibreELEC[CR]Google+: https://plus.google.com/+libreelec"
 
-msgctxt "#611"
-msgid "The LibreELEC project runs on goodwill, love, and your donations. If you would like to contribute to the project you can donate using PayPal, Flattr or Bitcoin. Making a donation is easy and takes only a couple of minutes. http://libreelec.tv/donate"
-msgstr "Het LibreELEC project draait op goede wil, liefde, en uw donaties. Als u wilt bijdragen aan het project, dan kunt u doneren via PayPal, Flattr of Bitcoin. Een donatie doen is makkelijk en neemt een paar minuten in beslag. Ga naar http://libreelec.tv/donate"
-
 msgctxt "#700"
 msgid "Configure a hostname, keyboard type, perform a reset, update, or backups and restores"
 msgstr "Configureer een hostnaam, toetsenbordtype, voer een reset uit, update, of backups en restores"

--- a/language/English (Australia)/strings.po
+++ b/language/English (Australia)/strings.po
@@ -56,10 +56,6 @@ msgctxt "#610"
 msgid "[B]Support:[/B][CR]Web: http://libreelec.tv[CR]Forum: http://forum.libreelec.tv/[CR]Wiki: http://wiki.libreelec.tv[CR][CR][B]Social Media:[/B][CR]IRC: #libreelec on freenode.net (web-based chat is also available from the website)[CR]Twitter: https://twitter.com/libreelec[CR]Facebook: http://www.facebook.com/LibreELEC[CR]Google+: https://plus.google.com/+libreelec"
 msgstr "[B]Support:[/B][CR]Web: http://libreelec.tv[CR]Forum: http://forum.libreelec.tv/[CR]Wiki: http://wiki.libreelec.tv[CR][CR][B]Social Media:[/B][CR]IRC: #libreelec on freenode.net (web-based chat is also available from the website)[CR]Twitter: https://twitter.com/libreelec[CR]Facebook: http://www.facebook.com/LibreELEC[CR]Google+: https://plus.google.com/+libreelec"
 
-msgctxt "#611"
-msgid "The LibreELEC project runs on goodwill, love, and your donations. If you would like to contribute to the project you can donate using PayPal, Flattr or Bitcoin. Making a donation is easy and takes only a couple of minutes. http://libreelec.tv/donate"
-msgstr "The LibreELEC project runs on goodwill, love, and your donations. If you would like to contribute to the project you can donate using PayPal, Flattr or Bitcoin. Making a donation is easy and takes only a couple of minutes. http://libreelec.tv/donate"
-
 msgctxt "#700"
 msgid "Configure a hostname, keyboard type, perform a reset, update, or backups and restores"
 msgstr "Configure a hostname, keyboard type, perform a reset, update, or backups and restores"

--- a/language/English (New Zealand)/strings.po
+++ b/language/English (New Zealand)/strings.po
@@ -60,10 +60,6 @@ msgctxt "#610"
 msgid "[B]Support:[/B][CR]Web: http://libreelec.tv[CR]Forum: http://forum.libreelec.tv/[CR]Wiki: http://wiki.libreelec.tv[CR][CR][B]Social Media:[/B][CR]IRC: #libreelec on freenode.net (web-based chat is also available from the website)[CR]Twitter: https://twitter.com/libreelec[CR]Facebook: http://www.facebook.com/LibreELEC[CR]Google+: https://plus.google.com/+libreelec"
 msgstr "[B]Support:[/B][CR]Web: http://libreelec.tv[CR]Forum: http://forum.libreelec.tv/[CR]Wiki: http://wiki.libreelec.tv[CR][CR][B]Social Media:[/B][CR]IRC: #libreelec on freenode.net (web-based chat is also available from the website)[CR]Twitter: https://twitter.com/libreelec[CR]Facebook: http://www.facebook.com/LibreELEC[CR]Google+: https://plus.google.com/+libreelec"
 
-msgctxt "#611"
-msgid "The LibreELEC project runs on goodwill, love, and your donations. If you would like to contribute to the project you can donate using PayPal, Flattr or Bitcoin. Making a donation is easy and takes only a couple of minutes. http://libreelec.tv/donate"
-msgstr "The LibreELEC project runs on goodwill, love, and your donations. If you would like to contribute to the project you can donate using PayPal, Flattr or Bitcoin. Making a donation is easy and takes only a couple of minutes. http://libreelec.tv/donate"
-
 msgctxt "#700"
 msgid "Configure a hostname, keyboard type, perform a reset, update, or backups and restores"
 msgstr "Configure a hostname, keyboard type, perform a reset, update, or backups and restores"

--- a/language/English (US)/strings.po
+++ b/language/English (US)/strings.po
@@ -60,10 +60,6 @@ msgctxt "#610"
 msgid "[B]Support:[/B][CR]Web: http://libreelec.tv[CR]Forum: http://forum.libreelec.tv/[CR]Wiki: http://wiki.libreelec.tv[CR][CR][B]Social Media:[/B][CR]IRC: #libreelec on freenode.net (web-based chat is also available from the website)[CR]Twitter: https://twitter.com/libreelec[CR]Facebook: http://www.facebook.com/LibreELEC[CR]Google+: https://plus.google.com/+libreelec"
 msgstr "[B]Support:[/B][CR]Web: http://libreelec.tv[CR]Forum: http://forum.libreelec.tv/[CR]Wiki: http://wiki.libreelec.tv[CR][CR][B]Social Media:[/B][CR]IRC: #libreelec on freenode.net (web-based chat is also available from the website)[CR]Twitter: https://twitter.com/libreelec[CR]Facebook: http://www.facebook.com/LibreELEC[CR]Google+: https://plus.google.com/+libreelec"
 
-msgctxt "#611"
-msgid "The LibreELEC project runs on goodwill, love, and your donations. If you would like to contribute to the project you can donate using PayPal, Flattr or Bitcoin. Making a donation is easy and takes only a couple of minutes. http://libreelec.tv/donate"
-msgstr "The LibreELEC project runs on goodwill, love, and your donations. If you would like to contribute to the project you can donate using PayPal, Flattr or Bitcoin. Making a donation is easy and takes only a couple of minutes. http://libreelec.tv/donate"
-
 msgctxt "#700"
 msgid "Configure a hostname, keyboard type, perform a reset, update, or backups and restores"
 msgstr "Configure a hostname, keyboard type, perform a reset, update, or backups and restores"

--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -52,10 +52,6 @@ msgctxt "#610"
 msgid "[B]Support:[/B][CR]Web: http://libreelec.tv[CR]Forum: http://forum.libreelec.tv/[CR]Wiki: http://wiki.libreelec.tv[CR][CR][B]Social Media:[/B][CR]IRC: #libreelec on freenode.net (web-based chat is also available from the website)[CR]Twitter: https://twitter.com/libreelec[CR]Facebook: http://www.facebook.com/LibreELEC"
 msgstr ""
 
-msgctxt "#611"
-msgid "The LibreELEC project runs on goodwill, love, and your donations. If you would like to contribute to the project you can donate using PayPal. Making a donation is easy and takes only a couple of minutes. http://libreelec.tv"
-msgstr ""
-
 msgctxt "#700"
 msgid "Configure a hostname, keyboard type, perform a reset, update, or backups and restores"
 msgstr ""

--- a/language/Estonian/strings.po
+++ b/language/Estonian/strings.po
@@ -48,10 +48,6 @@ msgctxt "#608"
 msgid "Architecture: "
 msgstr "Arhitektuur:"
 
-msgctxt "#611"
-msgid "The LibreELEC project runs on goodwill, love, and your donations. If you would like to contribute to the project you can donate using PayPal, Flattr or Bitcoin. Making a donation is easy and takes only a couple of minutes. http://libreelec.tv/donate"
-msgstr "LibreELEC projekt elab heast tahtest,  altruistlikust tööst ja Sinu annetustest. Kui soovid ka omalt poolt projekti finantsiliselt toetada, saad seda teha Paypal, Flattr või Bitcoin kaudu. Annetuse tegemine on lihtne ja võtab aega vaid mõne minuti.  http://libreelec.tv/donate"
-
 msgctxt "#700"
 msgid "Configure a hostname, keyboard type, perform a reset, update, or backups and restores"
 msgstr "Süsteemi nime ja klaviatuuripaigutuse seadmine, algseadistuste laadimine, tarkvara uuendamine ning varundamine ja taastamine"

--- a/language/Finnish/strings.po
+++ b/language/Finnish/strings.po
@@ -60,10 +60,6 @@ msgctxt "#610"
 msgid "[B]Support:[/B][CR]Web: http://libreelec.tv[CR]Forum: http://forum.libreelec.tv/[CR]Wiki: http://wiki.libreelec.tv[CR][CR][B]Social Media:[/B][CR]IRC: #libreelec on freenode.net (web-based chat is also available from the website)[CR]Twitter: https://twitter.com/libreelec[CR]Facebook: http://www.facebook.com/LibreELEC[CR]Google+: https://plus.google.com/+libreelec"
 msgstr "[B]Tuki:[/B][CR]Internet: http://libreelec.tv[CR]Foorumi: http://forum.libreelec.tv/[CR]Wiki: http://wiki.libreelec.tv[CR][CR][B]Sosiaalinen media:[/B][CR]IRC: #libreelec freenode.net:ssä (web-pohjainen chat löytyy myös nettisivuilta)[CR]Twitter: https://twitter.com/libreelec[CR]Facebook: http://www.facebook.com/LibreELEC[CR]Google+: https://plus.google.com/+libreelec"
 
-msgctxt "#611"
-msgid "The LibreELEC project runs on goodwill, love, and your donations. If you would like to contribute to the project you can donate using PayPal, Flattr or Bitcoin. Making a donation is easy and takes only a couple of minutes. http://libreelec.tv/donate"
-msgstr "LibreELEC-projekti perustuu vapaaehtoisuudeen, pyyteettömyyteen ja lahjoituksiin. Jos haluat osallistua projektiin, voit lahjoittaa haluamasi summan käyttäen PayPalia, Flattria tai Bitcoinia. Lahjoituksen tekeminen on helppoa ja vie vain pari minuuttia aikaasi. http://libreelec.tv/donate"
-
 msgctxt "#700"
 msgid "Configure a hostname, keyboard type, perform a reset, update, or backups and restores"
 msgstr "Aseta verkkonimi ja näppäimistön tyyppi. Palauta asetukset, päivitä tai ota varmuuskopiot "

--- a/language/French (Canada)/strings.po
+++ b/language/French (Canada)/strings.po
@@ -60,10 +60,6 @@ msgctxt "#610"
 msgid "[B]Support:[/B][CR]Web: http://libreelec.tv[CR]Forum: http://forum.libreelec.tv/[CR]Wiki: http://wiki.libreelec.tv[CR][CR][B]Social Media:[/B][CR]IRC: #libreelec on freenode.net (web-based chat is also available from the website)[CR]Twitter: https://twitter.com/libreelec[CR]Facebook: http://www.facebook.com/LibreELEC[CR]Google+: https://plus.google.com/+libreelec"
 msgstr "[B]Soutien :[/B][CR]Web : http://libreelec.tv[CR]Forum : http://forum.libreelec.tv/[CR]Wiki : http://wiki.libreelec.tv[CR][CR][B]Médias sociaux :[/B][CR]IRC: #libreelec sur freenode.net (le clavardage Web est aussi proposé sur le site Web)[CR]Twitter : https://twitter.com/libreelec[CR]Facebook : http://www.facebook.com/LibreELEC[CR]Google+ : https://plus.google.com/+libreelec"
 
-msgctxt "#611"
-msgid "The LibreELEC project runs on goodwill, love, and your donations. If you would like to contribute to the project you can donate using PayPal, Flattr or Bitcoin. Making a donation is easy and takes only a couple of minutes. http://libreelec.tv/donate"
-msgstr "Le projet LibreELEC fonctionne sur la bonne volonté, l'amour et vos dons. Si vous aimeriez contribuer au projet, vous pouvez faire un don par PayPal, Flattr ou en bitcoins. Faire un don est simple et ne prend que quelques minutes. http://libreelec.tv/donate"
-
 msgctxt "#700"
 msgid "Configure a hostname, keyboard type, perform a reset, update, or backups and restores"
 msgstr "Configurer un nom d'hôte, type de clavier, réinitialiser, mettre à jour ou sauvegarder et restaurer"

--- a/language/French/strings.po
+++ b/language/French/strings.po
@@ -60,10 +60,6 @@ msgctxt "#610"
 msgid "[B]Support:[/B][CR]Web: http://libreelec.tv[CR]Forum: http://forum.libreelec.tv/[CR]Wiki: http://wiki.libreelec.tv[CR][CR][B]Social Media:[/B][CR]IRC: #libreelec on freenode.net (web-based chat is also available from the website)[CR]Twitter: https://twitter.com/libreelec[CR]Facebook: http://www.facebook.com/LibreELEC[CR]Google+: https://plus.google.com/+libreelec"
 msgstr "[B]Support :[/B][CR]Internet : http://libreelec.tv[CR]Forum : http://forum.libreelec.tv/[CR]Wiki : http://wiki.libreelec.tv[CR][CR][B]Médias sociaux :[/B][CR]IRC : #libreelec sur freenode.net (client web aussi disponible sur le site)[CR]Twitter : https://twitter.com/libreelec[CR]Facebook : http://www.facebook.com/LibreELEC[CR]Google+ : https://plus.google.com/+libreelec"
 
-msgctxt "#611"
-msgid "The LibreELEC project runs on goodwill, love, and your donations. If you would like to contribute to the project you can donate using PayPal, Flattr or Bitcoin. Making a donation is easy and takes only a couple of minutes. http://libreelec.tv/donate"
-msgstr "Le projet LibreELEC s’appuie sur la bonne volonté, l'amour, et vos dons. Vous pouvez contribuer au projet via PayPal, Flattr ou Bitcoin. Faire un don est simple et ne prend que quelques minutes. http://libreelec.tv/donate"
-
 msgctxt "#700"
 msgid "Configure a hostname, keyboard type, perform a reset, update, or backups and restores"
 msgstr "Configurer un nom d’hôte, le type de clavier, réinitialiser, mettre à jour, sauvegarder et restaurer"

--- a/language/German/strings.po
+++ b/language/German/strings.po
@@ -60,10 +60,6 @@ msgctxt "#610"
 msgid "[B]Support:[/B][CR]Web: http://libreelec.tv[CR]Forum: http://forum.libreelec.tv/[CR]Wiki: http://wiki.libreelec.tv[CR][CR][B]Social Media:[/B][CR]IRC: #libreelec on freenode.net (web-based chat is also available from the website)[CR]Twitter: https://twitter.com/libreelec[CR]Facebook: http://www.facebook.com/LibreELEC[CR]Google+: https://plus.google.com/+libreelec"
 msgstr "[B]Support:[/B][CR]Web: http://www.libreelec.tv[CR]Forum: http://forum.libreelec.tv[CR]Wiki: http://wiki.libreelec.tv[CR][CR][B]Be Social! Besuchen Sie unsere Community:[/B][CR]IRC: #libreelec bei freenode.net (auch verfügbar über Web Chat)[CR]Twitter: https://twitter.com/libreelec[CR]Facebook: http://www.facebook.com/LibreELEC[CR]Google+: https://plus.google.com/+libreelec\n  "
 
-msgctxt "#611"
-msgid "The LibreELEC project runs on goodwill, love, and your donations. If you would like to contribute to the project you can donate using PayPal, Flattr or Bitcoin. Making a donation is easy and takes only a couple of minutes. http://libreelec.tv/donate"
-msgstr "Wenn Sie sich am [COLOR FFFFFFFF]LibreELEC[/COLOR] Projekt beteiligen möchten, können Sie uns mit einer Spende über PayPal helfen. Spenden ist einfach und dauert nur wenige Minuten. http://libreelec.tv/donate"
-
 msgctxt "#700"
 msgid "Configure a hostname, keyboard type, perform a reset, update, or backups and restores"
 msgstr "Konfigurieren: Computernamen, Tastaturtyp | System: Zurücksetzen, Aktualisieren, Datensicherung und -wiederherstellung"

--- a/language/Greek/strings.po
+++ b/language/Greek/strings.po
@@ -60,10 +60,6 @@ msgctxt "#610"
 msgid "[B]Support:[/B][CR]Web: http://libreelec.tv[CR]Forum: http://forum.libreelec.tv/[CR]Wiki: http://wiki.libreelec.tv[CR][CR][B]Social Media:[/B][CR]IRC: #libreelec on freenode.net (web-based chat is also available from the website)[CR]Twitter: https://twitter.com/libreelec[CR]Facebook: http://www.facebook.com/LibreELEC[CR]Google+: https://plus.google.com/+libreelec"
 msgstr "[B]Υποστήριξη:[/B][CR]Web: http://libreelec.tv[CR]Φόρουμ: http://forum.libreelec.tv/[CR]Wiki: http://wiki.libreelec.tv[CR][CR][B]Κοινωνικά Μέσα:[/B][CR]IRC: #libreelec στο freenode.net (μέσω του ιστότοπου διατίθεται και διαδικτυακό chat)[CR]Twitter: https://twitter.com/libreelec[CR]Facebook: http://www.facebook.com/LibreELEC[CR]Google+: https://plus.google.com/+libreelec"
 
-msgctxt "#611"
-msgid "The LibreELEC project runs on goodwill, love, and your donations. If you would like to contribute to the project you can donate using PayPal, Flattr or Bitcoin. Making a donation is easy and takes only a couple of minutes. http://libreelec.tv/donate"
-msgstr "Το έργο LibreELEC τροφοδοτείται από καλές προθέσεις, αγάπη, και τις δωρεές σας. Αν επιθυμείτε να συνεισφέρετε στο έργο μπορείτε να κάνετε μια δωρεά μέσω PayPal, Flattr ή Bitcoin. Η δωρεά είναι απλή διαδικασία και διαρκεί μόνο λίγα λεπτά. http://libreelec.tv/donate"
-
 msgctxt "#700"
 msgid "Configure a hostname, keyboard type, perform a reset, update, or backups and restores"
 msgstr "Διαμόρφωση του κεντρικού υπολογιστή, του τύπου πληκτρολογίου, πραγματοποίηση επαναφοράς, ενημέρωσης, ή δημιουργίας/επαναφοράς αντιγράφου"

--- a/language/Hebrew/strings.po
+++ b/language/Hebrew/strings.po
@@ -60,10 +60,6 @@ msgctxt "#610"
 msgid "[B]Support:[/B][CR]Web: http://libreelec.tv[CR]Forum: http://forum.libreelec.tv/[CR]Wiki: http://wiki.libreelec.tv[CR][CR][B]Social Media:[/B][CR]IRC: #libreelec on freenode.net (web-based chat is also available from the website)[CR]Twitter: https://twitter.com/libreelec[CR]Facebook: http://www.facebook.com/LibreELEC[CR]Google+: https://plus.google.com/+libreelec"
 msgstr "[B]תמיכה:[/B][CR]אתר: http://libreelec.tv[CR]פורום: http://forum.libreelec.tv/[CR]וויקי: http://wiki.libreelec.tv[CR][CR][B]מדיה חברתית:[/B][CR]IRC: #libreelec on freenode.net (דרך אתר זה ניתן לנהל צ'אט בעזרת הדפדפן)[CR]טוויטר: https://twitter.com/libreelec[CR]פייסבוק: http://www.facebook.com/LibreELEC[CR]גוגל+: https://plus.google.com/+libreelec"
 
-msgctxt "#611"
-msgid "The LibreELEC project runs on goodwill, love, and your donations. If you would like to contribute to the project you can donate using PayPal, Flattr or Bitcoin. Making a donation is easy and takes only a couple of minutes. http://libreelec.tv/donate"
-msgstr "פרויקט LibreELEC מבוסס על רצון טוב, אהבה ותרומות. ניתן לתרום לפרויקט באמצעות PayPal, Flattr או Bitcoin. שליחת תרומה הינה תהליך פשוט שאורכו מספר דקות מצומצם. http://libreelec.tv/donate"
-
 msgctxt "#700"
 msgid "Configure a hostname, keyboard type, perform a reset, update, or backups and restores"
 msgstr "הגדרת שם מארח, סוג מקלדת, ביצוע איפוס, עדכון, או גיבוי ושחזור"

--- a/language/Hungarian/strings.po
+++ b/language/Hungarian/strings.po
@@ -60,10 +60,6 @@ msgctxt "#610"
 msgid "[B]Support:[/B][CR]Web: http://libreelec.tv[CR]Forum: http://forum.libreelec.tv/[CR]Wiki: http://wiki.libreelec.tv[CR][CR][B]Social Media:[/B][CR]IRC: #libreelec on freenode.net (web-based chat is also available from the website)[CR]Twitter: https://twitter.com/libreelec[CR]Facebook: http://www.facebook.com/LibreELEC[CR]Google+: https://plus.google.com/+libreelec"
 msgstr "[B]Támogatás:[/B][CR]Web: http://libreelec.tv[CR]Fórum: http://forum.libreelec.tv/[CR]Wiki: http://wiki.libreelec.tv[CR][CR][B]Közzöségi oldalak:[/B][CR]IRC: #libreelec on freenode.net (web alapú szintén elérhető a webes felületről)[CR]Twitter: https://twitter.com/libreelec[CR]Facebook: http://www.facebook.com/LibreELEC[CR]Google+: https://plus.google.com/+libreelec"
 
-msgctxt "#611"
-msgid "The LibreELEC project runs on goodwill, love, and your donations. If you would like to contribute to the project you can donate using PayPal, Flattr or Bitcoin. Making a donation is easy and takes only a couple of minutes. http://libreelec.tv/donate"
-msgstr "Az LibreELEC projekt a jóakaraton, szereteten és az adományokon alapszik. Ha szeretne hozzájárulni a projekthez, ezt megteheti az alábbi formákba: PayPal, Flattr or Bitcoin. Az adakozás egyszerű és néhány perc alatt elvégezhető. http://libreelec.tv/donate"
-
 msgctxt "#700"
 msgid "Configure a hostname, keyboard type, perform a reset, update, or backups and restores"
 msgstr "Hosztnév, billentyűzettípus beállítása, reset, frissítés, mentés és visszaállítás kezdeményezése "

--- a/language/Italian/strings.po
+++ b/language/Italian/strings.po
@@ -60,10 +60,6 @@ msgctxt "#610"
 msgid "[B]Support:[/B][CR]Web: http://libreelec.tv[CR]Forum: http://forum.libreelec.tv/[CR]Wiki: http://wiki.libreelec.tv[CR][CR][B]Social Media:[/B][CR]IRC: #libreelec on freenode.net (web-based chat is also available from the website)[CR]Twitter: https://twitter.com/libreelec[CR]Facebook: http://www.facebook.com/LibreELEC[CR]Google+: https://plus.google.com/+libreelec"
 msgstr "[B]Supporto:[/B][CR]Web: http://libreelec.tv[CR]Forum: http://forum.libreelec.tv/[CR]Wiki: http://wiki.libreelec.tv[CR][CR][B]Social Media:[/B][CR]IRC: #libreelec su freenode.net (una chat online è inoltre disponibile sul sito web)[CR]Twitter: https://twitter.com/libreelec[CR]Facebook: http://www.facebook.com/LibreELEC[CR]Google+: https://plus.google.com/+libreelec"
 
-msgctxt "#611"
-msgid "The LibreELEC project runs on goodwill, love, and your donations. If you would like to contribute to the project you can donate using PayPal, Flattr or Bitcoin. Making a donation is easy and takes only a couple of minutes. http://libreelec.tv/donate"
-msgstr "Il Progetto LibreELEC è basato sulla buona volontà, sulla passione e sulle vostre donazioni. Se vuoi contribuire al progetto puoi farlo usando PayPal, Flattr o Bitcoin. Fare una donazione è facile e richiede solo un paio di minuti. http://libreelec.tv/donate"
-
 msgctxt "#700"
 msgid "Configure a hostname, keyboard type, perform a reset, update, or backups and restores"
 msgstr "Configura lo hostname, il tipo di tastiera, effettua un reset, aggiorna, fai un backup o ripristina un backup precedente"

--- a/language/Japanese/strings.po
+++ b/language/Japanese/strings.po
@@ -60,10 +60,6 @@ msgctxt "#610"
 msgid "[B]Support:[/B][CR]Web: http://libreelec.tv[CR]Forum: http://forum.libreelec.tv/[CR]Wiki: http://wiki.libreelec.tv[CR][CR][B]Social Media:[/B][CR]IRC: #libreelec on freenode.net (web-based chat is also available from the website)[CR]Twitter: https://twitter.com/libreelec[CR]Facebook: http://www.facebook.com/LibreELEC[CR]Google+: https://plus.google.com/+libreelec"
 msgstr "[B]サポート:[/B][CR]ウェブ: http://libreelec.tv[CR]フォーラム: http://forum.libreelec.tv/[CR]: ウィキ: http://wiki.libreelec.tv[CR][CR][B]ソーシャルメディア:[/B][CR]IRC: #libreelec on freenode.net (ウェブからのウェブベースのチャットも利用できます)[CR]Twitter: https://twitter.com/libreelec[CR]Facebook: http://www.facebook.com/LibreELEC[CR]Google+: https://plus.google.com/+libreelec"
 
-msgctxt "#611"
-msgid "The LibreELEC project runs on goodwill, love, and your donations. If you would like to contribute to the project you can donate using PayPal, Flattr or Bitcoin. Making a donation is easy and takes only a couple of minutes. http://libreelec.tv/donate"
-msgstr "LibreELEC プロジェクトは親切、愛、そして寄付で運営しています。プロジェクトに貢献いただくご意志があれば、PayPal、Flattr またはBitcoin による寄付ができます。寄付は簡単でほんの数分で終わります。 http://libreelec.tv/donate"
-
 msgctxt "#700"
 msgid "Configure a hostname, keyboard type, perform a reset, update, or backups and restores"
 msgstr "ホスト名やキーボードの種類の設定、システムのリセットや更新、そしてバックアップとリストアを行います。"

--- a/language/Lithuanian/strings.po
+++ b/language/Lithuanian/strings.po
@@ -60,10 +60,6 @@ msgctxt "#610"
 msgid "[B]Support:[/B][CR]Web: http://libreelec.tv[CR]Forum: http://forum.libreelec.tv/[CR]Wiki: http://wiki.libreelec.tv[CR][CR][B]Social Media:[/B][CR]IRC: #libreelec on freenode.net (web-based chat is also available from the website)[CR]Twitter: https://twitter.com/libreelec[CR]Facebook: http://www.facebook.com/LibreELEC[CR]Google+: https://plus.google.com/+libreelec"
 msgstr "[B]Palaikymas:[/B][CR]Žiniatinklis: http://libreelec.tv[CR]Forumas: http://forum.libreelec.tv/[CR]Wiki: http://wiki.libreelec.tv[CR][CR][B]Socialinė žiniasklaida:[/B][CR]IRC: #libreelec on freenode.net (žiniatinklio tikralaikiai pokalbiai taip pat prieinami ir tinklapyje)[CR]Twitter: https://twitter.com/libreelec[CR]Facebook: http://www.facebook.com/LibreELEC[CR]Google+: https://plus.google.com/+libreelec"
 
-msgctxt "#611"
-msgid "The LibreELEC project runs on goodwill, love, and your donations. If you would like to contribute to the project you can donate using PayPal, Flattr or Bitcoin. Making a donation is easy and takes only a couple of minutes. http://libreelec.tv/donate"
-msgstr "LibreELEC projektas veikia palaikomas geros valios, meilės ir jūsų aukų. Jei norite prisidėti prie projekto, galite aukoti, naudodami PayPal, Flattr arba Bitcoin. Paaukoti labai paprasta ir užtruks pora minučių. http://libreelec.tv/donate"
-
 msgctxt "#700"
 msgid "Configure a hostname, keyboard type, perform a reset, update, or backups and restores"
 msgstr "Konfigūruoti pagrindinio kompiuterio vardą, klaviatūros tipą, atlikti atstatymą į pradinę būseną, atnaujinimą ar atsarginės kopijos sukūrimą ir atstatymą"

--- a/language/Norwegian/strings.po
+++ b/language/Norwegian/strings.po
@@ -56,10 +56,6 @@ msgctxt "#610"
 msgid "[B]Support:[/B][CR]Web: http://libreelec.tv[CR]Forum: http://forum.libreelec.tv/[CR]Wiki: http://wiki.libreelec.tv[CR][CR][B]Social Media:[/B][CR]IRC: #libreelec on freenode.net (web-based chat is also available from the website)[CR]Twitter: https://twitter.com/libreelec[CR]Facebook: http://www.facebook.com/LibreELEC[CR]Google+: https://plus.google.com/+libreelec"
 msgstr "[B]Støtte:[/B][CR]Nett: http://libreelec.tv[CR]Forum: http://forum.libreelec.tv/[CR]Wiki: http://wiki.libreelec.tv[CR][CR][B]Sosiale medier:[/B][CR]IRC: #libreelec on freenode.net (nettbasert chat er også tilgjengelig fra nettsiden)[CR]Twitter: https://twitter.com/libreelec[CR]Facebook: http://www.facebook.com/LibreELEC[CR]Google+: https://plus.google.com/+libreelec"
 
-msgctxt "#611"
-msgid "The LibreELEC project runs on goodwill, love, and your donations. If you would like to contribute to the project you can donate using PayPal, Flattr or Bitcoin. Making a donation is easy and takes only a couple of minutes. http://libreelec.tv/donate"
-msgstr "LibreELEC-prosjektet lever av «goodwill», kjærlighet og dine donasjoner. Hvis du vil bidra til prosjektet kan du donere ved å bruke PayPal, Flattr eller Bitcoin. Å donere er enkelt og tar kun noen minutter. http://libreelec.tv/donate"
-
 msgctxt "#700"
 msgid "Configure a hostname, keyboard type, perform a reset, update, or backups and restores"
 msgstr "Konfigurer maskinnavn, tastaturtype, tilbakestill, oppdater, eller sikkerhetskopier og gjenopprett"

--- a/language/Polish/strings.po
+++ b/language/Polish/strings.po
@@ -60,10 +60,6 @@ msgctxt "#610"
 msgid "[B]Support:[/B][CR]Web: http://libreelec.tv[CR]Forum: http://forum.libreelec.tv/[CR]Wiki: http://wiki.libreelec.tv[CR][CR][B]Social Media:[/B][CR]IRC: #libreelec on freenode.net (web-based chat is also available from the website)[CR]Twitter: https://twitter.com/libreelec[CR]Facebook: http://www.facebook.com/LibreELEC[CR]Google+: https://plus.google.com/+libreelec"
 msgstr "[B]Pomoc:[/B][CR]Web: http://libreelec.tv[CR]Forum: http://forum.libreelec.tv/[CR]Wiki: http://wiki.libreelec.tv[CR][CR][B]Media społeczne:[/B][CR]IRC: #libreelec on freenode.net (chat jest również dostępny na stronie internetowej)[CR]Twitter: https://twitter.com/libreelec[CR]Facebook: http://www.facebook.com/LibreELEC[CR]Google+: https://plus.google.com/+libreelec"
 
-msgctxt "#611"
-msgid "The LibreELEC project runs on goodwill, love, and your donations. If you would like to contribute to the project you can donate using PayPal, Flattr or Bitcoin. Making a donation is easy and takes only a couple of minutes. http://libreelec.tv/donate"
-msgstr "Projekt LibreELEC działa dzięki wsparciu, ciężkiej pracy i entuzjazmowi tysięcy ludzi oraz Waszym darowiznom. Jeśli chcesz przyczynić się do dalszego rozwoju projektu, prześlij nam darowiznę za pośrednictwem systemu PayPal, Flattr lub Bitcoin. Dokonanie wpłaty jest proste i zajmuje tylko kilka minut. Dziękujemy za wsparcie.\nhttp://libreelec.tv/donate "
-
 msgctxt "#700"
 msgid "Configure a hostname, keyboard type, perform a reset, update, or backups and restores"
 msgstr "Konfiguracja nazwy hosta, typu klawiatury, sposobu aktualizacji oraz tworzenia kopii zapasowych i przywracania "

--- a/language/Portuguese (Brazil)/strings.po
+++ b/language/Portuguese (Brazil)/strings.po
@@ -60,10 +60,6 @@ msgctxt "#610"
 msgid "[B]Support:[/B][CR]Web: http://libreelec.tv[CR]Forum: http://forum.libreelec.tv/[CR]Wiki: http://wiki.libreelec.tv[CR][CR][B]Social Media:[/B][CR]IRC: #libreelec on freenode.net (web-based chat is also available from the website)[CR]Twitter: https://twitter.com/libreelec[CR]Facebook: http://www.facebook.com/LibreELEC[CR]Google+: https://plus.google.com/+libreelec"
 msgstr "[B]Ajuda:[/B][CR]Web: http://libreelec.tv[CR]Fórum: http://forum.libreelec.tv/[CR]Wiki: http://wiki.libreelec.tv[CR][CR][B]Redes Sociais:[/B][CR]IRC: #libreelec em freenode.net (conversação por web está também disponível no site)[CR]Twitter: https://twitter.com/libreelec[CR]Facebook: http://www.facebook.com/LibreELEC[CR]Google+: https://plus.google.com/+libreelec"
 
-msgctxt "#611"
-msgid "The LibreELEC project runs on goodwill, love, and your donations. If you would like to contribute to the project you can donate using PayPal, Flattr or Bitcoin. Making a donation is easy and takes only a couple of minutes. http://libreelec.tv/donate"
-msgstr "O projeto LibreELEC funciona à base de boa vontade, de amizade e de suas doações. Se quiser contribuir para o projeto, pode fazer uma doação através do Paypal, Flattr ou Bitcoin. Fazer uma doação é fácil e leva apenas alguns minutos. http://libreelec.tv/donate"
-
 msgctxt "#700"
 msgid "Configure a hostname, keyboard type, perform a reset, update, or backups and restores"
 msgstr "Configure o nome do computador, tipo de teclado, reinicie o sistema, atualize ou faça backup e restauração dos mesmos"

--- a/language/Portuguese/strings.po
+++ b/language/Portuguese/strings.po
@@ -60,10 +60,6 @@ msgctxt "#610"
 msgid "[B]Support:[/B][CR]Web: http://libreelec.tv[CR]Forum: http://forum.libreelec.tv/[CR]Wiki: http://wiki.libreelec.tv[CR][CR][B]Social Media:[/B][CR]IRC: #libreelec on freenode.net (web-based chat is also available from the website)[CR]Twitter: https://twitter.com/libreelec[CR]Facebook: http://www.facebook.com/LibreELEC[CR]Google+: https://plus.google.com/+libreelec"
 msgstr "[B]Ajuda:[/B][CR]Web: http://libreelec.tv[CR]Fórum: http://forum.libreelec.tv/[CR]Wiki: http://wiki.libreelec.tv[CR][CR][B]Redes Sociais:[/B][CR]IRC: #libreelec em freenode.net (conversação por web está também disponível no site)[CR]Twitter: https://twitter.com/libreelec[CR]Facebook: http://www.facebook.com/LibreELEC[CR]Google+: https://plus.google.com/+libreelec"
 
-msgctxt "#611"
-msgid "The LibreELEC project runs on goodwill, love, and your donations. If you would like to contribute to the project you can donate using PayPal, Flattr or Bitcoin. Making a donation is easy and takes only a couple of minutes. http://libreelec.tv/donate"
-msgstr "O projecto LibreELEC funciona à base de boa vontade, de amizade e das vossas doações. Se quiser contribuir para o projecto, pode fazer uma doação através do Paypal, Flattr ou Bitcoin. Fazer uma doação é fácil e leva apenas alguns minutos. http://libreelec.tv/donate"
-
 msgctxt "#700"
 msgid "Configure a hostname, keyboard type, perform a reset, update, or backups and restores"
 msgstr "Configure um nome do servidor, tipo de teclado, reinicie o sistema, actualize-o ou faça cópias de segurança e restauro das mesmas"

--- a/language/Russian/strings.po
+++ b/language/Russian/strings.po
@@ -60,10 +60,6 @@ msgctxt "#610"
 msgid "[B]Support:[/B][CR]Web: http://libreelec.tv[CR]Forum: http://forum.libreelec.tv/[CR]Wiki: http://wiki.libreelec.tv[CR][CR][B]Social Media:[/B][CR]IRC: #libreelec on freenode.net (web-based chat is also available from the website)[CR]Twitter: https://twitter.com/libreelec[CR]Facebook: http://www.facebook.com/LibreELEC[CR]Google+: https://plus.google.com/+libreelec"
 msgstr "[B]Поддержка:[/B][CR]Веб: http://libreelec.tv[CR]Форум: http://forum.libreelec.tv/[CR]Вики: http://wiki.libreelec.tv[CR][CR][B]Социальные ресурсы:[/B][CR]IRC: #libreelec на freenode.net (веб-чат также доступен на сайте)[CR]Twitter: https://twitter.com/libreelec[CR]Facebook: http://www.facebook.com/LibreELEC[CR]Google+: https://plus.google.com/+libreelec"
 
-msgctxt "#611"
-msgid "The LibreELEC project runs on goodwill, love, and your donations. If you would like to contribute to the project you can donate using PayPal, Flattr or Bitcoin. Making a donation is easy and takes only a couple of minutes. http://libreelec.tv/donate"
-msgstr "Проект LibreELEC развивается в основном за счет доброй воли, любви и Ваших пожертвований. Если Вы хотите помочь проекту - Вы можете сделать пожертвование через систему PayPal, Flattr или Bitcoin. Это займет у Вас всего несколько минут. http://libreelec.tv/donate"
-
 msgctxt "#700"
 msgid "Configure a hostname, keyboard type, perform a reset, update, or backups and restores"
 msgstr "Конфигурация имени хоста, типа клавиатуры, а также возможность сброса, обновления или резервного копирования и восстановления"

--- a/language/Slovak/strings.po
+++ b/language/Slovak/strings.po
@@ -56,10 +56,6 @@ msgctxt "#610"
 msgid "[B]Support:[/B][CR]Web: http://libreelec.tv[CR]Forum: http://forum.libreelec.tv/[CR]Wiki: http://wiki.libreelec.tv[CR][CR][B]Social Media:[/B][CR]IRC: #libreelec on freenode.net (web-based chat is also available from the website)[CR]Twitter: https://twitter.com/libreelec[CR]Facebook: http://www.facebook.com/LibreELEC[CR]Google+: https://plus.google.com/+libreelec"
 msgstr "[B]Podpora:[/B][CR]Web: http://libreelec.tv[CR]Forum: http://forum.libreelec.tv/[CR]Wiki: http://wiki.libreelec.tv[CR][CR][B]Sociálne siete:[/B][CR]IRC: #libreelec na freenode.net (webový chat je tiež k dispozícii na tejto stránke)[CR]Twitter: https://twitter.com/libreelec[CR]Facebook: http://www.facebook.com/LibreELEC[CR]Google+: https://plus.google.com/+libreelec"
 
-msgctxt "#611"
-msgid "The LibreELEC project runs on goodwill, love, and your donations. If you would like to contribute to the project you can donate using PayPal, Flattr or Bitcoin. Making a donation is easy and takes only a couple of minutes. http://libreelec.tv/donate"
-msgstr "Projekt LibreELEC je funguje vďaka dobrej vôli, láske a peňažným príspevkom. Ak máte záujem prispieť do projektu, môžete tak urobiť zaslaním peňažného príspevku prostredníctvom služieb PayPal, Flattr alebo Bitcoin. Zaberie to iba zopár minút. http://libreelec.tv/donate"
-
 msgctxt "#700"
 msgid "Configure a hostname, keyboard type, perform a reset, update, or backups and restores"
 msgstr "Nastavenie mena počítača, typu klávesnice, vykonanie reštartu, aktualizácie, zálohovania alebo obnovy"

--- a/language/Slovenian/strings.po
+++ b/language/Slovenian/strings.po
@@ -60,10 +60,6 @@ msgctxt "#610"
 msgid "[B]Support:[/B][CR]Web: http://libreelec.tv[CR]Forum: http://forum.libreelec.tv/[CR]Wiki: http://wiki.libreelec.tv[CR][CR][B]Social Media:[/B][CR]IRC: #libreelec on freenode.net (web-based chat is also available from the website)[CR]Twitter: https://twitter.com/libreelec[CR]Facebook: http://www.facebook.com/LibreELEC[CR]Google+: https://plus.google.com/+libreelec"
 msgstr "[B]Podpora:[/B][CR]Splet: http://libreelec.tv[CR]Forum: http://forum.libreelec.tv/[CR]Wiki: http://wiki.libreelec.tv[CR][CR][B]Družabna omrežja:[/B][CR]IRC: #libreelec na freenode.net (na spletišču je na voljo tudi klepet prek spletnega vmesnika)[CR]Twitter: https://twitter.com/libreelec[CR]Facebook: http://www.facebook.com/LibreELEC[CR]Google+: https://plus.google.com/+libreelec"
 
-msgctxt "#611"
-msgid "The LibreELEC project runs on goodwill, love, and your donations. If you would like to contribute to the project you can donate using PayPal, Flattr or Bitcoin. Making a donation is easy and takes only a couple of minutes. http://libreelec.tv/donate"
-msgstr "Projekt LibreELEC poganjajo dobra volja, ljubezen in vaši prispevki. Če bi radi prispevali projektu, lahko donirate prek storitev PayPal, Flattr in Bitcoin. Doniranje je enostavno in vzame le nekaj minut. http://libreelec.tv/donate"
-
 msgctxt "#700"
 msgid "Configure a hostname, keyboard type, perform a reset, update, or backups and restores"
 msgstr "Prilagodite ime gostitelja, vrsto tipkovnice, izvedite ponastavitev, posodobitev ali varnostno kopiranje in obnavljanje."

--- a/language/Spanish (Mexico)/strings.po
+++ b/language/Spanish (Mexico)/strings.po
@@ -52,10 +52,6 @@ msgctxt "#610"
 msgid "[B]Support:[/B][CR]Web: http://libreelec.tv[CR]Forum: http://forum.libreelec.tv/[CR]Wiki: http://wiki.libreelec.tv[CR][CR][B]Social Media:[/B][CR]IRC: #libreelec on freenode.net (web-based chat is also available from the website)[CR]Twitter: https://twitter.com/libreelec[CR]Facebook: http://www.facebook.com/LibreELEC[CR]Google+: https://plus.google.com/+libreelec"
 msgstr "[B]Soporte:[/B][CR]Web: http://libreelec.tv[CR]Foro: http://forum.libreelec.tv/[CR]Wiki: http://wiki.libreelec.tv[CR][CR][B]Redes Sociales:[/B][CR]IRC: #libreelec on freenode.net (web-chat disponible desde el sitio)[CR]Twitter: https://twitter.com/libreelec[CR]Facebook: http://www.facebook.com/LibreELEC[CR]Google+: https://plus.google.com/+libreelec"
 
-msgctxt "#611"
-msgid "The LibreELEC project runs on goodwill, love, and your donations. If you would like to contribute to the project you can donate using PayPal, Flattr or Bitcoin. Making a donation is easy and takes only a couple of minutes. http://libreelec.tv/donate"
-msgstr "El proyecto LibreELEC se sustenta de buenas intenciones, amor y sus donaciones. Si deseas contribuir puedes hacer una donacion al proyecto via PayPal, Flattr o Bitcoin. Donar es sencillo y solo toma un par de minutos. http://libreelec.tv/donate"
-
 msgctxt "#700"
 msgid "Configure a hostname, keyboard type, perform a reset, update, or backups and restores"
 msgstr "Configura el nombre del equipo, el tipo de teclado, reinicio o actualización del sistema, respalda y restaura la configuración del sistema."

--- a/language/Spanish/strings.po
+++ b/language/Spanish/strings.po
@@ -60,10 +60,6 @@ msgctxt "#610"
 msgid "[B]Support:[/B][CR]Web: http://libreelec.tv[CR]Forum: http://forum.libreelec.tv/[CR]Wiki: http://wiki.libreelec.tv[CR][CR][B]Social Media:[/B][CR]IRC: #libreelec on freenode.net (web-based chat is also available from the website)[CR]Twitter: https://twitter.com/libreelec[CR]Facebook: http://www.facebook.com/LibreELEC[CR]Google+: https://plus.google.com/+libreelec"
 msgstr "[B]Soporte:[/B][CR]Web: http://libreelec.tv[CR]Forum: http://forum.libreelec.tv/[CR]Wiki: http://wiki.libreelec.tv[CR][CR][B]Redes Sociales:[/B][CR]IRC: #libreelec on freenode.net (hay disponible un chat basado en web en el sitio web)[CR]Twitter: https://twitter.com/libreelec[CR]Facebook: http://www.facebook.com/LibreELEC[CR]Google+: https://plus.google.com/+libreelec"
 
-msgctxt "#611"
-msgid "The LibreELEC project runs on goodwill, love, and your donations. If you would like to contribute to the project you can donate using PayPal, Flattr or Bitcoin. Making a donation is easy and takes only a couple of minutes. http://libreelec.tv/donate"
-msgstr "El proyecto LibreELEC se soporta en buenas intenciones, amor y sus donaciones. Si desea contribuir con el proyecto LibreELEC puede hacer una donación utilizando PayPal, Flattr o Bitcoin. Donar es sencillo y solo tomara unos pocos minutos. http://libreelec.tv/donate"
-
 msgctxt "#700"
 msgid "Configure a hostname, keyboard type, perform a reset, update, or backups and restores"
 msgstr "Configura un nombre de host, el tipo teclado, realiza un reinicio, actualiza, o haz copias de seguridad y restauraciones."

--- a/language/Swedish/strings.po
+++ b/language/Swedish/strings.po
@@ -60,10 +60,6 @@ msgctxt "#610"
 msgid "[B]Support:[/B][CR]Web: http://libreelec.tv[CR]Forum: http://forum.libreelec.tv/[CR]Wiki: http://wiki.libreelec.tv[CR][CR][B]Social Media:[/B][CR]IRC: #libreelec on freenode.net (web-based chat is also available from the website)[CR]Twitter: https://twitter.com/libreelec[CR]Facebook: http://www.facebook.com/LibreELEC[CR]Google+: https://plus.google.com/+libreelec"
 msgstr "[B]Support:[/B][CR]Webb: http://libreelec.tv[CR]Forum: http://forum.libreelec.tv/[CR]Wiki: http://wiki.libreelec.tv[CR][CR][B]Social media:[/B][CR]IRC: #libreelec på freenode.net (webb-baserad chat finns också tillgänglig på webbsidan)[CR]Twitter: https://twitter.com/libreelec[CR]Facebook: http://www.facebook.com/LibreELEC[CR]Google+: https://plus.google.com/+libreelec"
 
-msgctxt "#611"
-msgid "The LibreELEC project runs on goodwill, love, and your donations. If you would like to contribute to the project you can donate using PayPal, Flattr or Bitcoin. Making a donation is easy and takes only a couple of minutes. http://libreelec.tv/donate"
-msgstr "LibreELEC-projektet drivs av god vilja, kärlek och dina donationer. Om du skulle vilja bidra till projektet kan du donera med hjälp av PayPal, Flattr eller Bitcoin. Att donera är enkelt och tar endast ett par minuter. http://libreelec.tv/donate"
-
 msgctxt "#700"
 msgid "Configure a hostname, keyboard type, perform a reset, update, or backups and restores"
 msgstr "Ställ in ett värdnamn, tangentbordstyp, nollställ inställningar, uppdatera eller skapa/återställ backup"

--- a/language/Turkish/strings.po
+++ b/language/Turkish/strings.po
@@ -60,10 +60,6 @@ msgctxt "#610"
 msgid "[B]Support:[/B][CR]Web: http://libreelec.tv[CR]Forum: http://forum.libreelec.tv/[CR]Wiki: http://wiki.libreelec.tv[CR][CR][B]Social Media:[/B][CR]IRC: #libreelec on freenode.net (web-based chat is also available from the website)[CR]Twitter: https://twitter.com/libreelec[CR]Facebook: http://www.facebook.com/LibreELEC[CR]Google+: https://plus.google.com/+libreelec"
 msgstr "[B]Destek:[/B][CR]Web: http://libreelec.tv[CR]Forum: http://forum.libreelec.tv/[CR]Wiki: http://wiki.libreelec.tv[CR][CR][B]Sosyal Medya:[/B][CR]IRC: freenode.net üzerinde #libreelec (web tabanlı sohbet web sitesinden de mevcuttur)[CR]Twitter: https://twitter.com/libreelec[CR]Facebook: http://www.facebook.com/LibreELEC[CR]Google+: https://plus.google.com/+libreelec"
 
-msgctxt "#611"
-msgid "The LibreELEC project runs on goodwill, love, and your donations. If you would like to contribute to the project you can donate using PayPal, Flattr or Bitcoin. Making a donation is easy and takes only a couple of minutes. http://libreelec.tv/donate"
-msgstr "LibreELEC projesi, iyi niyet, sevgi ve bağışlarınız ile çalışır. Projeye katkıda bulunmak istiyorsanız PayPal, Flattr veya Bitcoin kullanarak bağış yapabilirsiniz. Bağış yapmak kolaydır ve sadece birkaç dakika sürer. http://libreelec.tv/donate"
-
 msgctxt "#700"
 msgid "Configure a hostname, keyboard type, perform a reset, update, or backups and restores"
 msgstr "Ana bilgisayar adı, klavye türü, sıfırlama, güncelleme veya yedekleme ve geri yüklemeyi yapılandır"

--- a/language/Vietnamese/strings.po
+++ b/language/Vietnamese/strings.po
@@ -60,10 +60,6 @@ msgctxt "#610"
 msgid "[B]Support:[/B][CR]Web: http://libreelec.tv[CR]Forum: http://forum.libreelec.tv/[CR]Wiki: http://wiki.libreelec.tv[CR][CR][B]Social Media:[/B][CR]IRC: #libreelec on freenode.net (web-based chat is also available from the website)[CR]Twitter: https://twitter.com/libreelec[CR]Facebook: http://www.facebook.com/LibreELEC[CR]Google+: https://plus.google.com/+libreelec"
 msgstr "[B]Hỗ trợ:[/B][CR]Trang Web: http://libreelec.tv[CR]Forum: http://forum.libreelec.tv/[CR]Wiki: http://wiki.libreelec.tv[CR][CR][B]Social Media:[/B][CR]IRC: #libreelec trên freenode.net (trò chuyện trên web cũng có sẵn từ trang web)[CR]Twitter: https://twitter.com/libreelec[CR]Facebook: http://www.facebook.com/LibreELEC[CR]Google+: https://plus.google.com/+libreelec"
 
-msgctxt "#611"
-msgid "The LibreELEC project runs on goodwill, love, and your donations. If you would like to contribute to the project you can donate using PayPal, Flattr or Bitcoin. Making a donation is easy and takes only a couple of minutes. http://libreelec.tv/donate"
-msgstr "Dự án LibreELEC Khởi chạy với sự thiện chí, tình yêu, và sự đóng góp của bạn. Nếu bạn muốn đóng góp cho dự án bạn có thể tặng cho chúng tôi sử dụng PayPal, Flattr hoặc Bitcoin. Việc đóng góp rất dễ dàng và chỉ mất một vài phút. http://libreelec.tv/donate"
-
 msgctxt "#700"
 msgid "Configure a hostname, keyboard type, perform a reset, update, or backups and restores"
 msgstr "Cấu hình một loại tên máy, bàn phím, thực hiện một thiết lập lại từ đầu, cập nhật, hoặc sao lưu và khôi phục"

--- a/skins/Default/1080i/service-LibreELEC-Settings-mainWindow.xml
+++ b/skins/Default/1080i/service-LibreELEC-Settings-mainWindow.xml
@@ -213,7 +213,6 @@
                         <font>font10</font>
                         <textcolor>white</textcolor>
                         <align>left</align>
-                        <label>$ADDON[service.libreelec.settings 705]</label>
                     </control>
                 </control>
                 <!-- simple list content -->
@@ -1061,6 +1060,17 @@
                         </control>
                     </focusedlayout>
                 </control>
+            </control>
+            <control type="textbox" id="1400">
+                <left>466</left>
+                <top>808</top>
+                <width>1150</width>
+                <height>90</height>
+                <label>$INFO[Window.Property(InfoText)]</label>
+                <align>left</align>
+                <font>font10</font>
+                <textcolor>white</textcolor>
+                <shadowcolor>black</shadowcolor>
             </control>
             <control type="button" id="1501">
                 <left>1400</left>


### PR DESCRIPTION
this was broken in https://github.com/LibreELEC/service.libreelec.settings/commit/31b8d612f6d49d595c75ff3bc1a13b5b9fcb80ef

it caused the info tooltip not to be displayed at the bottom for each setting.