### PR TITLE
backup folder size fix

### DIFF
--- a/src/resources/lib/modules/system.py
+++ b/src/resources/lib/modules/system.py
@@ -894,7 +894,7 @@ class system:
                 # free space check
                 try:
                     folder_stat = os.statvfs(bckDir)
-                    free_space = folder_stat.f_bsize * folder_stat.f_bavail
+                    free_space = folder_stat.f_frsize * folder_stat.f_bavail
                     if self.total_backup_size > free_space:
                         txt = self.oe.split_dialog_text(self.oe._(32379).encode('utf-8'))
                         xbmcDialog = xbmcgui.Dialog()
@@ -942,7 +942,7 @@ class system:
                 os.makedirs(self.RESTORE_DIR)
             folder_stat = os.statvfs(self.RESTORE_DIR)
             file_size = os.path.getsize(restore_file_path)
-            free_space = folder_stat.f_bsize * folder_stat.f_bavail
+            free_space = folder_stat.f_frsize * folder_stat.f_bavail
             if free_space > file_size * 2:
                 if os.path.exists(self.RESTORE_DIR + restore_file_name):
                     os.remove(self.RESTORE_DIR + restore_file_name)
@@ -1084,7 +1084,9 @@ class system:
     def get_folder_size(self, folder):
         for item in os.listdir(folder):
             itempath = os.path.join(folder, item)
-            if os.path.isfile(itempath):
+            if os.path.islink(itempath):
+                continue
+            elif os.path.isfile(itempath):
                 self.total_backup_size += os.path.getsize(itempath)
             elif os.path.ismount(itempath):
                 continue


### PR DESCRIPTION
current get_folder_size() function has some issues:
- It does follow symbolic links what leads to few issues: 1) it goes outside of BACKUP_DIRS 2) it counts filesize more then one time for the same file and ignores actual size of a symlink
- It does not count directory size, like directory itself (usually it's 4096 bytes)
- It does not know anything about hardlinks, so single inode can be summarized multiple times 

do_backup function should use f_frsize rather than f_bsize to calculate the right size in bytes:
statvfs.F_BSIZE - Preferred file system block size
statvfs.F_FRSIZE - Fundamental file system block size