### PR TITLE
ssh password: switch to text mode, disable buffering

### DIFF
--- a/src/resources/lib/modules/services.py
+++ b/src/resources/lib/modules/services.py
@@ -665,12 +665,11 @@ class services:
                     self.oe.execute('cp -fp /usr/cache/shadow /storage/.cache/shadow')
                     readout3 = "Retype password"
                 else:
-                    ssh = subprocess.Popen(["passwd"], shell=False, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                    ssh = subprocess.Popen(["passwd"], shell=False, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, bufsize=0)
                     readout1 = ssh.stdout.readline()
-                    ssh.stdin.write(newpwd + '\n')
-                    ssh.stdin.flush()
+                    ssh.stdin.write('%s\n' % newpwd)
                     readout2 = ssh.stdout.readline()
-                    ssh.stdin.write(newpwd + '\n')
+                    ssh.stdin.write('%s\n' % newpwd)
                     readout3 = ssh.stdout.readline()
                 if "Bad password" in readout3:
                     xbmcDialog.ok(self.oe._(32220), self.oe._(32221))


### PR DESCRIPTION
Fix issue reported on the [forum](https://forum.kodi.tv/showthread.php?tid=343069&pid=2919489#pid2919489).

Switching to `text` mode avoids the hassle of dealing with bytes as everything we read/write will be a string.

Buffering is disabled by setting `bufsize=0` which means we don't need to flush stdin (which can fail when re-entering the password a second time if `passwd` has already bailed due to a weak password).