### PR TITLE
improve download performance on fast connections

### DIFF
--- a/src/resources/lib/modules/system.py
+++ b/src/resources/lib/modules/system.py
@@ -583,12 +583,16 @@ class system:
             copy_success = 0
             xbmcDialog = xbmcgui.Dialog()
             restore_file_path = xbmcDialog.browse( 1,
-                                              self.oe._(32373),
-                                              'files',
-                                              '??????????????.tar',
-                                              False,
-                                              False,
-                                              self.BACKUP_DESTINATION )
+                                                   self.oe._(32373),
+                                                   'files',
+                                                   '??????????????.tar',
+                                                   False,
+                                                   False,
+                                                   self.BACKUP_DESTINATION )
+
+            # Do nothing if the dialog is cancelled - path will be the backup destination
+            if not os.path.isfile(restore_file_path):
+                return
 
             restore_file_name = restore_file_path.split('/')[-1]
 


### PR DESCRIPTION
As noted on the [forum](https://forum.kodi.tv/showthread.php?tid=343069&pid=2918914#pid2918914), the update download speed in Kodi is significantly lower than the user is able to achieve at the command line using `curl`.

This is because we update the progress dialog up to 80 times a second, although the actual rate at which we update is dependent on the connection speed (and also the 32KB chunk size). A high-ish download speed combined with the small chunk size results in a high rate of dialog updates.

My own internet connection speed is 1Gbps, and on an i5 Skylake NUC `curl` downloads a tar file from the download server to NVMe storage at the full 100MB/s, but Kodi only achieves 22.5MB/s as it is updating the dialog 70-75 times a second.

Increasing the chunk size would reduce the number of GUI updates but I'm not sure how this will behave on very slow connections - we still need to process the loop frequently in order to catch the cancel/abort, but we also need to limit the number of GUI updates. Keeping the chunk size as it is and implementing rate limiting is the best solution (IMHO).

This PR refactors the progress dialog into a class and adds rate limiting (default maximum 5 times a second). Sampling is also reduced from every 2 seconds to every 1.0 second.

With this PR, the NUC now downloads the tar file at the full 100MB/s. An RPi3+ improves from 2MB/s to 8-9MB/s (limited by the 100Mbs NIC, and write speed of the SD card). So very roughly a 4x-5x improvement.

The `extract_file()` function isn't used anywhere that I can find, so I've removed it.
