### PR TITLE
remove lirc enable/disable setting

### DIFF
--- a/language/Bulgarian/strings.po
+++ b/language/Bulgarian/strings.po
@@ -213,10 +213,6 @@ msgctxt "#745"
 msgid "Set to ON to enable the cron daemon"
 msgstr "Включете за да активирате Cron демона"
 
-msgctxt "#746"
-msgid "Set to ON to enable the lirc daemon"
-msgstr "Включете за да активирате lirc демона"
-
 msgctxt "#750"
 msgid "750"
 msgstr "750"
@@ -818,11 +814,3 @@ msgstr "Изключи режима за готовност"
 msgctxt "#32390"
 msgid "Settings addon is not yet ready, please try again later."
 msgstr "Добавката за настройките не е в готовност. Моля, опитайте по-късно."
-
-msgctxt "#32391"
-msgid "Lirc"
-msgstr "Lirc"
-
-msgctxt "#32392"
-msgid "Enable Lirc"
-msgstr "Включи Lirc"

--- a/language/Czech/strings.po
+++ b/language/Czech/strings.po
@@ -214,10 +214,6 @@ msgctxt "#745"
 msgid "Set to ON to enable the cron daemon"
 msgstr "Nastavit do polohy povolit pro zapnutí cron daemonu"
 
-msgctxt "#746"
-msgid "Set to ON to enable the lirc daemon"
-msgstr "Nastavit do polohy povolit pro zapnutí lirc daemonu"
-
 msgctxt "#750"
 msgid "750"
 msgstr "750"
@@ -817,11 +813,3 @@ msgstr "zakázat pohotovostní režim"
 msgctxt "#32390"
 msgid "Settings addon is not yet ready, please try again later."
 msgstr "Nastavení doplňku není připraveno, prosím zkuste později."
-
-msgctxt "#32391"
-msgid "Lirc"
-msgstr "LIRC"
-
-msgctxt "#32392"
-msgid "Enable Lirc"
-msgstr "Povolit LIRC"

--- a/language/Dutch/strings.po
+++ b/language/Dutch/strings.po
@@ -214,10 +214,6 @@ msgctxt "#745"
 msgid "Set to ON to enable the cron daemon"
 msgstr "Zet AAN om de Cron-daemon in te schakelen"
 
-msgctxt "#746"
-msgid "Set to ON to enable the lirc daemon"
-msgstr "Zet AAN om lirc daemon in te schakelen"
-
 msgctxt "#750"
 msgid "750"
 msgstr "750"
@@ -817,11 +813,3 @@ msgstr "Standby uitschakelen"
 msgctxt "#32390"
 msgid "Settings addon is not yet ready, please try again later."
 msgstr "De Instellingen-Addon is nog niet gereed, probeert u het later nog eens."
-
-msgctxt "#32391"
-msgid "Lirc"
-msgstr "Lirc"
-
-msgctxt "#32392"
-msgid "Enable Lirc"
-msgstr "Lirc inschakelen"

--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -200,10 +200,6 @@ msgctxt "#745"
 msgid "Set to ON to enable the cron daemon"
 msgstr ""
 
-msgctxt "#746"
-msgid "Set to ON to enable the lirc daemon"
-msgstr ""
-
 msgctxt "#750"
 msgid "750"
 msgstr ""
@@ -838,14 +834,6 @@ msgstr ""
 
 msgctxt "#32390"
 msgid "Settings addon is not yet ready, please try again later."
-msgstr ""
-
-msgctxt "#32391"
-msgid "Lirc"
-msgstr ""
-
-msgctxt "#32392"
-msgid "Enable Lirc"
 msgstr ""
 
 msgctxt "#32393"

--- a/language/French/strings.po
+++ b/language/French/strings.po
@@ -213,10 +213,6 @@ msgctxt "#745"
 msgid "Set to ON to enable the cron daemon"
 msgstr "Activer cette option pour utiliser le démon cron"
 
-msgctxt "#746"
-msgid "Set to ON to enable the lirc daemon"
-msgstr "Activer cette option pour utiliser le démon lirc"
-
 msgctxt "#750"
 msgid "750"
 msgstr "750"
@@ -816,11 +812,3 @@ msgstr "Désactiver la mise en veille"
 msgctxt "#32390"
 msgid "Settings addon is not yet ready, please try again later."
 msgstr "Le greffon des paramètres n'est pas encore prêt, veuillez ré-essayer plus tard."
-
-msgctxt "#32391"
-msgid "Lirc"
-msgstr "Lirc"
-
-msgctxt "#32392"
-msgid "Enable Lirc"
-msgstr "Activer Lirc"

--- a/language/German/strings.po
+++ b/language/German/strings.po
@@ -213,10 +213,6 @@ msgctxt "#745"
 msgid "Set to ON to enable the cron daemon"
 msgstr "Auf EIN stellen, um den Cron-Daemon zu aktivieren."
 
-msgctxt "#746"
-msgid "Set to ON to enable the lirc daemon"
-msgstr "Auf EIN stellen, um den Lirc-Daemon zu aktivieren"
-
 msgctxt "#750"
 msgid "750"
 msgstr "750"
@@ -816,11 +812,3 @@ msgstr "Deaktivere Standby"
 msgctxt "#32390"
 msgid "Settings addon is not yet ready, please try again later."
 msgstr "Das Einstellungs-Addon ist nicht bereit. Versuch es später erneut."
-
-msgctxt "#32391"
-msgid "Lirc"
-msgstr "Lirc"
-
-msgctxt "#32392"
-msgid "Enable Lirc"
-msgstr "Lirc aktivieren"

--- a/language/Italian/strings.po
+++ b/language/Italian/strings.po
@@ -213,10 +213,6 @@ msgctxt "#745"
 msgid "Set to ON to enable the cron daemon"
 msgstr "Impostare su ON per attivare il demone cron"
 
-msgctxt "#746"
-msgid "Set to ON to enable the lirc daemon"
-msgstr "Impostare su ON per attivare il servizio lirc"
-
 msgctxt "#750"
 msgid "750"
 msgstr "750"
@@ -816,11 +812,3 @@ msgstr "Disabilita standby"
 msgctxt "#32390"
 msgid "Settings addon is not yet ready, please try again later."
 msgstr "L'addon delle impostazioni non è ancora pronto. Provare più tardi."
-
-msgctxt "#32391"
-msgid "Lirc"
-msgstr "Lirc"
-
-msgctxt "#32392"
-msgid "Enable Lirc"
-msgstr "Abilita Lirc"

--- a/language/Lithuanian/strings.po
+++ b/language/Lithuanian/strings.po
@@ -212,10 +212,6 @@ msgctxt "#745"
 msgid "Set to ON to enable the cron daemon"
 msgstr "Nustatykite ĮJUNGTA norėdami įjungti Cron tarnybą"
 
-msgctxt "#746"
-msgid "Set to ON to enable the lirc daemon"
-msgstr "Nustatykite ĮJUNGTA norėdami įjungti lirc tarnybą"
-
 msgctxt "#750"
 msgid "750"
 msgstr "750"
@@ -815,11 +811,3 @@ msgstr "Išjungti sistemos pristabdymą"
 msgctxt "#32390"
 msgid "Settings addon is not yet ready, please try again later."
 msgstr "Nustatymų priedas dar neparuoštas, pamėginkite vėliau."
-
-msgctxt "#32391"
-msgid "Lirc"
-msgstr "Lirc"
-
-msgctxt "#32392"
-msgid "Enable Lirc"
-msgstr "Įjungti Lirc"

--- a/language/Norwegian/strings.po
+++ b/language/Norwegian/strings.po
@@ -213,10 +213,6 @@ msgctxt "#745"
 msgid "Set to ON to enable the cron daemon"
 msgstr "Sett til PÅ for å aktivere cron daemon"
 
-msgctxt "#746"
-msgid "Set to ON to enable the lirc daemon"
-msgstr "Sett til PÅ for å aktivere lirc daemon"
-
 msgctxt "#750"
 msgid "750"
 msgstr "750"
@@ -818,11 +814,3 @@ msgstr "Deaktiver Standby"
 msgctxt "#32390"
 msgid "Settings addon is not yet ready, please try again later."
 msgstr "Innstillinger tillegget er ikke klart ennå, vennligst prøv igjen senere."
-
-msgctxt "#32391"
-msgid "Lirc"
-msgstr "Lirc"
-
-msgctxt "#32392"
-msgid "Enable Lirc"
-msgstr "Aktiver Lirc"

--- a/language/Portuguese (Brazil)/strings.po
+++ b/language/Portuguese (Brazil)/strings.po
@@ -213,10 +213,6 @@ msgctxt "#745"
 msgid "Set to ON to enable the cron daemon"
 msgstr "Defina como ON para ativar o daemon cron"
 
-msgctxt "#746"
-msgid "Set to ON to enable the lirc daemon"
-msgstr "Defina como ON para ativar o daemon lirc"
-
 msgctxt "#750"
 msgid "750"
 msgstr "750"
@@ -816,11 +812,3 @@ msgstr "Desabilitar Modo de Espera"
 msgctxt "#32390"
 msgid "Settings addon is not yet ready, please try again later."
 msgstr "O addon de configurações ainda não está pronto. Tente novamente mais tarde."
-
-msgctxt "#32391"
-msgid "Lirc"
-msgstr "Lirc"
-
-msgctxt "#32392"
-msgid "Enable Lirc"
-msgstr "Habilitar Lirc"

--- a/language/Russian/strings.po
+++ b/language/Russian/strings.po
@@ -212,10 +212,6 @@ msgctxt "#745"
 msgid "Set to ON to enable the cron daemon"
 msgstr "Включение службы CRON для запуска задач по расписанию"
 
-msgctxt "#746"
-msgid "Set to ON to enable the lirc daemon"
-msgstr "Включение службы lirc "
-
 msgctxt "#750"
 msgid "750"
 msgstr "750"
@@ -815,11 +811,3 @@ msgstr "Отключить режим ожидания"
 msgctxt "#32390"
 msgid "Settings addon is not yet ready, please try again later."
 msgstr "Настройки дополнения ещё не готовы. Повторите попытку позже."
-
-msgctxt "#32391"
-msgid "Lirc"
-msgstr "Lirc"
-
-msgctxt "#32392"
-msgid "Enable Lirc"
-msgstr "Включить Lirc"

--- a/language/Swedish/strings.po
+++ b/language/Swedish/strings.po
@@ -212,10 +212,6 @@ msgctxt "#745"
 msgid "Set to ON to enable the cron daemon"
 msgstr "Välj PÅ för att aktivera Cron-tjänsten"
 
-msgctxt "#746"
-msgid "Set to ON to enable the lirc daemon"
-msgstr "När inställningen är PÅ aktiveras lirc-tjänsten"
-
 msgctxt "#750"
 msgid "750"
 msgstr "750"
@@ -816,11 +812,3 @@ msgstr "Inaktivera Standby"
 msgctxt "#32390"
 msgid "Settings addon is not yet ready, please try again later."
 msgstr "Inställnings-tillägget är inte redo, försök igen senare."
-
-msgctxt "#32391"
-msgid "Lirc"
-msgstr "Lirc"
-
-msgctxt "#32392"
-msgid "Enable Lirc"
-msgstr "Aktivera Lirc"

--- a/src/defaults.py
+++ b/src/defaults.py
@@ -77,8 +77,6 @@ services = {
     'D_SSH_DISABLE_PW_AUTH': '0',
     'AVAHI_DAEMON': '/usr/sbin/avahi-daemon',
     'CRON_DAEMON': '/sbin/crond',
-    'LIRCD_DAEMON': '/usr/sbin/lircd',
-    'LIRCD_UINPUT_DAEMON': '/usr/sbin/lircd-uinput',
     }
 
 system = {
@@ -115,6 +113,5 @@ _services = {
     'bluez': ['bluetooth.service'],
     'obexd': ['obex.service'],
     'crond': ['cron.service'],
-    'lircd': ['lircd.service', 'lircd-uinput.service'],
     'iptables': ['iptables.service'],
     }

--- a/src/resources/lib/modules/services.py
+++ b/src/resources/lib/modules/services.py
@@ -47,8 +47,6 @@ class services:
     OPT_SSH_NOPASSWD = None
     AVAHI_DAEMON = None
     CRON_DAEMON = None
-    LIRCD_DAEMON = None
-    LIRCD_UINPUT_DAEMON = None
     menu = {'4': {
         'name': 32001,
         'menuLoader': 'load_menu',
@@ -261,21 +259,6 @@ class services:
                             },
                         },
                     },
-                'lircd': {
-                    'order': 7,
-                    'name': 32391,
-                    'not_supported': [],
-                    'settings': {
-                        'lircd_autostart': {
-                            'order': 1,
-                            'name': 32392,
-                            'value': None,
-                            'action': 'initialize_lircd',
-                            'type': 'bool',
-                            'InfoText': 746,
-                            },
-                        },
-                    },
                 }
 
             self.oe = oeMain
@@ -292,7 +275,6 @@ class services:
             self.initialize_avahi(service=1)
             self.initialize_cron(service=1)
             self.init_bluetooth(service=1)
-            self.initialize_lircd(service=1)
             self.oe.dbg_log('services::start_service', 'exit_function', 0)
         except Exception, e:
             self.oe.dbg_log('services::start_service', 'ERROR: (%s)' % repr(e))
@@ -399,13 +381,6 @@ class services:
                         self.struct['bluez']['settings']['obex_root']['hidden'] = True
                 else:
                     self.struct['bluez']['hidden'] = 'true'
-
-            # LIRCD
-
-            if os.path.isfile(self.LIRCD_DAEMON) and os.path.isfile(self.LIRCD_UINPUT_DAEMON):
-                self.struct['lircd']['settings']['lircd_autostart']['value'] = self.oe.get_service_state('lircd')
-            else:
-                self.struct['lircd']['hidden'] = 'true'
 
             self.oe.dbg_log('services::load_values', 'exit_function', 0)
         except Exception, e:
@@ -551,23 +526,6 @@ class services:
         except Exception, e:
             self.oe.set_busy(0)
             self.oe.dbg_log('services::init_obex', 'ERROR: (' + repr(e) + ')', 4)
-
-    def initialize_lircd(self, **kwargs):
-        try:
-            self.oe.dbg_log('services::inititialize_lircd', 'enter_function', 0)
-            self.oe.set_busy(1)
-            if 'listItem' in kwargs:
-                self.set_value(kwargs['listItem'])
-            state = 1
-            options = {}
-            if self.struct['lircd']['settings']['lircd_autostart']['value'] != '1':
-                state = 0
-            self.oe.set_service('lircd', options, state)
-            self.oe.set_busy(0)
-            self.oe.dbg_log('services::inititialize_lircd', 'exit_function', 0)
-        except Exception, e:
-            self.oe.set_busy(0)
-            self.oe.dbg_log('services::inititialize_lircd', 'ERROR: (' + repr(e) + ')', 4)
 
     def exit(self):
         try:


### PR DESCRIPTION
This is no longer needed when https://github.com/LibreELEC/LibreELEC.tv/pull/2341 gets merged - lirc start is then only controlled by presence of a user lircd.conf file
