### PR TITLE
filter certain paths from backup

### DIFF
--- a/resources/lib/defaults.py
+++ b/resources/lib/defaults.py
@@ -74,6 +74,11 @@ system = {
         CONFIG_CACHE,
         '/storage/.ssh',
         ],
+    'BACKUP_FILTER' : [
+        f'{XBMC_USER_HOME}/addons/packages',
+        f'{XBMC_USER_HOME}/addons/temp',
+        f'{XBMC_USER_HOME}/temp'
+        ],
     'BACKUP_DESTINATION': '/storage/backup/',
     'RESTORE_DIR': '/storage/.restore/',
     }

--- a/resources/lib/modules/system.py
+++ b/resources/lib/modules/system.py
@@ -29,6 +29,7 @@ class system(modules.Module):
     UDEV_KEYBOARD_INFO = None
     NOX_KEYBOARD_INFO = None
     BACKUP_DIRS = None
+    BACKUP_FILTER = None
     BACKUP_DESTINATION = None
     RESTORE_DIR = None
     SET_CLOCK_CMD = None
@@ -533,7 +534,9 @@ class system(modules.Module):
                         pass
                     return 0
                 itempath = os.path.join(folder, item)
-                if os.path.islink(itempath):
+                if itempath in self.BACKUP_FILTER:
+                    continue
+                elif os.path.islink(itempath):
                     tar.add(itempath)
                 elif os.path.ismount(itempath):
                     tar.add(itempath, recursive=False)
@@ -555,7 +558,7 @@ class system(modules.Module):
     def get_folder_size(self, folder):
         for item in os.listdir(folder):
             itempath = os.path.join(folder, item)
-            if os.path.islink(itempath):
+            if itempath in self.BACKUP_FILTER or os.path.islink(itempath):
                 continue
             elif os.path.isfile(itempath):
                 self.total_backup_size += os.path.getsize(itempath)


### PR DESCRIPTION
This adds a filter (or mask) to prevent paths within BACKUP_DIRS from being backed up. The proposed filters are:

.kodi/addons/temp
.kodi/temp
.kodi/userdata/Thumbnails

The first two, I'm taking at their face value that they are indeed temporary directories and unimportant for a restoration. userdata/Thumbnails is Kodi's artwork cache. For me, this trimmed about 15MB off a backup tarball (I believe almost all attributable to the art cache).

Needs #160 to work.