### PR TITLE
sprunge.us: replace by ix.io

### DIFF
--- a/language/Bulgarian/strings.po
+++ b/language/Bulgarian/strings.po
@@ -110,8 +110,8 @@ msgid "Set to ON and an on-screen notification will be displayed when a new upda
 msgstr "Включите ли опцията, ще бъдете известявани при наличие на нова актуализация"
 
 msgctxt "#718"
-msgid "Send config.txt, cmdline.txt, shutdown.sh, autostart.sh, and kodi.log to http://sprunge.us and display the short URL"
-msgstr "Изпрати config.txt, cmdline.txt, shutdown.sh, autostart.sh, и kodi.log на http://sprunge.us и покажи съкратен линк"
+msgid "Send config.txt, cmdline.txt, shutdown.sh, autostart.sh, and kodi.log to http://ix.io and display the short URL"
+msgstr "Изпрати config.txt, cmdline.txt, shutdown.sh, autostart.sh, и kodi.log на http://ix.io и покажи съкратен линк"
 
 msgctxt "#720"
 msgid "Set to ON and Bluetooth devices will be disabled during power-saving modes"

--- a/language/Czech/strings.po
+++ b/language/Czech/strings.po
@@ -111,8 +111,8 @@ msgid "Set to ON and an on-screen notification will be displayed when a new upda
 msgstr "Nastavte do polohy povolit, aby se  na obrazovce zobrazila informace o nové aktualizaci"
 
 msgctxt "#718"
-msgid "Send config.txt, cmdline.txt, shutdown.sh, autostart.sh, and kodi.log to http://sprunge.us and display the short URL"
-msgstr "Poslat config.txt, cmdline.txt, shutdown.sh, autostart.sh a kodi.log k http://sprunge.us a zobrazí krátký URL"
+msgid "Send config.txt, cmdline.txt, shutdown.sh, autostart.sh, and kodi.log to http://ix.io and display the short URL"
+msgstr "Poslat config.txt, cmdline.txt, shutdown.sh, autostart.sh a kodi.log k http://ix.io a zobrazí krátký URL"
 
 msgctxt "#720"
 msgid "Set to ON and Bluetooth devices will be disabled during power-saving modes"

--- a/language/Dutch/strings.po
+++ b/language/Dutch/strings.po
@@ -111,8 +111,8 @@ msgid "Set to ON and an on-screen notification will be displayed when a new upda
 msgstr "Schakel in om notificaties op het scherm te krijgen wanneer er een nieuwe update beschikbaar is"
 
 msgctxt "#718"
-msgid "Send config.txt, cmdline.txt, shutdown.sh, autostart.sh, and kodi.log to http://sprunge.us and display the short URL"
-msgstr "Stuur config.txt, cmdline.txt, shutdown.sh, autostart.sh, en kodi.log naar http://sprunge.us en laat de verkorte URL zien"
+msgid "Send config.txt, cmdline.txt, shutdown.sh, autostart.sh, and kodi.log to http://ix.io and display the short URL"
+msgstr "Stuur config.txt, cmdline.txt, shutdown.sh, autostart.sh, en kodi.log naar http://ix.io en laat de verkorte URL zien"
 
 msgctxt "#720"
 msgid "Set to ON and Bluetooth devices will be disabled during power-saving modes"

--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -101,11 +101,11 @@ msgid "Set to ON and an on-screen notification will be displayed when a new upda
 msgstr ""
 
 msgctxt "#718"
-msgid "Send boot config files from /flash, kodi.log, kernel log and Samba configs to http://sprunge.us, and display the short URL"
+msgid "Send boot config files from /flash, kodi.log, kernel log and Samba configs to http://ix.io, and display the short URL"
 msgstr ""
 
 msgctxt "#719"
-msgid "Send boot config files from /flash, kodi_crash.log, kernel log and Samba configs to http://sprunge.us, and display the short URL"
+msgid "Send boot config files from /flash, kodi_crash.log, kernel log and Samba configs to http://ix.io, and display the short URL"
 msgstr ""
 
 msgctxt "#720"

--- a/language/French/strings.po
+++ b/language/French/strings.po
@@ -110,8 +110,8 @@ msgid "Set to ON and an on-screen notification will be displayed when a new upda
 msgstr "Activer cette option affichera une notification à l'écran lorsqu'une mise à jour sera disponible"
 
 msgctxt "#718"
-msgid "Send config.txt, cmdline.txt, shutdown.sh, autostart.sh, and kodi.log to http://sprunge.us and display the short URL"
-msgstr "Envoie config.txt, cmdline.txt, shutdown.sh, autostart.sh, et kodi.log à http://sprunge.us et affiche l'URL raccourcie"
+msgid "Send config.txt, cmdline.txt, shutdown.sh, autostart.sh, and kodi.log to http://ix.io and display the short URL"
+msgstr "Envoie config.txt, cmdline.txt, shutdown.sh, autostart.sh, et kodi.log à http://ix.io et affiche l'URL raccourcie"
 
 msgctxt "#720"
 msgid "Set to ON and Bluetooth devices will be disabled during power-saving modes"

--- a/language/German/strings.po
+++ b/language/German/strings.po
@@ -110,8 +110,8 @@ msgid "Set to ON and an on-screen notification will be displayed when a new upda
 msgstr "Auf EIN stellen und eine Bildschirm-Benachrichtigung wird angezeigt, sobald eine neue Aktualisierung verfügbar ist."
 
 msgctxt "#718"
-msgid "Send config.txt, cmdline.txt, shutdown.sh, autostart.sh, and kodi.log to http://sprunge.us and display the short URL"
-msgstr "config.txt, cmdline.txt, shutdown.sh, autostart.sh und kodi.log an http://sprunge.us übermitteln und die Kurz-URL anzeigen"
+msgid "Send config.txt, cmdline.txt, shutdown.sh, autostart.sh, and kodi.log to http://ix.io and display the short URL"
+msgstr "config.txt, cmdline.txt, shutdown.sh, autostart.sh und kodi.log an http://ix.io übermitteln und die Kurz-URL anzeigen"
 
 msgctxt "#720"
 msgid "Set to ON and Bluetooth devices will be disabled during power-saving modes"

--- a/language/Italian/strings.po
+++ b/language/Italian/strings.po
@@ -110,8 +110,8 @@ msgid "Set to ON and an on-screen notification will be displayed when a new upda
 msgstr "Impostare su ON per avere una notifica nel caso sia disponibile un aggiornamento"
 
 msgctxt "#718"
-msgid "Send config.txt, cmdline.txt, shutdown.sh, autostart.sh, and kodi.log to http://sprunge.us and display the short URL"
-msgstr "Invia i file config.txt, cmdline.txt, shutdown.sh, autostart.sh, e kodi.log a http://sprunge.us e mostra l'URL abbreviato"
+msgid "Send config.txt, cmdline.txt, shutdown.sh, autostart.sh, and kodi.log to http://ix.io and display the short URL"
+msgstr "Invia i file config.txt, cmdline.txt, shutdown.sh, autostart.sh, e kodi.log a http://ix.io e mostra l'URL abbreviato"
 
 msgctxt "#720"
 msgid "Set to ON and Bluetooth devices will be disabled during power-saving modes"

--- a/language/Lithuanian/strings.po
+++ b/language/Lithuanian/strings.po
@@ -109,8 +109,8 @@ msgid "Set to ON and an on-screen notification will be displayed when a new upda
 msgstr "Nustatykite ĮJUNGTA ir ekrane bus rodomas pranešimas, jei prieinama nauja versija"
 
 msgctxt "#718"
-msgid "Send config.txt, cmdline.txt, shutdown.sh, autostart.sh, and kodi.log to http://sprunge.us and display the short URL"
-msgstr "Nusiųskite config.txt, cmdline.txt, shutdown.sh, autostart.sh ir kodi.log į http://sprunge.us ir pateikite trumpą URL adresą"
+msgid "Send config.txt, cmdline.txt, shutdown.sh, autostart.sh, and kodi.log to http://ix.io and display the short URL"
+msgstr "Nusiųskite config.txt, cmdline.txt, shutdown.sh, autostart.sh ir kodi.log į http://ix.io ir pateikite trumpą URL adresą"
 
 msgctxt "#720"
 msgid "Set to ON and Bluetooth devices will be disabled during power-saving modes"

--- a/language/Norwegian/strings.po
+++ b/language/Norwegian/strings.po
@@ -110,8 +110,8 @@ msgid "Set to ON and an on-screen notification will be displayed when a new upda
 msgstr "Sett til PÅ og en melding vil vise på skjermen når en oppdatering er tilgjengelig."
 
 msgctxt "#718"
-msgid "Send config.txt, cmdline.txt, shutdown.sh, autostart.sh, and kodi.log to http://sprunge.us and display the short URL"
-msgstr "Send config.txt, cmdline.txt, shutdown.sh, autostart.sh, og kodi.log til http://sprunge.us og vis den korte URLen"
+msgid "Send config.txt, cmdline.txt, shutdown.sh, autostart.sh, and kodi.log to http://ix.io and display the short URL"
+msgstr "Send config.txt, cmdline.txt, shutdown.sh, autostart.sh, og kodi.log til http://ix.io og vis den korte URLen"
 
 msgctxt "#720"
 msgid "Set to ON and Bluetooth devices will be disabled during power-saving modes"

--- a/language/Portuguese (Brazil)/strings.po
+++ b/language/Portuguese (Brazil)/strings.po
@@ -110,8 +110,8 @@ msgid "Set to ON and an on-screen notification will be displayed when a new upda
 msgstr "Defina como ON e uma notificação na tela será exibida quando uma nova atualização estiver disponível"
 
 msgctxt "#718"
-msgid "Send config.txt, cmdline.txt, shutdown.sh, autostart.sh, and kodi.log to http://sprunge.us and display the short URL"
-msgstr "Enviar config.txt, cmdline.txt, shutdown.sh, autostart.sh, e kodi.log para http://sprunge.us e exiba a URL encurtada"
+msgid "Send config.txt, cmdline.txt, shutdown.sh, autostart.sh, and kodi.log to http://ix.io and display the short URL"
+msgstr "Enviar config.txt, cmdline.txt, shutdown.sh, autostart.sh, e kodi.log para http://ix.io e exiba a URL encurtada"
 
 msgctxt "#720"
 msgid "Set to ON and Bluetooth devices will be disabled during power-saving modes"

--- a/language/Russian/strings.po
+++ b/language/Russian/strings.po
@@ -109,8 +109,8 @@ msgid "Set to ON and an on-screen notification will be displayed when a new upda
 msgstr "Включите, если хотите, чтобы на экране появлялись уведомления о доступности нового ПО для обновления"
 
 msgctxt "#718"
-msgid "Send config.txt, cmdline.txt, shutdown.sh, autostart.sh, and kodi.log to http://sprunge.us and display the short URL"
-msgstr "Отправить config.txt, cmdline.txt, shutdown.sh, autostart.sh, and kodi.log на сайт http://sprunge.us и показать короткую URL ссылку"
+msgid "Send config.txt, cmdline.txt, shutdown.sh, autostart.sh, and kodi.log to http://ix.io and display the short URL"
+msgstr "Отправить config.txt, cmdline.txt, shutdown.sh, autostart.sh, and kodi.log на сайт http://ix.io и показать короткую URL ссылку"
 
 msgctxt "#720"
 msgid "Set to ON and Bluetooth devices will be disabled during power-saving modes"

--- a/language/Swedish/strings.po
+++ b/language/Swedish/strings.po
@@ -109,8 +109,8 @@ msgid "Set to ON and an on-screen notification will be displayed when a new upda
 msgstr "När inställningen är PÅ kommer en notis visas när en ny uppdatering finns tillgänglig"
 
 msgctxt "#718"
-msgid "Send config.txt, cmdline.txt, shutdown.sh, autostart.sh, and kodi.log to http://sprunge.us and display the short URL"
-msgstr "Skicka config.txt, cmdline.txt, shutdown.sh, autostart.sh, och kodi.log till http://sprunge.us och visa den korta URL:en"
+msgid "Send config.txt, cmdline.txt, shutdown.sh, autostart.sh, and kodi.log to http://ix.io and display the short URL"
+msgstr "Skicka config.txt, cmdline.txt, shutdown.sh, autostart.sh, och kodi.log till http://ix.io och visa den korta URL:en"
 
 msgctxt "#720"
 msgid "Set to ON and Bluetooth devices will be disabled during power-saving modes"


### PR DESCRIPTION
I've manually edited the non-English language files - these will need to be pushed to Transifex.