### PR TITLE
Stop referencing non-existant window

### DIFF
--- a/skins/Default/1080i/service-LibreELEC-Settings-mainWindow.xml
+++ b/skins/Default/1080i/service-LibreELEC-Settings-mainWindow.xml
@@ -8,7 +8,7 @@
             <control type="image">
                 <depth>DepthBackground</depth>
                 <aspectratio>scale</aspectratio>
-                <animation effect="fade" start="100" end="bg_alpha" time="0" condition="Player.HasMedia + String.IsEmpty(Window(videolibrary).Property(PlayingBackgroundMedia))">Conditional</animation>
+                <animation effect="fade" start="100" end="bg_alpha" time="0" condition="Player.HasMedia + String.IsEmpty(Window(videos).Property(PlayingBackgroundMedia))">Conditional</animation>
                 <animation effect="fade" start="0" end="100" time="300" condition="Window.Previous(fullscreenvideo) | Window.Previous(startup)">WindowOpen</animation>
                 <texture>bg.jpg</texture>
 


### PR DESCRIPTION
`videolibrary` is removed by https://github.com/xbmc/xbmc/pull/9886 (no longer valid since Krypton) and currently produces this error when entering the Settings addon:
```
2019-09-18 23:24:24.208 T:1931829264   ERROR: Window Translator: Can't find window videolibrary
```