### PR TITLE
 Fix crash in ProgressDialog

### DIFF
--- a/src/oe.py
+++ b/src/oe.py
@@ -84,9 +84,9 @@ xbmc.log('## LibreELEC Addon ## ' + unicode(__addon__.getAddonInfo('version')))
 
 class ProgressDialog:
     def __init__(self, label1=32181, label2=32182, label3=32183, minSampleInterval=1.0, maxUpdatesPerSecond=5):
-        self.label1 = _(label1).encode('utf-8')
-        self.label2 = _(label2).encode('utf-8')
-        self.label3 = _(label3).encode('utf-8')
+        self.label1 = _(label1)
+        self.label2 = _(label2)
+        self.label3 = _(label3)
         self.minSampleInterval = minSampleInterval
         self.maxUpdatesPerSecond = 1 / maxUpdatesPerSecond
 


### PR DESCRIPTION
Use unicode labels in ProgressDialog to fix crash when using non ASCII UTF-8 characters.

The error has been reported in the forum [here](https://forum.libreelec.tv/thread/22145-can-t-update-v9-2-1-to-v9-2-3-through-gui-in-czech-language/) and [here](https://forum.libreelec.tv/thread/22511-manual-update-doesn-t-work-in-bulgarian-language/).  Manual update did not work.

``` text
2020-06-08 06:17:03.165 T:2962219888   ERROR: ## LibreELEC Addon ## oe::download_file(http://releases.libreelec.tv/LibreELEC-RPi4.arm-9.2.3.tar, /storage/.kodi/temp/update_file) ## ERROR: (UnicodeDecodeError('ascii', 'Jm\xc3\xa9no souboru: ', 2, 3, 'ordinal not in range(128)'))
2020-06-08 06:17:03.166 T:2962219888   ERROR: Traceback (most recent call last):
                                       File "/var/lib/jenkins/LE/build5/workspace/RPi4/build.LibreELEC-RPi4.arm-9.2.1/LibreELEC-settings-6f6ca1e46c230d1e5045e6bb92a03889e1f1c71a/.install_pkg/usr/share/kodi/addons/service.libreelec.settings/oe.py", line 389, in download_file
                                       File "/var/lib/jenkins/LE/build5/workspace/RPi4/build.LibreELEC-RPi4.arm-9.2.1/LibreELEC-settings-6f6ca1e46c230d1e5045e6bb92a03889e1f1c71a/.install_pkg/usr/share/kodi/addons/service.libreelec.settings/oe.py", line 133, in update
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 2: ordinal not in range(128)
```

This is a LibreELEC 9.2 only issue and does not exist on master.
