### PR TITLE
add safe mode support

### DIFF
--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -101,7 +101,11 @@ msgid "Set to ON and an on-screen notification will be displayed when a new upda
 msgstr ""
 
 msgctxt "#718"
-msgid "Send config.txt, cmdline.txt, shutdown.sh, autostart.sh, and kodi.log to http://sprunge.us and display the short URL"
+msgid "Send boot config files from /flash, kodi.log, kernel log and Samba configs to http://sprunge.us, and display the short URL"
+msgstr ""
+
+msgctxt "#719"
+msgid "Send boot config files from /flash, kodi_crash.log, kernel log and Samba configs to http://sprunge.us, and display the short URL"
 msgstr ""
 
 msgctxt "#720"
@@ -773,7 +777,11 @@ msgid "Submit Log"
 msgstr ""
 
 msgctxt "#32377"
-msgid "Pastebin system logs and get short URL"
+msgid "Upload latest Kodi log and configs, and view the short URL"
+msgstr ""
+
+msgctxt "#32378"
+msgid "Upload latest Kodi crash log and configs, and view the short URL"
 msgstr ""
 
 msgctxt "#32379"
@@ -831,3 +839,12 @@ msgstr ""
 msgctxt "#32392"
 msgid "Enable Lirc"
 msgstr ""
+
+msgctxt "#32393"
+msgid "** SAFE MODE! ** SAFE MODE! ** SAFE MODE! **"
+msgstr ""
+
+msgctxt "#32394"
+msgid "@DISTRONAME@ has temporarily started in safe mode due to repeated Kodi crashes.[CR][CR]You may now investigate the cause of the crashes by enabling ssh or Samba.[CR][CR]Your original Kodi installation can be accessed via \"/storage/.kodi.FAILED\" and the Samba \"Kodi-Failed\" share.[CR][CR]Rebooting will return to your original Kodi installation.[CR][CR]Go to https://forum.libreelec.tv if you require further assistance. When posting to the forum include the link to your crash log which can be viewed by clicking the crash log option in Settings > LibreELEC > System > Submit Log."
+msgstr ""
+

--- a/src/oe.py
+++ b/src/oe.py
@@ -816,6 +816,8 @@ if os.path.exists('/etc/machine-id'):
 else:
     SYSTEMID = os.environ.get('SYSTEMID', '')
 
+BOOT_STATUS = load_file('/storage/.config/boot.status')
+
 ############################################################################################
 
 try:

--- a/src/resources/lib/oeWindows.py
+++ b/src/resources/lib/oeWindows.py
@@ -495,8 +495,12 @@ class wizard(xbmcgui.WindowXMLDialog):
             self.getControl(self.buttons[4]['id']).setVisible(False)
             self.getControl(self.radiobuttons[1]['id']).setVisible(False)
             self.getControl(self.radiobuttons[2]['id']).setVisible(False)
-            self.set_wizard_title(self.oe._(32301).encode('utf-8'))
-            self.set_wizard_text(self.oe._(32302).encode('utf-8'))
+            if self.oe.BOOT_STATUS == "SAFE":
+              self.set_wizard_title("[COLOR red][B]%s[/B][/COLOR]" % self.oe._(32393).encode('utf-8'))
+              self.set_wizard_text(self.oe._(32394).encode('utf-8'))
+            else:
+              self.set_wizard_title(self.oe._(32301).encode('utf-8'))
+              self.set_wizard_text(self.oe._(32302).encode('utf-8'))
             self.showButton(1, 32303)
             self.setFocusId(self.buttons[1]['id'])
         except Exception, e:


### PR DESCRIPTION
See: https://github.com/LibreELEC/LibreELEC.tv/pull/2228

If "safe mode" is activated (contents of `/storage/.config/boot.status` will be `SAFE` rather than `OK`) then the following landing page will be shown:
![s1](https://i.imgur.com/K1DhPkz.png)

In addition this PR adds the following enhancements:

1. Added a second "Submit log" option which uploads the latest `kodi_crash.log` rather than the regular `kodi.log`
2. When in "safe mode", the uploaded logs will be read from the `.kodi.FAILED` folder
3. I've updated the help text string associated with the existing "Submit log" item, as it was not accurate (will need translating)
4. I've added x86 boot file support to the uploaded logs (syslinux.cfg etc.)
5. The "Boot mode" (`EFI` or `BIOS`) will be recorded in the log (second line) for `x86_64` systems
6. The addon will no longer `cat` files that don't exist (meaning it doesn't include `RPi` config files in `x86_64` logs)
7. Improved cleanup - don't leave temporary files hanging around
8. Replaced `dmesg` with `journalctl -a` when uploading logs
9. Added Samba client/server and u-boot configs to upload log
10. The "failed" `.kodi.FAILED` folder is now auto-shared as "Kodi-Failed" while safe mode is active.

No need to translate #32393 and #32394 as this text will only ever be visible in a "clean" Kodi that will only be using the default English language.