### PR TITLE
Add (and display) pretty names in release order - not name order

### DIFF
--- a/src/resources/lib/modules/system.py
+++ b/src/resources/lib/modules/system.py
@@ -732,7 +732,7 @@ class system:
                     if channel in self.update_json:
                         regex = re.compile(self.update_json[channel]['prettyname_regex'])
                         if self.oe.ARCHITECTURE in self.update_json[channel]['project']:
-                            for i in self.update_json[channel]['project'][self.oe.ARCHITECTURE]['releases']:
+                            for i in sorted(self.update_json[channel]['project'][self.oe.ARCHITECTURE]['releases'], key=int, reverse=True):
                                 if shortname is None:
                                     update_files.append(regex.findall(self.update_json[channel]['project'][self.oe.ARCHITECTURE]['releases'][i]['file']['name'])[0].strip('.tar'))
                                 else:

--- a/src/resources/lib/oeWindows.py
+++ b/src/resources/lib/oeWindows.py
@@ -262,7 +262,7 @@ class mainWindow(xbmcgui.WindowXMLDialog):
                 if strTyp == 'multivalue':
                     items1 = []
                     items2 = []
-                    for item in sorted(selectedItem.getProperty('values').split('|'), reverse=True):
+                    for item in selectedItem.getProperty('values').split('|'):
                         if item != ':':
                             boo = item.split(':')
                             if len(boo) > 1:


### PR DESCRIPTION
Rather than sort the list of available builds by the displayed name, we should sort the available builds by the reverse order in which they appear in the `releases.json` file (ie. n, n-1, n-2, ... 0).

This PR prevents a build such as `#0101` (from 2017) being listed last in the list and `#1231` (from 2016) being listed first, which happens because we are sorting the list into reverse sort order based on the displayed list value - `#0101` is a more recent build than `#1231`, and should be listed first.

In `releases.json` we have:
```
{
"0": {"file": {"sha256": "476425330acdae7227082009dbc1b13c549cfe3485b623698493c376351161b6", "name": "LibreELEC-Generic.x86_64-8.0-Milhouse-20160331012541-#0330-g46e67b7.tar", "size": "215193600"}},
"1": {"file": {"sha256": "b5c4d7f1e0a38da4a73474b5140e72dbc4f6edacec91bde65cb8883e75906d0c", "name": "LibreELEC-Generic.x86_64-8.0-Milhouse-20160331172353-#0331-gce890b1.tar", "size": "216524800"}},
...
"267": {"file": {"sha256": "7ff9274c36d8547e2565a1de127dc2656f74b0ac004da52dfe6a8615f4017ae2", "name": "LibreELEC-Generic.x86_64-8.0-Milhouse-20161231210212-#1231-g742b909.tar", "size": "214988800"}},
"268": {"file": {"sha256": "b2642309630bf7760f63c2d5e668f3b45610e60c0b5eac69d11cb380bdff9dfc", "name": "LibreELEC-Generic.x86_64-8.0-Milhouse-20170101225622-#0101-g8e3dbe5.tar", "size": "215040000"}}
}
```
Sorting by the key (0, 1, 267, 268 etc.) as we process the items in `releases.json`, and then displaying the processed items in the default order, ensures the displayed list is in the correct order regardless of what pretty name is displayed.

With this change...

Update Channel: Milhouse-8.0 (latest release: `#0101`):
![s1](http://i.imgur.com/AVV6Wbl.png)

Update Channel: LibreELEC-8.0:
![s2](http://i.imgur.com/Q8Qu8dT.png)

Update Channel: LibreELEC-7.0:
![s3](http://i.imgur.com/12852zP.png)
