### PR TITLE
Fix duplicate bluetooth devices

### DIFF
--- a/src/resources/lib/modules/bluetooth.py
+++ b/src/resources/lib/modules/bluetooth.py
@@ -1115,6 +1115,7 @@ class discoveryThread(threading.Thread):
             while not self.stopped and not xbmc.abortRequested:
                 current_time = time.time()
                 if current_time > self.last_run + 5:
+                    self.clear_list()
                     self.oe.dictModules['bluetooth'].menu_connections(None)
                     self.last_run = current_time
                 if not self.main_menu.getSelectedItem().getProperty('modul') == 'bluetooth':


### PR DESCRIPTION
This PR fixes duplicate bluetooth devices being listed after reopening add-on.