### PR TITLE
Add support for RPi4 Bootloader flashing

### DIFF
--- a/language/resource.language.en_gb/strings.po
+++ b/language/resource.language.en_gb/strings.po
@@ -340,6 +340,42 @@ msgctxt "#32021"
 msgid "Submit Statistics"
 msgstr ""
 
+msgctxt "#32022"
+msgid "Raspberry Pi Flashing"
+msgstr ""
+
+msgctxt "#32023"
+msgid "Updating will occur once the system is rebooted."
+msgstr ""
+
+msgctxt "#32024"
+msgid "Bootloader EEPROM"
+msgstr ""
+
+msgctxt "#32025"
+msgid "Update the Raspberry Pi Bootloader EEPROM to the latest version. This option is automatically disabled after rebooting. Reboot the system to apply the update."
+msgstr ""
+
+msgctxt "#32026"
+msgid "VIA USB3 Firmware"
+msgstr ""
+
+msgctxt "#32027"
+msgid "Update the Raspberry Pi VIA USB3 firmware to the latest version. This option is automatically disabled after rebooting. Reboot the system to apply the update."
+msgstr ""
+
+msgctxt "#32028"
+msgid "[COLOR FFFF0000]BOOTLOADER CORRUPT: update required![/COLOR]"
+msgstr ""
+
+msgctxt "#32029"
+msgid "update from %s to %s"
+msgstr ""
+
+msgctxt "#32030"
+msgid "up to date: %s"
+msgstr ""
+
 msgctxt "#32100"
 msgid "Connections"
 msgstr ""

--- a/src/defaults.py
+++ b/src/defaults.py
@@ -80,6 +80,8 @@ updates = {
     'UPDATE_REQUEST_URL': 'https://update.libreelec.tv/updates.php',
     'UPDATE_DOWNLOAD_URL': 'http://%s.libreelec.tv/%s',
     'LOCAL_UPDATE_DIR': '/storage/.update/',
+
+    'RPI_FLASHING_TRIGGER': '/storage/.rpi_flash_firmware',
     }
 
 about = {'ENABLED': True}

--- a/src/resources/lib/modules/system.py
+++ b/src/resources/lib/modules/system.py
@@ -668,7 +668,14 @@ class system:
                 else:
                     self.oe.execute('echo "Firmware Boot Mode: BIOS" >> /storage/.kodi/temp/paste.tmp')
 
+            if os.path.exists('/usr/lib/libreelec/rpi-flash-firmware') and os.path.exists('/flash/recovery.bin'):
+                self.oe.execute('echo "WARNING: /flash/recovery.bin is present - bootloader in safe-mode!" >> /storage/.kodi/temp/paste.tmp')
+
+            if self.oe.PROJECT == "RPi":
+                self.oe.execute('grep "^Revision" /proc/cpuinfo | sed "s/Revision[[:space:]]*:/RPi Hardware Revision:/" >> /storage/.kodi/temp/paste.tmp')
+
             self.cat_file('/storage/.kodi/temp/paste.tmp', '/flash/config.txt') # RPi
+            self.cat_file('/storage/.kodi/temp/paste.tmp', '/flash/distroconfig.txt') # RPi
             self.cat_file('/storage/.kodi/temp/paste.tmp', '/flash/cmdline.txt') # RPi
             self.cat_file('/storage/.kodi/temp/paste.tmp', '/flash/syslinux.cfg') # x86 BIOS
             self.cat_file('/storage/.kodi/temp/paste.tmp', '/flash/EFI/BOOT/syslinux.cfg') # x86 EFI


### PR DESCRIPTION
Support https://github.com/LibreELEC/LibreELEC.tv/pull/3729

This option will be hidden on systems other than RPi4 (ie. any system that lacks `/usr/lib/libreelec/rpi-flash-firmware`).

![s1](https://i.imgur.com/hdjKIGs.png)

![s2](https://i.imgur.com/rMm4kmG.png)

It does not automatically reboot once enabled - I figure we can extend this to support updating of the VIA USB firmware with a second option. That way users can choose to update one or the other, or both, and *then* reboot, at which point one or both will be updated.