### PR TITLE
Support RPi CPU detection, enable firmware updates only for RPi4

### DIFF
--- a/src/oe.py
+++ b/src/oe.py
@@ -877,6 +877,11 @@ if os.path.exists('/etc/machine-id'):
 else:
     SYSTEMID = os.environ.get('SYSTEMID', '')
 
+if PROJECT == 'RPi':
+  RPI_CPU_VER = execute('vcgencmd otp_dump 2>/dev/null | grep 30: | cut -c8', get_result=1).replace('\n','')
+else:
+  RPI_CPU_VER = ''
+
 BOOT_STATUS = load_file('/storage/.config/boot.status')
 
 ############################################################################################

--- a/src/resources/lib/modules/updates.py
+++ b/src/resources/lib/modules/updates.py
@@ -325,21 +325,26 @@ class updates:
             self.struct['update']['settings']['Channel']['values'] = self.get_channels()
             self.struct['update']['settings']['Build']['values'] = self.get_available_builds()
 
-            # RPi Flash
-            if os.path.exists('/usr/lib/libreelec/rpi-flash-firmware') == False:
+            # RPi Flash for RPi4
+            if self.oe.RPI_CPU_VER != '3':
                 self.struct['rpibootloader']['hidden'] = 'true'
             else:
                 self.rpi_spi_state = self.get_rpi_flash_state()
                 if self.rpi_spi_state['incompatible']:
-                    self.struct['rpibootloader']['hidden'] = 'true'
+                    self.struct['rpibootloader']['settings']['SPIBootloader']['hidden'] = 'true'
                 else:
                     self.struct['rpibootloader']['settings']['SPIBootloader']['value'] = self.get_rpi_flash('BOOTLOADER')
                     self.struct['rpibootloader']['settings']['SPIBootloader']['name'] = self.oe._(32024).encode('utf-8') + ' (' + self.rpi_spi_state["state"] + ')'
 
-                    if os.path.exists('/usr/bin/vl805') == False:
-                        self.struct['rpibootloader']['settings']['VIAUSB3']['hidden'] = 'true'
-                    else:
-                        self.struct['rpibootloader']['settings']['VIAUSB3']['value'] = self.get_rpi_flash('USB3')
+                if os.path.exists('/usr/bin/vl805') == False:
+                    self.struct['rpibootloader']['settings']['VIAUSB3']['hidden'] = 'true'
+                else:
+                    self.struct['rpibootloader']['settings']['VIAUSB3']['value'] = self.get_rpi_flash('USB3')
+
+                # Hide entire section if all options are hidden
+                if 'hidden' in self.struct['rpibootloader']['settings']['SPIBootloader'] and \
+                   'hidden' in self.struct['rpibootloader']['settings']['VIAUSB3']:
+                   self.struct['rpibootloader']['hidden'] = 'true'
 
             self.oe.dbg_log('updates::load_values', 'exit_function', 0)
 


### PR DESCRIPTION
This adds `RPI_CPU_VER`:

`0`=`BCM2835` (ARM1176 - RPi0/RPi1)
`1`=`BCM2836` (Cortex-A7 - RPi2)
`2`=`BCM2837` (Cortex-A53 - RPi2/RPi3/RPi3+)
`3`=`BCM2838` (Cortex-A72 - RPi4)

Use `RPI_CPU_VER` to enable/disable the RPi Flashing options, ensuring we disable RPi Flashing whenever the RPi4 image is installed on RPi2/RPi3 hardware.