### PR TITLE
settings: use https for update checks

### DIFF
--- a/src/defaults.py
+++ b/src/defaults.py
@@ -81,7 +81,7 @@ system = {
     'ENABLED': True,
     'KERNEL_CMD': '/proc/cmdline',
     'SET_CLOCK_CMD': '/sbin/hwclock --systohc --utc',
-    'UPDATE_REQUEST_URL': 'http://update.libreelec.tv/updates.php',
+    'UPDATE_REQUEST_URL': 'https://update.libreelec.tv/updates.php',
     'UPDATE_DOWNLOAD_URL': 'http://%s.libreelec.tv/%s',
     'LOCAL_UPDATE_DIR': '/storage/.update/',
     'GET_CPU_FLAG': "cat /proc/cpuinfo | grep -q 'flags.* lm ' && echo '1' || echo '0'",


### PR DESCRIPTION
This change moves the initial update check request to https to avoiding an initial http request that is 301 redirected and results in a second (https) request.

NB: no bump to changelog/makefile in this PR as #58 removes the need for that in master.