### PR TITLE
change default from manual-update to auto-update

### DIFF
--- a/src/resources/lib/modules/system.py
+++ b/src/resources/lib/modules/system.py
@@ -139,10 +139,10 @@ class system:
                     'settings': {
                         'AutoUpdate': {
                             'name': 32014,
-                            'value': 'manual',
+                            'value': 'auto',
                             'action': 'set_auto_update',
                             'type': 'multivalue',
-                            'values': ['manual', 'auto'],
+                            'values': ['auto', 'manual'],
                             'InfoText': 714,
                             'order': 1,
                             },


### PR DESCRIPTION
LE should default enable auto-update so our userbase is herded towards the current release with the latest bug and security fixes. This will reduce our support effort and lower risk for users. In the past this was impossible because the high rate of change (and untested change) in OE release branches resulted in maintenance releases that frequently broke as much stuff as they fixed. LE is proving to be much more responsible and conservative about maintenance release content, and IMHO it's time to do this.

This also needs exposing in the first-run wizard so that nervous people can opt-out, but I need to learn some Python before I tackle that change :)

CLARIFICATION: This will allow us to push 9.0.1, 9.0.2 etc. or 9.0.2 to 9.2.0 and have the majority of users update track new releases. There is no intention to force auto-update when Kodi major version changes, i.e. 9.0.x to 10.0.x as this usually brings notable change to the user experience (default skin etc.) and creates issues with user-installed add-ons.