### PR TITLE
bluetooth: avoid race during disable

### DIFF
--- a/src/oe.py
+++ b/src/oe.py
@@ -439,6 +439,11 @@ def copy_file(source, destination, silent=False):
         dbg_log('oe::copy_file(' + source + ', ' + destination + ')', 'ERROR: (' + repr(e) + ')')
 
 
+def is_busy():
+    global __busy__
+    return __busy__ > 0
+
+
 def set_busy(state):
     global __busy__, __oe__, input_request, is_service
     try:

--- a/src/resources/lib/modules/bluetooth.py
+++ b/src/resources/lib/modules/bluetooth.py
@@ -405,6 +405,8 @@ class bluetooth:
 
     def menu_connections(self, focusItem=None):
         try:
+            if self.oe.is_busy():
+                return 0
             if not hasattr(self.oe, 'winOeMain'):
                 return 0
             if not self.oe.winOeMain.visible:


### PR DESCRIPTION
Disabling Bluetooth will result in the following error:

```
23:54:04.581 T:1503253392   DEBUG: ## LibreELEC Addon ## services::init_bluetooth ## enter_function
23:54:04.581 T:1503253392   DEBUG: ## LibreELEC Addon ## oe::set_busy ## __busy__ = 1
23:54:04.581 T:1503253392   DEBUG: ## LibreELEC Addon ## services::set_value ## enter_function
23:54:04.581 T:1503253392   DEBUG: ## LibreELEC Addon ## services::set_value ## exit_function
23:54:04.581 T:1503253392   DEBUG: ## LibreELEC Addon ## oe::set_service ## enter_function
23:54:04.581 T:1503253392   DEBUG: ## LibreELEC Addon ## oe::set_service::service ## 'bluez'
23:54:04.581 T:1503253392   DEBUG: ## LibreELEC Addon ## oe::set_service::options ## {}
23:54:04.581 T:1503253392   DEBUG: ## LibreELEC Addon ## oe::set_service::state ## 0
23:54:04.581 T:1503253392   DEBUG: ## LibreELEC Addon ## oe::execute ## enter_function
23:54:04.582 T:1503253392   DEBUG: ## LibreELEC Addon ## oe::execute::command ## systemctl restart bluetooth.service
23:54:04.619 T:1942945904   DEBUG: Activating window ID: 10138
23:54:04.619 T:1942945904   DEBUG: ------ Window Init (DialogBusy.xml) ------
23:54:04.661 T:1520030608   DEBUG: ## LibreELEC Addon ## bluetooth::monitor::InterfacesRemoved ## enter_function
23:54:04.661 T:1520030608   DEBUG: ## LibreELEC Addon ## bluetooth::monitor::InterfacesRemoved::path ## dbus.ObjectPath('/org/bluez/hci0')
23:54:04.661 T:1520030608   DEBUG: ## LibreELEC Addon ## bluetooth::monitor::InterfacesRemoved::interfaces ## dbus.Array([dbus.String(u'org.bluez.Media1')], signature=dbus.Signature('s'))
23:54:04.661 T:1520030608   DEBUG: ## LibreELEC Addon ## bluetooth::menu_connections ## enter_function
23:54:04.667 T:1520030608   DEBUG: ## LibreELEC Addon ## bluetooth::adapter_info ## enter_function
23:54:04.668 T:1520030608   DEBUG: ## LibreELEC Addon ## bluetooth::adapter_info::adapter ## <Interface <ProxyObject wrapping <dbus._dbus.SystemBus (system) at 0x5d1ce5a0> :1.16 /org/bluez/hci0 at 0x5bdce0f0> implementing u'org.bluez.Adapter1' at 0x5bdce1b0>
23:54:04.669 T:1520030608   DEBUG: ## LibreELEC Addon ## bluetooth::adapter_info::name ## u'Powered'
23:54:04.676 T:1503253392   DEBUG: ## LibreELEC Addon ## oe::execute ## exit_function
23:54:04.676 T:1503253392   DEBUG: ## LibreELEC Addon ## oe::set_service ## exit_function
23:54:04.677 T:1503253392   DEBUG: ## LibreELEC Addon ## oe::set_busy ## __busy__ = 0
23:54:04.677 T:1503253392   DEBUG: ## LibreELEC Addon ## services::init_bluetooth ## exit_function
23:54:04.774 T:1503253392   DEBUG: ## LibreELEC Addon ## services::load_menu ## enter_function
23:54:04.776 T:1520030608   ERROR: ## LibreELEC Addon ## bluetooth::adapter_info ## ERROR: (DBusException('The name :1.16 was not provided by any .service files',))
23:54:04.779 T:1520030608   ERROR: Traceback (most recent call last):
                                              File "/usr/share/kodi/addons/service.libreelec.settings/resources/lib/modules/bluetooth.py", line 150, in adapter_info
                                                return adapter_interface.Get('org.bluez.Adapter1', name)
                                              File "/usr/lib/python2.7/site-packages/dbus/proxies.py", line 70, in __call__
                                              File "/usr/lib/python2.7/site-packages/dbus/proxies.py", line 145, in __call__
                                              File "/usr/lib/python2.7/site-packages/dbus/connection.py", line 651, in call_blocking
                                            DBusException: org.freedesktop.DBus.Error.ServiceUnknown: The name :1.16 was not provided by any .service files
23:54:04.779 T:1520030608   ERROR: ## LibreELEC Addon ## bluetooth::menu_connections ## ERROR: (TypeError("int() argument must be a string or a number, not 'NoneType'",))
23:54:04.780 T:1520030608   ERROR: Traceback (most recent call last):
                                              File "/usr/share/kodi/addons/service.libreelec.settings/resources/lib/modules/bluetooth.py", line 427, in menu_connections
                                                if int(self.adapter_info(self.dbusBluezAdapter, 'Powered')) != 1:
                                            TypeError: int() argument must be a string or a number, not 'NoneType'
23:54:04.780 T:1520030608   DEBUG: ## LibreELEC Addon ## bluetooth::monitor::InterfacesRemoved ## exit_function
23:54:04.780 T:1520030608   DEBUG: ## LibreELEC Addon ## bluetooth::monitor::InterfacesRemoved ## enter_function
23:54:04.780 T:1520030608   DEBUG: ## LibreELEC Addon ## bluetooth::monitor::InterfacesRemoved::path ## dbus.ObjectPath('/org/bluez')
23:54:04.781 T:1520030608   DEBUG: ## LibreELEC Addon ## bluetooth::monitor::InterfacesRemoved::interfaces ## dbus.Array([dbus.String(u'org.freedesktop.DBus.Introspectable'), dbus.String(u'org.bluez.AgentManager1'), dbus.String(u'org.bluez.ProfileManager1')], signature=dbus.Signature('s'))
23:54:04.781 T:1520030608   DEBUG: ## LibreELEC Addon ## bluetooth::menu_connections ## enter_function
23:54:04.781 T:1942945904   DEBUG: ------ Window Deinit (DialogBusy.xml) ------
```

This is due to a race condition as the bluetooth monitor thread reacts to the removal of the Bluetooth interface(s) and attempts to refresh the connections visible in the settings menu. Unfortunately, as Bluetooth is in the process of being disabled by `systemd`, the dbus interface disappears during the bluetooth monitor thread, resulting in the above error.

Since the addon is "busy" while the Bluetooth interface is being disabled, observing the busy status in the bluetooth monitoring thread and avoiding updating the menu listing (and thus not querying a potentially non-existent Bluetooth adapter) while busy, seems like the quickest fix.

