### PR TITLE
Favour non-X keyboard layouts over X

### DIFF
--- a/src/resources/lib/modules/system.py
+++ b/src/resources/lib/modules/system.py
@@ -560,7 +560,13 @@ class system:
             arrLayouts = []
             arrVariants = {}
             arrTypes = []
-            if os.path.exists(self.KEYBOARD_INFO):
+            if os.path.exists(self.NOX_KEYBOARD_INFO):
+                for layout in glob.glob(self.NOX_KEYBOARD_INFO + '/*/*.bmap'):
+                    if os.path.isfile(layout):
+                        arrLayouts.append(layout.split('/')[-1].split('.')[0])
+                arrLayouts.sort()
+                arrTypes = None
+            elif os.path.exists(self.KEYBOARD_INFO):
                 objXmlFile = open(self.KEYBOARD_INFO, 'r')
                 strXmlText = objXmlFile.read()
                 objXmlFile.close()
@@ -603,12 +609,6 @@ class system:
                                         arrTypes.append(subnode_2.firstChild.nodeValue + ':' + value)
                 arrLayouts.sort()
                 arrTypes.sort()
-            elif os.path.exists(self.NOX_KEYBOARD_INFO):
-                for layout in glob.glob(self.NOX_KEYBOARD_INFO + '/*/*.bmap'):
-                    if os.path.isfile(layout):
-                        arrLayouts.append(layout.split('/')[-1].split('.')[0])
-                arrLayouts.sort()
-                arrTypes = None
             else:
                 self.oe.dbg_log('system::get_keyboard_layouts', 'exit_function (no keyboard layouts found)', 0)
                 return (None, None, None)


### PR DESCRIPTION
With the switch to libinput/libxkbcommon both X and non-X keyboard layouts
are now available but only the non-X layouts should be loaded when both are
present in the system (eg. RPi/RPi2).

Non-X layouts are not available in X-based systems (ie. Generic) while X-layouts are available.

This is dependent on https://github.com/LibreELEC/LibreELEC.tv/pull/2654 which introduces libinput and libxkbcommon. If we merge this before https://github.com/LibreELEC/LibreELEC.tv/pull/2654 then I'll add the bump in the PR. Leave this for a few days so I can test it in nightly builds.