### PR TITLE
lircd: allow disabling

### DIFF
--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -200,6 +200,10 @@ msgctxt "#745"
 msgid "Set to ON to enable the cron daemon"
 msgstr ""
 
+msgctxt "#746"
+msgid "Set to ON to enable the lirc daemon"
+msgstr ""
+
 msgctxt "#750"
 msgid "750"
 msgstr ""
@@ -800,3 +804,10 @@ msgctxt "#32390"
 msgid "Settings addon is not yet ready, please try again later."
 msgstr ""
 
+msgctxt "#32391"
+msgid "Lirc"
+msgstr ""
+
+msgctxt "#32392"
+msgid "Enable Lirc"
+msgstr ""

--- a/src/defaults.py
+++ b/src/defaults.py
@@ -74,6 +74,7 @@ services = {
     'D_SSH_DISABLE_PW_AUTH': '0',
     'AVAHI_DAEMON': '/usr/sbin/avahi-daemon',
     'CRON_DAEMON': '/sbin/crond',
+    'LIRCD_UEVENT_FILE': '/sys/class/lirc/lirc0/uevent',
     }
 
 system = {

--- a/src/resources/lib/modules/services.py
+++ b/src/resources/lib/modules/services.py
@@ -44,6 +44,7 @@ class services:
     OPT_SSH_NOPASSWD = None
     AVAHI_DAEMON = None
     CRON_DAEMON = None
+    LIRCD_UEVENT_FILE = None
     menu = {'4': {
         'name': 32001,
         'menuLoader': 'load_menu',
@@ -210,6 +211,21 @@ class services:
                             },
                         },
                     },
+                'lircd': {
+                    'order': 7,
+                    'name': 32391,
+                    'not_supported': [],
+                    'settings': {
+                        'lircd_autostart': {
+                            'order': 1,
+                            'name': 32392,
+                            'value': None,
+                            'action': 'initialize_lircd',
+                            'type': 'bool',
+                            'InfoText': 746,
+                            },
+                        },
+                    },
                 }
 
             self.oe = oeMain
@@ -226,6 +242,7 @@ class services:
             self.initialize_avahi(service=1)
             self.initialize_cron(service=1)
             self.init_bluetooth(service=1)
+            self.initialize_lircd(service=1)
             self.oe.dbg_log('services::start_service', 'exit_function', 0)
         except Exception, e:
             self.oe.dbg_log('services::start_service', 'ERROR: (%s)' % repr(e))
@@ -326,6 +343,14 @@ class services:
                         self.struct['bluez']['settings']['obex_root']['hidden'] = True
                 else:
                     self.struct['bluez']['hidden'] = 'true'
+
+            # LIRCD
+
+            if os.path.isfile(self.LIRCD_UEVENT_FILE):
+                self.struct['lircd']['settings']['lircd_autostart']['value'] = self.oe.get_service_state('lircd')
+            else:
+                self.struct['lircd']['hidden'] = 'true'
+
             self.oe.dbg_log('services::load_values', 'exit_function', 0)
         except Exception, e:
             self.oe.dbg_log('services::load_values', 'ERROR: (%s)' % repr(e))
@@ -467,6 +492,31 @@ class services:
         except Exception, e:
             self.oe.set_busy(0)
             self.oe.dbg_log('services::init_obex', 'ERROR: (' + repr(e) + ')', 4)
+
+    def initialize_lircd(self, **kwargs):
+        try:
+            self.oe.dbg_log('services::inititialize_lircd', 'enter_function', 0)
+            self.oe.set_busy(1)
+            if 'listItem' in kwargs:
+                self.set_value(kwargs['listItem'])
+            state = 1
+            options = {}
+            if self.struct['lircd']['settings']['lircd_autostart']['value'] == '1':
+                if os.path.exists(self.LIRCD_UEVENT_FILE):
+                    with open(self.LIRCD_UEVENT_FILE, 'w') as f:
+                        f.write('add')
+            else:
+                if os.path.exists(self.LIRCD_UEVENT_FILE):
+                    with open(self.LIRCD_UEVENT_FILE, 'w') as f:
+                        f.write('remove')
+                state = 0
+            self.oe.set_service('lircd', options, state)
+            self.oe.set_busy(0)
+            self.oe.dbg_log('services::inititialize_lircd', 'exit_function', 0)
+        except Exception, e:
+            self.oe.set_busy(0)
+            self.oe.dbg_log('services::inititialize_lircd', 'ERROR: (' + repr(e) + ')', 4)
+
     def exit(self):
         try:
             self.oe.dbg_log('services::exit', 'enter_function', 0)


### PR DESCRIPTION
This cheeses it a little bit by abusing the `/sys/class/lirc/lirc0/uevent` to fake a remove or add event to udev.

This is needed because the systemd service is dynamic as it is called by a udev rule that matches certain files/modules to run the `lircd@.service`

So it's not possible to start/stop the `lircd@.service` directly. This calls a remove/add event which will trigger udev to start/stop the specific systemd `lircd@.service` file

Please take a look at the strings and capitalization.

This is needed with https://github.com/LibreELEC/LibreELEC.tv/pull/913