### PR TITLE
connman.py: More secure default password for tethering

### DIFF
--- a/src/resources/lib/modules/connman.py
+++ b/src/resources/lib/modules/connman.py
@@ -35,6 +35,8 @@ import xbmcgui
 import threading
 import oeWindows
 import ConfigParser
+import random
+import string
 
 
 ####################################################################
@@ -554,7 +556,7 @@ class connman:
                         'TetheringPassphrase': {
                             'order': 4,
                             'name': 32107,
-                            'value': 'libreelec',
+                            'value': ''.join(random.SystemRandom().choice(string.ascii_letters + string.digits) for _ in range(10)),
                             'action': 'set_technologie',
                             'type': 'text',
                             'dbus': 'String',


### PR DESCRIPTION
Enabling Wifi tethering always defaults to the password: libreelec. Since the SSID defaults to LibreELEC-AP it is a pretty simple password to guess. 
Now a 10 character long random (digits and letters only) string is generated by default. Not sure about the 10 characters is too long or too short.