### PR TITLE
Makefile: Need /bin/bash for bashisms

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ ADDON_NAME=service.libreelec.settings
 ADDON_VERSION=0.8.7
 DISTRONAME:=LibreELEC
 
+SHELL=/bin/bash
 BUILDDIR=build
 DATADIR=/usr/share/kodi
 ADDONDIR=$(DATADIR)/addons


### PR DESCRIPTION
#49 added file-name brace expansion:
```
cp textures/$(DISTRONAME)/*.{png,jpg} $(BUILDDIR)/$(ADDON_NAME)/resources/skins/Default/media/default
```

Brace expansion is a bash-ism. By default, when the SHELL variable is not set, `make` will use `/bin/sh` as the shell, see [manual](https://www.gnu.org/software/make/manual/html_node/Choosing-the-Shell.html).

Consequently after #49, `make` fails:
```
      BUILD    LibreELEC-settings (target)
Executing (target): make DISTRONAME=LibreELEC ROOT_PASSWORD=libreelec
make[1]: Entering directory '/home/neil/projects/LibreELEC.tv/build.LibreELEC-RPi.arm-8.0-devel/LibreELEC-settings-ede7dc8'
mkdir -p build/service.libreelec.settings/resources/skins/Default/media/default
mkdir -p build/service.libreelec.settings/resources/skins/Default/media/icons
mkdir -p build/service.libreelec.settings/resources/language
cp textures/LibreELEC/*.{png,jpg} build/service.libreelec.settings/resources/skins/Default/media/default
cp icons/*.png build/service.libreelec.settings/resources/skins/Default/media/icons
cp -R language/* build/service.libreelec.settings/resources/language
cp: cannot stat 'textures/LibreELEC/*.{png,jpg}': No such file or directory
make[1]: *** [Makefile:74: build/service.libreelec.settings/resources/skins/Default/media/default] Error 1
make[1]: *** Waiting for unfinished jobs....
sed -e "s,@DISTRONAME@,LibreELEC,g" \
    -e "s,@ROOT_PASSWORD@,libreelec,g" \
    -i build/service.libreelec.settings/resources/language/*/*.po
make[1]: Leaving directory '/home/neil/projects/LibreELEC.tv/build.LibreELEC-RPi.arm-8.0-devel/LibreELEC-settings-ede7dc8'
Makefile:9: recipe for target 'release' failed
make: *** [release] Error 2
```

This fixes the build issue.