### PR TITLE
Fixes for connman module

### DIFF
--- a/src/resources/lib/modules/connman.py
+++ b/src/resources/lib/modules/connman.py
@@ -696,12 +696,12 @@ class connman:
             # IPTABLES
             nf_values = [self.oe._(32397), self.oe._(32398), self.oe._(32399)]
             nf_custom_rules = [self.NF_CUSTOM_PATH + "rules.v4" , self.NF_CUSTOM_PATH + "rules.v6"]
-	    for custom_rule in nf_custom_rules:
+            for custom_rule in nf_custom_rules:
                 if os.path.exists(custom_rule):
-		    nf_values.append(self.oe._(32396))
+                    nf_values.append(self.oe._(32396))
                     break
             self.struct['advanced']['settings']['netfilter']['values'] = nf_values
-	    if self.oe.get_service_state('iptables') == '1':
+            if self.oe.get_service_state('iptables') == '1':
                 nf_option = self.oe.get_service_option('iptables', 'RULES', 'home')
                 if nf_option == "custom":
                     nf_option_str = self.oe._(32396)
@@ -1169,7 +1169,7 @@ class connman:
                 options['RULES'] = "home"
             elif self.struct['advanced']['settings']['netfilter']['value'] == self.oe._(32399):
                 options['RULES'] = "public"
-	    else:
+            else:
                 state = 0
             self.oe.set_service('iptables', options, state)
             self.oe.set_busy(0)

--- a/src/resources/lib/modules/connman.py
+++ b/src/resources/lib/modules/connman.py
@@ -1051,7 +1051,7 @@ class connman:
             if 'InProgress' in err_name:
                 if self.net_disconnected != 1:
                     self.disconnect_network()
-                else
+                else:
                     self.net_disconnected = 0
                 self.connect_network()
             else:

--- a/src/resources/lib/modules/connman.py
+++ b/src/resources/lib/modules/connman.py
@@ -1048,7 +1048,8 @@ class connman:
                 self.connect_network()
             else:
                 err_message = error.get_dbus_message()
-                self.oe.notify('Network Error', err_message)
+                if not 'Did not receive a reply' in err_message:
+                    self.oe.notify('Network Error', err_message)
                 self.oe.dbg_log('connman::dbus_error_handler', 'ERROR: (' + err_message + ')', 4)
             self.oe.dbg_log('connman::dbus_error_handler', 'exit_function', 0)
         except Exception, e:

--- a/src/resources/lib/modules/connman.py
+++ b/src/resources/lib/modules/connman.py
@@ -472,6 +472,7 @@ class connman:
     NF_CUSTOM_PATH = "/storage/.config/iptables/"
     connect_attempt = 0
     log_error = 1
+    net_disconnected = 0
     notify_error = 1
     menu = {
         '3': {
@@ -1048,7 +1049,10 @@ class connman:
             self.oe.set_busy(0)
             err_name = error.get_dbus_name()
             if 'InProgress' in err_name:
-                self.disconnect_network()
+                if self.net_disconnected != 1:
+                    self.disconnect_network()
+                else
+                    self.net_disconnected = 0
                 self.connect_network()
             else:
                 err_message = error.get_dbus_message()
@@ -1085,6 +1089,7 @@ class connman:
             self.oe.dbg_log('connman::disconnect_network', 'enter_function', 0)
             self.oe.set_busy(1)
             self.connect_attempt = 0
+            self.net_disconnected = 1
             if listItem == None:
                 listItem = self.oe.winOeMain.getControl(self.oe.listObject['netlist']).getSelectedItem()
             service_object = self.oe.dbusSystemBus.get_object('net.connman', listItem.getProperty('entry'))

--- a/src/resources/lib/modules/connman.py
+++ b/src/resources/lib/modules/connman.py
@@ -1292,11 +1292,12 @@ class connman:
         def initialize_agent(self):
             try:
                 self.oe.dbg_log('connman::monitor::initialize_agent', 'enter_function', 0)
-                dbusConnmanManager = dbus.Interface(self.oe.dbusSystemBus.get_object('net.connman', '/'), 'net.connman.Manager')
-                self.wifiAgent = connmanWifiAgent(self.oe.dbusSystemBus, self.wifiAgentPath)
-                self.wifiAgent.oe = self.oe
-                dbusConnmanManager.RegisterAgent(self.wifiAgentPath)
-                dbusConnmanManager = None
+                if not hasattr(self, 'wifiAgent'):
+                    dbusConnmanManager = dbus.Interface(self.oe.dbusSystemBus.get_object('net.connman', '/'), 'net.connman.Manager')
+                    self.wifiAgent = connmanWifiAgent(self.oe.dbusSystemBus, self.wifiAgentPath)
+                    self.wifiAgent.oe = self.oe
+                    dbusConnmanManager.RegisterAgent(self.wifiAgentPath)
+                    dbusConnmanManager = None
                 self.oe.dbg_log('connman::monitor::initialize_agent', 'exit_function', 0)
             except Exception, e:
                 self.oe.dbg_log('connman::monitor::initialize_agent', 'ERROR: (' + repr(e) + ')', 4)


### PR DESCRIPTION
This PR does 4 things:
- Fix warnings from use of tabs.
- Log D-Bus error "Did not receive a reply"  silently.
- Fix intermittent connection issues and possible Kodi crash
- Only run initialize_agent if its not already done