### PR TITLE
disable network configuration settings when using kernel ip config / netboot

### DIFF
--- a/src/defaults.py
+++ b/src/defaults.py
@@ -19,7 +19,7 @@ USER_CONFIG = os.environ.get('USER_CONFIG', '/storage/.config')
 connman = {
     'CONNMAN_DAEMON': '/usr/sbin/connmand',
     'WAIT_CONF_FILE': '%s/libreelec/network_wait' % CONFIG_CACHE,
-    'ENABLED': lambda : (True if os.path.exists(connman['CONNMAN_DAEMON']) else False),
+    'ENABLED': lambda : (True if os.path.exists(connman['CONNMAN_DAEMON']) and not os.path.exists('/dev/.kernel_ipconfig') else False),
     }
 connman['ENABLED'] = connman['ENABLED']()
 

--- a/src/resources/lib/oeWindows.py
+++ b/src/resources/lib/oeWindows.py
@@ -669,7 +669,7 @@ class wizard(xbmcgui.WindowXMLDialog):
 
                 for module in sorted(self.oe.dictModules, key=lambda x: self.oe.dictModules[x].menu.keys()):
                     strModule = module
-                    if hasattr(self.oe.dictModules[strModule], 'do_wizard'):
+                    if hasattr(self.oe.dictModules[strModule], 'do_wizard') and self.oe.dictModules[strModule].ENABLED:
                         if strModule == self.last_wizard:
                             if hasattr(self.oe.dictModules[strModule], 'exit'):
                                 self.oe.dictModules[strModule].exit()


### PR DESCRIPTION
LE settings changes for https://github.com/LibreELEC/LibreELEC.tv/pull/3936

If the /dev/.kernel_ipconfig marker file is present the connman module is disabled (and thus the network settings aren't shown)