### PR TITLE
Evaluate lambdas

### DIFF
--- a/src/defaults.py
+++ b/src/defaults.py
@@ -21,6 +21,7 @@ connman = {
     'WAIT_CONF_FILE': '%s/libreelec/network_wait' % CONFIG_CACHE,
     'ENABLED': lambda : (True if os.path.exists(connman['CONNMAN_DAEMON']) else False),
     }
+connman['ENABLED'] = connman['ENABLED']()
 
 ################################################################################
 # Bluez Module
@@ -32,6 +33,7 @@ bluetooth = {
     'ENABLED': lambda : (True if os.path.exists(bluetooth['BLUETOOTH_DAEMON']) else False),
     'D_OBEXD_ROOT': '/storage/downloads/',
     }
+bluetooth['ENABLED'] = bluetooth['ENABLED']()
 
 ################################################################################
 # Service Module


### PR DESCRIPTION
The lambdas exist to late evaluate the respective DAEMON path.

But unless the lamdas are evaluated, then 'ENABLED' is just a function, which always evaluates to `True`.

Thanks @hiassoft.