### PR TITLE
Mask PIN input

### DIFF
--- a/src/oe.py
+++ b/src/oe.py
@@ -530,7 +530,7 @@ def openConfigurationWindow():
                 PINtry = 4
                 while PINmatch == False:
                     if PINtry > 0:
-                        PINlock = xbmcDialog.input(_(32233), type=xbmcgui.INPUT_NUMERIC)
+                        PINlock = xbmcDialog.numeric(0, _(32233), bHiddenInput=True)
                         if PINlock == '':
                             break
                         else:


### PR DESCRIPTION
This masks the input of the PIN when access to LibreELEC Settings is locked and PIN entry is required.

Depends on https://github.com/xbmc/xbmc/pull/17661