### PR TITLE
fix bluetooth standby when screensaver is activated

### DIFF
--- a/src/oe.py
+++ b/src/oe.py
@@ -504,6 +504,13 @@ def openConfigurationWindow():
         xbmc.executebuiltin('Dialog.Close(busydialog)')
         dbg_log('oe::openConfigurationWindow', 'ERROR: (' + repr(e) + ')')
 
+def standby_devices():
+    global dictModules
+    try:
+        if 'bluetooth' in dictModules:
+            dictModules['bluetooth'].standby_devices()
+    except Exception, e:
+        dbg_log('oe::standby_devices', 'ERROR: (' + repr(e) + ')')
 
 def load_config():
     try:

--- a/src/resources/lib/modules/bluetooth.py
+++ b/src/resources/lib/modules/bluetooth.py
@@ -624,11 +624,13 @@ class bluetooth:
                 if not devices == None:
                     devices = devices.split(',')
                     if len(devices) > 0:
+                        self.oe.input_request = True
                         lstItem = xbmcgui.ListItem()
                         for device in devices:
                             lstItem.setProperty('entry', device)
                             self.disconnect_device(lstItem)
                         lstItem = None
+                        self.oe.input_request = False
             self.oe.dbg_log('bluetooth::standby_devices', 'exit_function', 0)
         except Exception, e:
             self.oe.dbg_log('bluetooth::standby_devices', 'ERROR: (' + repr(e) + ')', 4)

--- a/src/service.py
+++ b/src/service.py
@@ -100,8 +100,8 @@ class cxbmcm(xbmc.Monitor):
 
     def onScreensaverActivated(self):
         oe.__oe__.dbg_log('c_xbmcm::onScreensaverActivated', 'enter_function', 0)
-        if 'bluetooth' in oe.__oe__.dictModules:
-            oe.__oe__.dictModules['bluetooth'].standby_devices()
+        if oe.__oe__.read_setting('bluetooth', 'standby'):
+            threading.Thread(target=oe.__oe__.standby_devices).start()
         oe.__oe__.dbg_log('c_xbmcm::onScreensaverActivated', 'exit_function', 0)
 
     def onAbortRequested(self):


### PR DESCRIPTION
This PR fixes:
- Screensaver never being activated when `Enable Standby` is activated for a bluetooth device
- `Enable Standby` devices not being disconnected when the screensaver is activated

https://forum.libreelec.tv/thread-1442.html