### PR TITLE
RPi4 Flashing: parse machine output

### DIFF
--- a/language/resource.language.en_gb/strings.po
+++ b/language/resource.language.en_gb/strings.po
@@ -365,14 +365,10 @@ msgid "Update the Raspberry Pi VIA USB3 firmware to the latest version. This opt
 msgstr ""
 
 msgctxt "#32028"
-msgid "[COLOR FFFF0000]BOOTLOADER CORRUPT: update required![/COLOR]"
-msgstr ""
-
-msgctxt "#32029"
 msgid "update from %s to %s"
 msgstr ""
 
-msgctxt "#32030"
+msgctxt "#32029"
 msgid "up to date: %s"
 msgstr ""
 

--- a/src/resources/lib/modules/system.py
+++ b/src/resources/lib/modules/system.py
@@ -670,6 +670,9 @@ class system:
 
             if self.oe.PROJECT == "RPi":
                 self.oe.execute('grep "^Revision" /proc/cpuinfo | sed "s/Revision[[:space:]]*:/RPi Hardware Revision:/" >> /storage/.kodi/temp/paste.tmp')
+                bootloader_version = self.oe.execute('vcgencmd bootloader_version', get_result=1)
+                if bootloader_version.find("Command not registered") == -1:
+                    self.oe.execute('echo -n "========== Bootloader version ==========\n%s" >> /storage/.kodi/temp/paste.tmp' % bootloader_version)
 
             self.cat_file('/storage/.kodi/temp/paste.tmp', '/flash/config.txt') # RPi
             self.cat_file('/storage/.kodi/temp/paste.tmp', '/flash/distroconfig.txt') # RPi

--- a/src/resources/lib/modules/system.py
+++ b/src/resources/lib/modules/system.py
@@ -668,9 +668,6 @@ class system:
                 else:
                     self.oe.execute('echo "Firmware Boot Mode: BIOS" >> /storage/.kodi/temp/paste.tmp')
 
-            if os.path.exists('/usr/lib/libreelec/rpi-flash-firmware') and os.path.exists('/flash/recovery.bin'):
-                self.oe.execute('echo "WARNING: /flash/recovery.bin is present - bootloader in safe-mode!" >> /storage/.kodi/temp/paste.tmp')
-
             if self.oe.PROJECT == "RPi":
                 self.oe.execute('grep "^Revision" /proc/cpuinfo | sed "s/Revision[[:space:]]*:/RPi Hardware Revision:/" >> /storage/.kodi/temp/paste.tmp')
 

--- a/src/resources/lib/modules/updates.py
+++ b/src/resources/lib/modules/updates.py
@@ -633,7 +633,7 @@ class updates:
                      'latest_ts': 0, 'latest': 'unknown'}
 
             with tempfile.NamedTemporaryFile(mode='r', delete=True) as machine_out:
-                console_output = self.oe.execute('/usr/bin/rpi-eeprom-update -j -m "%s"' % machine_out.name, get_result=1).split('\n')
+                console_output = self.oe.execute('/usr/bin/.rpi-eeprom-update.real -j -m "%s"' % machine_out.name, get_result=1).split('\n')
                 if os.path.getsize(machine_out.name) != 0:
                     state['incompatible'] = False
                     jdata = json.load(machine_out)

--- a/src/resources/lib/modules/updates.py
+++ b/src/resources/lib/modules/updates.py
@@ -627,7 +627,7 @@ class updates:
             self.oe.dbg_log('updates::get_rpi_flash_status', 'enter_function', 0)
 
             jdata = {'EXITCODE': 'EXIT_FAILED', 'CURRENT_TS': 0, 'LATEST_TS': 0}
-            state = {'incompatible': True, 'update': False, 'corrupt': False,
+            state = {'incompatible': True, 'update': False,
                      'state': '',
                      'current_ts': 0, 'current': 'unknown',
                      'latest_ts': 0, 'latest': 'unknown'}
@@ -651,14 +651,10 @@ class updates:
 
             if jdata['EXITCODE'] == 'EXIT_SUCCESS':
                 state["update"] = False
-                state["state"] = self.oe._(32030).encode('utf-8') % state["current"]
+                state["state"] = self.oe._(32029).encode('utf-8') % state["current"]
             elif jdata['EXITCODE'] == 'EXIT_UPDATE_REQUIRED':
                 state["update"] = True
-                state["state"] = self.oe._(32029).encode('utf-8') % (state["current"], state["latest"])
-            elif jdata['EXITCODE'] == 'EXIT_PREVIOUS_UPDATE_FAILED':
-                state["corrupt"] = True
-                state["update"] = True
-                state["state"] = self.oe._(32028).encode('utf-8')
+                state["state"] = self.oe._(32028).encode('utf-8') % (state["current"], state["latest"])
 
             self.oe.dbg_log('updates::get_rpi_flash_status', 'state: %s' % state, 0)
             self.oe.dbg_log('updates::get_rpi_flash_status', 'exit_function', 0)


### PR DESCRIPTION
This adds support for parsing the machine-readable output from the RPi flashing script.

Leaving as draft until changes accepted upstream.