### PR TITLE
Trigger update repositories at end of wizard

### DIFF
--- a/src/resources/lib/oeWindows.py
+++ b/src/resources/lib/oeWindows.py
@@ -635,6 +635,7 @@ class wizard(xbmcgui.WindowXMLDialog):
                             self.is_last_wizard = False
                             break
                 if self.is_last_wizard == True:
+                    xbmc.executebuiltin('UpdateAddonRepos')
                     self.oe.write_setting('libreelec', 'wizard_completed', 'True')
                     self.close()
             self.oe.dbg_log('wizard::onClick(' + unicode(controlID) + ')', 'exit_function', 0)


### PR DESCRIPTION
When fresh installing LibreELEC Kodi tries to update repositories at first start but may fail because  network is not yet configured (i.e. WLAN). Afterwards it is not possible to install any addon without manually selecting "Check for updates".

Work around the issue by triggering repository updates at end of setup wizard.

There have been several reports in the forum, latest [here](https://forum.libreelec.tv/thread/10851-nothing-works-to-install/).