### PR TITLE
service.py: wizard window does not have visible attribute

### DIFF
--- a/src/resources/lib/oeWindows.py
+++ b/src/resources/lib/oeWindows.py
@@ -416,6 +416,7 @@ class pinkeyWindow(xbmcgui.WindowXMLDialog):
 class wizard(xbmcgui.WindowXMLDialog):
 
     def __init__(self, *args, **kwargs):
+        self.visible = False
         self.lastMenu = -1
         self.guiMenList = 1000
         self.guiNetList = 1200
@@ -467,6 +468,7 @@ class wizard(xbmcgui.WindowXMLDialog):
         self.last_wizard = None
 
     def onInit(self):
+        self.visible = True
         try:
             self.setProperty('arch', self.oe.ARCHITECTURE)
             self.setProperty('distri', self.oe.DISTRIBUTION)
@@ -696,6 +698,7 @@ class wizard(xbmcgui.WindowXMLDialog):
                     time.sleep(.5)
                     xbmc.executebuiltin('SendClick(10100,11)')
                     self.oe.write_setting('libreelec', 'wizard_completed', 'True')
+                    self.visible = False
                     self.close()
                     xbmc.executebuiltin(lang_str)
             self.oe.dbg_log('wizard::onClick(' + str(controlID) + ')', 'exit_function', 0)

--- a/src/service.py
+++ b/src/service.py
@@ -94,7 +94,7 @@ monitor.start()
 
 xbmcm.waitForAbort()
 
-if hasattr(oe, 'winOeMain'):
+if hasattr(oe, 'winOeMain') and hasattr(oe.winOeMain, 'visible'):
     if oe.winOeMain.visible == True:
         oe.winOeMain.close()
 


### PR DESCRIPTION
If Kodi is shutdown when the First Run Wizard is active the following exception occurs:
```
2019-11-16 03:24:54.690 T:1929  NOTICE: stop dvd detect media
2019-11-16 03:24:54.692 T:1951   ERROR: EXCEPTION Thrown (PythonToCppException) : -->Python callback/script returned the following error<--
                                             - NOTE: IGNORING THIS CAN LEAD TO MEMORY LEAKS!
                                            Error Type: <class 'AttributeError'>
                                            Error Contents: 'wizard' object has no attribute 'visible'
                                            Traceback (most recent call last):
                                              File "/usr/share/kodi/addons/service.libreelec.settings/service.py", line 98, in <module>
                                                if oe.winOeMain.visible == True:
                                            AttributeError: 'wizard' object has no attribute 'visible'
                                            -->End of Python script error report<--
2019-11-16 03:24:59.693 T:1929   ERROR: CPythonInvoker(0, /usr/share/kodi/addons/service.libreelec.settings/service.py): script didn't stop in 5 seconds - let's kill it
2019-11-16 03:24:59.889 T:1929  NOTICE: Application stopped
```

Add a `visible` attribute to the wizard window, and be a bit more defensive for any window that may not have a visible attribute.