### PR TITLE
support for module overlays and add option to enable CrazyCat drivers / media_build 

### DIFF
--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -53,7 +53,7 @@ msgid "[B]Support:[/B][CR]Web: http://libreelec.tv[CR]Forum: http://forum.libree
 msgstr ""
 
 msgctxt "#700"
-msgid "Configure a hostname, keyboard type, perform a reset, update, or backups and restores"
+msgid "Configure a hostname, keyboard type, optional drivers, perform a reset, update, or backups and restores"
 msgstr ""
 
 msgctxt "#701"
@@ -806,4 +806,8 @@ msgstr ""
 
 msgctxt "#32392"
 msgid "Enable Lirc"
+msgstr ""
+
+msgctxt "#32393"
+msgid "Linux Kernel Drivers"
 msgstr ""

--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -240,6 +240,10 @@ msgctxt "#770"
 msgid "Select an available version"
 msgstr ""
 
+msgctxt "#771"
+msgid "Setting to ON enables the bleeding-edge CrazyCat DVB drivers. Use at your own risk! System has to be rebooted after changing this option"
+msgstr ""
+
 msgctxt "#32001"
 msgid "Services"
 msgstr ""
@@ -810,4 +814,8 @@ msgstr ""
 
 msgctxt "#32393"
 msgid "Linux Kernel Drivers"
+msgstr ""
+
+msgctxt "#32394"
+msgid "CrazyCat DVB drivers"
 msgstr ""

--- a/src/defaults.py
+++ b/src/defaults.py
@@ -102,7 +102,12 @@ system = {
     'RESTORE_DIR': '/storage/.restore/',
     'MODULE_OVERLAYS_DIR': MODULE_OVERLAYS_DIR,
     'MODULE_OVERLAYS': {
+        'media_build': {
+            'directory': 'media_build',
+            'level': 20,
+            },
         },
+    'MEDIA_BUILD_OVERLAY': 'media_build',
     }
 
 about = {'ENABLED': True}

--- a/src/defaults.py
+++ b/src/defaults.py
@@ -34,6 +34,7 @@ import os
 XBMC_USER_HOME = os.environ.get('XBMC_USER_HOME', '/storage/.kodi')
 CONFIG_CACHE = os.environ.get('CONFIG_CACHE', '/storage/.cache')
 USER_CONFIG = os.environ.get('USER_CONFIG', '/storage/.config')
+MODULE_OVERLAYS_DIR = os.environ.get('MODULE_OVERLAYS_DIR', '/usr/lib/module-overlays')
 
 ################################################################################
 # Connamn Module
@@ -99,6 +100,9 @@ system = {
         ],
     'BACKUP_DESTINATION': '/storage/backup/',
     'RESTORE_DIR': '/storage/.restore/',
+    'MODULE_OVERLAYS_DIR': MODULE_OVERLAYS_DIR,
+    'MODULE_OVERLAYS': {
+        },
     }
 
 about = {'ENABLED': True}

--- a/src/oe.py
+++ b/src/oe.py
@@ -251,6 +251,38 @@ def set_service(service, options, state):
     except Exception, e:
         dbg_log('oe::set_service', 'ERROR: (' + repr(e) + ')')
 
+def get_module_overlay_state(overlay, level=20):
+    try:
+        if os.path.exists('%s/module-overlays/%02d-%s.conf' % (CONFIG_CACHE, level, overlay)):
+            return '1'
+        else:
+            return '0'
+    except Exception, e:
+        dbg_log('oe::get_module_overlay_state', 'ERROR: (' + repr(e) + ')')
+
+def set_module_overlay(overlay, state, level=20):
+    try:
+        dbg_log('oe::set_module_overlay', 'enter_function', 0)
+        dbg_log('oe::set_module_overlay::overlay', repr(overlay), 0)
+        dbg_log('oe::set_module_overlay::state', repr(state), 0)
+        dbg_log('oe::set_module_overlay::level', repr(level), 0)
+
+        cfn = '%s/module-overlays/%02d-%s.conf' % (CONFIG_CACHE, level, overlay)
+
+        if state == 1:
+            # enable overlay if not already enabled
+            if get_module_overlay_state(overlay) != '1':
+                with open(cfn, 'w') as cf:
+                    cf.write('%s' % (overlay))
+        else:
+            # disable overlay if not already disabled
+            if get_module_overlay_state(overlay) != '0':
+                os.unlink(cfn)
+
+        dbg_log('oe::set_module_overlay', 'exit_function', 0)
+    except Exception, e:
+        dbg_log('oe::set_module_overlay', 'ERROR: (' + repr(e) + ')')
+
 
 def load_file(filename):
     try:

--- a/src/resources/lib/modules/system.py
+++ b/src/resources/lib/modules/system.py
@@ -59,6 +59,7 @@ class system:
     SET_CLOCK_CMD = None
     MODULE_OVERLAYS_DIR = None
     MODULE_OVERLAYS = None
+    MEDIA_BUILD_OVERLAY= None
     menu = {'1': {
         'name': 32002,
         'menuLoader': 'load_menu',
@@ -294,7 +295,14 @@ class system:
                     'order': 10,
                     'name': 32393,
                     'settings': {
-                        # add module overlays here...
+                        'media_build': {
+                            'order': 1,
+                            'name': 32394,
+                            'value': None,
+                            'action': 'set_media_build',
+                            'type': 'bool',
+                            'InfoText': 771,
+                            }
                         }
                     }
                 }
@@ -316,6 +324,7 @@ class system:
             self.set_keyboard_layout()
             self.set_hw_clock()
             self.set_auto_update()
+            self.set_media_build()
             del self.is_service
             self.oe.dbg_log('system::start_service', 'exit_function', 0)
         except Exception, e:
@@ -1082,6 +1091,23 @@ class system:
                 continue
             elif os.path.isdir(itempath):
                 self.get_folder_size(itempath)
+
+    def set_media_build(self, listItem=None):
+        try:
+            self.oe.dbg_log('system::set_media_build', 'enter_function', 0)
+            if not listItem == None:
+                self.set_transient_value(listItem)
+
+            state = 1
+            level = self.get_overlay_level(self.MEDIA_BUILD_OVERLAY)
+            if self.struct['module_overlays']['settings'][self.MEDIA_BUILD_OVERLAY]['value'] != '1':
+                state = 0
+
+            self.oe.set_module_overlay(self.MEDIA_BUILD_OVERLAY, state, level)
+
+            self.oe.dbg_log('system::set_media_build', 'exit_function', 0)
+        except Exception, e:
+            self.oe.dbg_log('system::set_media_build', 'ERROR: (' + repr(e) + ')')
 
     def do_wizard(self):
         try:


### PR DESCRIPTION
This is required for https://github.com/LibreELEC/LibreELEC.tv/pull/1835 so that users can enable the experimental CrazyCat DVB drivers.