### PR TITLE
fix variable reset in remove_agent() functions

### DIFF
--- a/src/resources/lib/modules/bluetooth.py
+++ b/src/resources/lib/modules/bluetooth.py
@@ -743,7 +743,7 @@ class bluetooth:
                     except:
                         dbusBluezManager = None
                         pass
-                    self.btAgent = None
+                    del self.btAgent
                 self.oe.dbg_log('bluetooth::monitor::remove_agent', 'exit_function', 0)
             except Exception, e:
                 self.oe.dbg_log('bluetooth::monitor::remove_agent', 'ERROR: (' + repr(e) + ')', 4)
@@ -786,7 +786,7 @@ class bluetooth:
                     except:
                         dbusBluezObexManager = None
                         pass
-                    self.obAgent = None
+                    del self.obAgent
                 self.oe.dbg_log('bluetooth::monitor::remove_obex_agent', 'exit_function', 0)
             except Exception, e:
                 self.oe.dbg_log('bluetooth::monitor::remove_obex_agent', 'ERROR: (' + repr(e) + ')', 4)

--- a/src/resources/lib/modules/connman.py
+++ b/src/resources/lib/modules/connman.py
@@ -1299,7 +1299,7 @@ class connman:
                         dbusConnmanManager = None
                     except:
                         dbusConnmanManager = None
-                    self.wifiAgent = None
+                    del self.wifiAgent
                 self.oe.dbg_log('connman::monitor::remove_agent', 'exit_function', 0)
             except Exception, e:
                 self.oe.dbg_log('connman::monitor::remove_agent', 'ERROR: (' + repr(e) + ')', 4)


### PR DESCRIPTION
Solves errors on shutdown:
```
ERROR: ## LibreELEC Addon ## bluetooth::monitor::remove_agent ## ERROR: (AttributeError("'NoneType' object has no attribute 'remove_from_connection'",))
ERROR: Traceback (most recent call last):
        File "/home/neil/projects/LibreELEC.tv/build.LibreELEC-Generic.x86_64-9.0-devel/LibreELEC-settings-659afa8/.install_pkg/usr/share/kodi/addons/service.libreelec.settings/resources/lib/modules/bluetooth.py", line 738, in remove_agent
        AttributeError: 'NoneType' object has no attribute 'remove_from_connection'
```
Kodi log: [http://ix.io/1kzb](http://ix.io/1kzb)