### PR TITLE
Compressed backups and wider range of restores

### DIFF
--- a/src/resources/lib/modules/system.py
+++ b/src/resources/lib/modules/system.py
@@ -542,7 +542,8 @@ class system:
                                         '',
                                         False,
                                         False,
-                                        self.BACKUP_DESTINATION )
+                                        self.BACKUP_DESTINATION,
+                                        False )
 
             if bckDir and os.path.exists(bckDir):
                 # free space check
@@ -561,8 +562,8 @@ class system:
                 self.backup_dlg.create('LibreELEC', self.oe._(32375))
                 if not os.path.exists(self.BACKUP_DESTINATION):
                     os.makedirs(self.BACKUP_DESTINATION)
-                self.backup_file = self.oe.timestamp() + '.tar'
-                tar = tarfile.open(bckDir + self.backup_file, 'w')
+                self.backup_file = self.oe.timestamp() + '.tar.gz'
+                tar = tarfile.open(bckDir + self.backup_file, 'w:gz', compresslevel=1)
                 for directory in self.BACKUP_DIRS:
                     self.tar_add_folder(tar, directory)
                 tar.close()

--- a/src/resources/lib/modules/system.py
+++ b/src/resources/lib/modules/system.py
@@ -582,10 +582,11 @@ class system:
             restore_file_path = xbmcDialog.browse( 1,
                                                    self.oe._(32373),
                                                    'files',
-                                                   '??????????????.tar',
+                                                   '.tar|.tar.gz|.tar.bz2|.tar.xz',
                                                    False,
                                                    False,
-                                                   self.BACKUP_DESTINATION )
+                                                   self.BACKUP_DESTINATION,
+                                                   False )
 
             # Do nothing if the dialog is cancelled - path will be the backup destination
             if not os.path.isfile(restore_file_path):
@@ -593,11 +594,9 @@ class system:
 
             restore_file_name = restore_file_path.split('/')[-1]
 
-            if not os.path.exists(self.RESTORE_DIR):
-                os.makedirs(self.RESTORE_DIR)
-            else:
+            if os.path.exists(self.RESTORE_DIR):
                 self.oe.execute('rm -rf %s' % self.RESTORE_DIR)
-                os.makedirs(self.RESTORE_DIR)
+            os.makedirs(self.RESTORE_DIR)
             folder_stat = os.statvfs(self.RESTORE_DIR)
             file_size = os.path.getsize(restore_file_path)
             free_space = folder_stat.f_frsize * folder_stat.f_bavail


### PR DESCRIPTION
This compresses the backup tarball that is created with gzip at level 1. The intent is to be quick enough for users to not notice something changed, while still having size savings. My backup went from 176MB to 86MB.

The file filter line on the restore isn't perfect, but I don't know that it's a problem. It picks up files that would be like "test.gz" instead of "test.tar.gz". 

This requires #160 and LE PR4463 to merge first.