### PR TITLE
add ssh passwd change to wizard

### DIFF
--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -580,8 +580,20 @@ msgctxt "#32209"
 msgid "SSH Password"
 msgstr ""
 
+msgctxt "#32210"
+msgid "It is recommended to set a new password for SSH"
+msgstr ""
+
 msgctxt "#32212"
 msgid "Cancel"
+msgstr ""
+
+msgctxt "#32213"
+msgid "Use Default"
+msgstr ""
+
+msgctxt "#32214"
+msgid "Set New Password"
 msgstr ""
 
 msgctxt "#32215"

--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -581,7 +581,7 @@ msgid "SSH Password"
 msgstr ""
 
 msgctxt "#32210"
-msgid "It is recommended to set a new password for SSH"
+msgid "The default LibreELEC SSH password is widely known it is considered insecure.[CR]Setting your own password of at least 8 characters (ideally a mixture of upper/lowercase/numeric/symbol characters) is strongly recommended."
 msgstr ""
 
 msgctxt "#32212"
@@ -589,11 +589,11 @@ msgid "Cancel"
 msgstr ""
 
 msgctxt "#32213"
-msgid "Use Default"
+msgid "Keep Existing"
 msgstr ""
 
 msgctxt "#32214"
-msgid "Set New Password"
+msgid "Set Password"
 msgstr ""
 
 msgctxt "#32215"

--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -581,7 +581,7 @@ msgid "SSH Password"
 msgstr ""
 
 msgctxt "#32210"
-msgid "The default LibreELEC SSH password is widely known it is considered insecure.[CR]Setting your own password of at least 8 characters (ideally a mixture of upper/lowercase/numeric/symbol characters) is strongly recommended."
+msgid "The default LibreELEC SSH password is widely known, and is considered insecure.[CR][CR]Setting your own password is recommended."
 msgstr ""
 
 msgctxt "#32212"

--- a/src/resources/lib/modules/services.py
+++ b/src/resources/lib/modules/services.py
@@ -366,7 +366,7 @@ class services:
                 # hide ssh settings if Kernel Parameter is set
 
                 cmd_file = open(self.KERNEL_CMD, 'r')
-                cmd_args = cmd_file.read()
+                cmd_args = cmd_file.read().split(' ')
                 if 'ssh' in cmd_args:
                     self.struct['ssh']['settings']['ssh_autostart']['value'] = '1'
                     self.struct['ssh']['settings']['ssh_autostart']['hidden'] = 'true'
@@ -601,7 +601,7 @@ class services:
             # ssh button does nothing if Kernel Parameter is set
 
             cmd_file = open(self.KERNEL_CMD, 'r')
-            cmd_args = cmd_file.read()
+            cmd_args = cmd_file.read().split(' ')
             if 'ssh' in cmd_args:
                 self.oe.notify('ssh', 'ssh enabled as boot parameter. can not disable')
             cmd_file.close()

--- a/src/resources/lib/modules/services.py
+++ b/src/resources/lib/modules/services.py
@@ -36,6 +36,7 @@ import xbmcaddon
 __scriptid__ = 'service.libreelec.settings'
 __addon__ = xbmcaddon.Addon(id=__scriptid__)
 _ = __addon__.getLocalizedString
+xbmcDialog = xbmcgui.Dialog()
 
 class services:
 
@@ -606,6 +607,8 @@ class services:
             cmd_file.close()
             self.initialize_ssh()
             self.load_values()
+            if self.struct['ssh']['settings']['ssh_autostart']['value'] == '1':
+                self.wizard_sshpasswd()
             self.set_wizard_buttons()
             self.oe.dbg_log('services::wizard_set_ssh', 'exit_function', 0)
         except Exception, e:
@@ -625,10 +628,22 @@ class services:
         except Exception, e:
             self.oe.dbg_log('services::wizard_set_samba', 'ERROR: (%s)' % repr(e))
 
+    def wizard_sshpasswd(self):
+        SSHresult = False
+        while SSHresult == False:
+            changeSSH = xbmcDialog.yesno(_(32209), _(32210), yeslabel=_(32214), nolabel=_(32213))
+            if changeSSH:
+                changeSSHresult = self.do_sshpasswd()
+                if changeSSHresult:
+                    SSHresult = True
+            else:
+                SSHresult = True
+        return
+
     def do_sshpasswd(self, **kwargs):
         try:
             self.oe.dbg_log('system::do_sshpasswd', 'enter_function', 0)
-            xbmcDialog = xbmcgui.Dialog()
+            SSHchange = False
             newpwd = xbmcDialog.input(_(746))
             if newpwd:
                 if newpwd == "libreelec":
@@ -648,10 +663,12 @@ class services:
                     return
                 elif "Retype password" in readout3:
                     xbmcDialog.ok(_(32222), _(32223))
+                    SSHchange = True
                 else:
                     xbmcDialog.ok(_(32224), _(32225))
                 self.oe.dbg_log('system::do_sshpasswd', 'exit_function', 0)
             else:
                 self.oe.dbg_log('system::do_sshpasswd', 'user_cancelled', 0)
+            return SSHchange
         except Exception, e:
             self.oe.dbg_log('system::do_sshpasswd', 'ERROR: (' + repr(e) + ')')

--- a/src/resources/lib/modules/services.py
+++ b/src/resources/lib/modules/services.py
@@ -631,13 +631,13 @@ class services:
     def wizard_sshpasswd(self):
         SSHresult = False
         while SSHresult == False:
-            changeSSH = xbmcDialog.yesno(_(32209), _(32210), yeslabel=_(32214), nolabel=_(32213))
+            changeSSH = xbmcDialog.yesno(_(32209), _(32210), yeslabel=_(32213), nolabel=_(32214))
             if changeSSH:
+                SSHresult = True
+            else:
                 changeSSHresult = self.do_sshpasswd()
                 if changeSSHresult:
                     SSHresult = True
-            else:
-                SSHresult = True
         return
 
     def do_sshpasswd(self, **kwargs):


### PR DESCRIPTION
This adds the suggestion to change the default password if SSH is enabled during the first run wizard.

It should cover all scenarios of a user starting to change the password, entering something that isn't valid, having the option to change try again or use default or changing their mind and cancelling back to the default.