### PR TITLE
bluetooth: add missing 'Connect' option when device is Trusted

### DIFF
--- a/src/resources/lib/modules/bluetooth.py
+++ b/src/resources/lib/modules/bluetooth.py
@@ -567,6 +567,11 @@ class bluetooth:
                     'text': self.oe._(32144),
                     'action': 'init_device',
                     }
+            elif listItem.getProperty('Trusted') == '1':
+                values[2] = {
+                    'text': self.oe._(32144),
+                    'action': 'trust_connect_device',
+                    }
             values[5] = {
                 'text': self.oe._(32141),
                 'action': 'remove_device',


### PR DESCRIPTION
This PR restores the old *Trust and Connect* option that has been missing since #18 for devices that was trusted but not paired. The new option was renamed to *Connect* and is only shown when a device is trusted.
Thanks @MilhouseVH for pinpointing when the issue started!