### PR TITLE
remove all attempts to open/close the busydialog which is now verboten

### DIFF
--- a/src/oe.py
+++ b/src/oe.py
@@ -332,11 +332,7 @@ def extract_file(filename, extract, destination, silent=False):
                 extract_dlg.create('LibreELEC ', _(32186).encode('utf-8'), ' ', ' ')
                 extract_dlg.update(0)
             compressed = tarfile.open(filename)
-            if silent == False:
-                xbmc.executebuiltin('ActivateWindow(busydialog)')
             names = compressed.getnames()
-            if silent == False:
-                xbmc.executebuiltin('Dialog.Close(busydialog)')
             for name in names:
                 for search in extract:
                     if search in name:
@@ -453,11 +449,6 @@ def set_busy(state):
             else:
                 __busy__ = __busy__ - 1
             dbg_log('oe::set_busy', '__busy__ = ' + unicode(__busy__), 0)
-            if __busy__ > 0:
-                if not input_request:
-                    xbmc.executebuiltin('ActivateWindow(busydialog)')
-            else:
-                xbmc.executebuiltin('Dialog.Close(busydialog)')
     except Exception, e:
         dbg_log('oe::set_busy', 'ERROR: (' + repr(e) + ')', 4)
 
@@ -492,7 +483,6 @@ def openWizard():
         winOeMain.doModal()
         winOeMain = oeWindows.mainWindow('service-LibreELEC-Settings-mainWindow.xml', __cwd__, 'Default', oeMain=__oe__)  # None
     except Exception, e:
-        xbmc.executebuiltin('Dialog.Close(busydialog)')
         dbg_log('oe::openWizard', 'ERROR: (' + repr(e) + ')')
 
 
@@ -506,7 +496,6 @@ def openConfigurationWindow():
         winOeMain = None
         del winOeMain
     except Exception, e:
-        xbmc.executebuiltin('Dialog.Close(busydialog)')
         dbg_log('oe::openConfigurationWindow', 'ERROR: (' + repr(e) + ')')
 
 def standby_devices():

--- a/src/resources/lib/modules/bluetooth.py
+++ b/src/resources/lib/modules/bluetooth.py
@@ -920,8 +920,6 @@ class bluetoothAgent(dbus.service.Object):
 
     def busy(self):
         self.oe.input_request = False
-        if self.oe.__busy__ > 0:
-            xbmc.executebuiltin('ActivateWindow(busydialog)')
 
     @dbus.service.method('org.bluez.Agent1', in_signature='', out_signature='')
     def Release(self):
@@ -938,7 +936,6 @@ class bluetoothAgent(dbus.service.Object):
             self.oe.dbg_log('bluetooth::btAgent::AuthorizeService::device=', repr(device), 0)
             self.oe.dbg_log('bluetooth::btAgent::AuthorizeService::uuid=', repr(uuid), 0)
             self.oe.input_request = True
-            xbmc.executebuiltin('Dialog.Close(busydialog)')
             xbmcDialog = xbmcgui.Dialog()
             answer = xbmcDialog.yesno('Bluetooth', 'Authorize service', 'Authorize service %s?' % (uuid))
             self.oe.dbg_log('bluetooth::btAgent::AuthorizeService::answer=', repr(answer), 0)
@@ -957,7 +954,6 @@ class bluetoothAgent(dbus.service.Object):
             self.oe.dbg_log('bluetooth::btAgent::RequestPinCode', 'enter_function', 0)
             self.oe.dbg_log('bluetooth::btAgent::RequestPinCode::device=', repr(device), 0)
             self.oe.input_request = True
-            xbmc.executebuiltin('Dialog.Close(busydialog)')
             xbmcKeyboard = xbmc.Keyboard('', 'Enter PIN code')
             xbmcKeyboard.doModal()
             pincode = xbmcKeyboard.getText()
@@ -974,7 +970,6 @@ class bluetoothAgent(dbus.service.Object):
             self.oe.dbg_log('bluetooth::btAgent::RequestPasskey', 'enter_function', 0)
             self.oe.dbg_log('bluetooth::btAgent::RequestPasskey::device=', repr(device), 0)
             self.oe.input_request = True
-            xbmc.executebuiltin('Dialog.Close(busydialog)')
             xbmcDialog = xbmcgui.Dialog()
             passkey = int(xbmcDialog.numeric(0, 'Enter passkey (number in 0-999999)', '0'))
             self.oe.dbg_log('bluetooth::btAgent::RequestPasskey::passkey=', repr(passkey), 0)
@@ -1021,7 +1016,6 @@ class bluetoothAgent(dbus.service.Object):
             self.oe.dbg_log('bluetooth::btAgent::RequestConfirmation::device=', repr(device), 0)
             self.oe.dbg_log('bluetooth::btAgent::RequestConfirmation::passkey=', repr(passkey), 0)
             self.oe.input_request = True
-            xbmc.executebuiltin('Dialog.Close(busydialog)')
             xbmcDialog = xbmcgui.Dialog()
             answer = xbmcDialog.yesno('Bluetooth', 'Request confirmation', 'Confirm passkey %06u' % (passkey))
             self.oe.dbg_log('bluetooth::btAgent::RequestConfirmation::answer=', repr(answer), 0)
@@ -1040,7 +1034,6 @@ class bluetoothAgent(dbus.service.Object):
             self.oe.dbg_log('bluetooth::btAgent::RequestAuthorization', 'enter_function', 0)
             self.oe.dbg_log('bluetooth::btAgent::RequestAuthorization::device=', repr(device), 0)
             self.oe.input_request = True
-            xbmc.executebuiltin('Dialog.Close(busydialog)')
             xbmcDialog = xbmcgui.Dialog()
             answer = xbmcDialog.yesno('Bluetooth', 'Request authorization', 'Accept pairing?')
             self.oe.dbg_log('bluetooth::btAgent::RequestAuthorization::answer=', repr(answer), 0)
@@ -1072,8 +1065,6 @@ class obexAgent(dbus.service.Object):
 
     def busy(self):
         self.oe.input_request = False
-        if self.oe.__busy__ > 0:
-            xbmc.executebuiltin('ActivateWindow(busydialog)')
 
     @dbus.service.method('org.bluez.obex.Agent1', in_signature='', out_signature='')
     def Release(self):
@@ -1091,7 +1082,6 @@ class obexAgent(dbus.service.Object):
             transfer = dbus.Interface(self.oe.dbusSystemBus.get_object('org.bluez.obex', path), 'org.freedesktop.DBus.Properties')
             properties = transfer.GetAll('org.bluez.obex.Transfer1')
             self.oe.input_request = True
-            xbmc.executebuiltin('Dialog.Close(busydialog)')
             xbmcDialog = xbmcgui.Dialog()
             answer = xbmcDialog.yesno('Bluetooth', self.oe._(32381), properties['Name'])
             self.oe.dbg_log('bluetooth::obexAgent::AuthorizePush::answer=', repr(answer), 0)

--- a/src/resources/lib/modules/connman.py
+++ b/src/resources/lib/modules/connman.py
@@ -1421,8 +1421,6 @@ class connmanWifiAgent(dbus.service.Object):
 
     def busy(self):
         self.oe.input_request = False
-        if self.oe.__busy__ > 0:
-            xbmc.executebuiltin('ActivateWindow(busydialog)')
 
     @dbus.service.method('net.connman.Agent', in_signature='', out_signature='')
     def Release(self):
@@ -1435,7 +1433,6 @@ class connmanWifiAgent(dbus.service.Object):
         try:
             self.oe.dbg_log('connman::connmanWifiAgent::RequestInput', 'enter_function', 0)
             self.oe.input_request = True
-            xbmc.executebuiltin('Dialog.Close(busydialog)')
             response = {}
             if fields.has_key('Name'):
                 xbmcKeyboard = xbmc.Keyboard('', self.oe._(32146).encode('utf-8'))


### PR DESCRIPTION
Attempts to open the `busydialog` now result in the following message (and no busy dialog is shown):
```
09:24:31.634 T:3987755888 WARNING: addons must not activate DialogBusy
```