### PR TITLE
settings: use https for update checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@
 ################################################################################
 
 ADDON_NAME=service.libreelec.settings
-ADDON_VERSION=0.8.9
+ADDON_VERSION=0.8.10
 DISTRONAME:=LibreELEC
 
 SHELL=/bin/bash

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+2017-03-10 v0.8.10
+  (update) use https for update checks
+
 2017-02-17 v0.8.9
   (fix) restore bluetooth 'connect and trust' option
 

--- a/src/defaults.py
+++ b/src/defaults.py
@@ -81,7 +81,7 @@ system = {
     'ENABLED': True,
     'KERNEL_CMD': '/proc/cmdline',
     'SET_CLOCK_CMD': '/sbin/hwclock --systohc --utc',
-    'UPDATE_REQUEST_URL': 'http://update.libreelec.tv/updates.php',
+    'UPDATE_REQUEST_URL': 'https://update.libreelec.tv/updates.php',
     'UPDATE_DOWNLOAD_URL': 'http://%s.libreelec.tv/%s',
     'LOCAL_UPDATE_DIR': '/storage/.update/',
     'GET_CPU_FLAG': "cat /proc/cpuinfo | grep -q 'flags.* lm ' && echo '1' || echo '0'",


### PR DESCRIPTION
This change moves the initial update check request to https to avoiding an initial http request that is 301 redirected and results in a second (https) request.