### PR TITLE
use device-tree flags for NXP/Qualcomm/Samsung devices

### DIFF
--- a/src/resources/lib/modules/updates.py
+++ b/src/resources/lib/modules/updates.py
@@ -273,7 +273,7 @@ class updates:
             return self.get_hardware_flags_x86_64()
         elif self.oe.PROJECT == "RPi":
             return self.get_hardware_flags_rpi()
-        elif self.oe.PROJECT in ['Allwinner', 'Amlogic', 'Rockchip']:
+        elif self.oe.PROJECT in ['Allwinner', 'Amlogic', 'NXP', 'Qualcomm', 'Rockchip', 'Samsung' ]:
             return self.get_hardware_flags_dtname()
         else:
             self.oe.dbg_log('updates::get_hardware_flags', 'Project is %s, no hardware flag available' % self.oe.PROJECT, 0)


### PR DESCRIPTION
This adds stats flags for some additional SoC types to the settings add-on. Samsung (aka Exynos aka Odroid XU4) is still a WIP effort, but IMHO harmless to add.