### PR TITLE
Fix manual IPv4 configuration [le92]

### DIFF
--- a/src/resources/lib/modules/connman.py
+++ b/src/resources/lib/modules/connman.py
@@ -73,6 +73,7 @@ class connmanService(object):
                                 'value': ['manual'],
                                 },
                             'action': 'set_value',
+                            'notempty': True,
                             },
                         'Netmask': {
                             'order': 3,
@@ -85,6 +86,7 @@ class connmanService(object):
                                 'value': ['manual'],
                                 },
                             'action': 'set_value',
+                            'notempty': True,
                             },
                         'Gateway': {
                             'order': 4,
@@ -97,6 +99,7 @@ class connmanService(object):
                                 'value': ['manual'],
                                 },
                             'action': 'set_value',
+                            'notempty': True,
                             },
                         },
                     },
@@ -376,7 +379,7 @@ class connmanService(object):
                 postfix = '.Configuration'
             for entry in sorted(self.struct[category]['settings'], key=lambda x: self.struct[category]['settings'][x]['order']):
                 setting = self.struct[category]['settings'][entry]
-                if (setting['value'] != '' or hasattr(setting, 'changed')) \
+                if (setting['value'] != '' or (hasattr(setting, 'changed') and not hasattr(setting, 'notempty'))) \
                    and (not 'parent' in setting or ('parent' in setting and self.struct[category]['settings'][setting['parent']['entry']]['value'] \
                                                     in setting['parent']['value'])):
                     if setting['dbus'] == 'Array':

--- a/src/resources/lib/modules/connman.py
+++ b/src/resources/lib/modules/connman.py
@@ -376,8 +376,9 @@ class connmanService(object):
                 postfix = '.Configuration'
             for entry in sorted(self.struct[category]['settings'], key=lambda x: self.struct[category]['settings'][x]['order']):
                 setting = self.struct[category]['settings'][entry]
-                if (setting['value'] != '' or hasattr(setting, 'changed')) and not 'parent' in setting or 'parent' in setting \
-                    and self.struct[category]['settings'][setting['parent']['entry']]['value'] in setting['parent']['value']:
+                if (setting['value'] != '' or hasattr(setting, 'changed')) \
+                   and (not 'parent' in setting or ('parent' in setting and self.struct[category]['settings'][setting['parent']['entry']]['value'] \
+                                                    in setting['parent']['value'])):
                     if setting['dbus'] == 'Array':
                         value = dbus.Array(dbus.String(setting['value'], variant_level=1).split(','), signature=dbus.Signature('s'),
                                            variant_level=1)

--- a/src/resources/lib/oeWindows.py
+++ b/src/resources/lib/oeWindows.py
@@ -297,6 +297,8 @@ class mainWindow(xbmcgui.WindowXMLDialog):
                     if returnValue != '' and returnValue != '/':
                         selectedItem.setProperty('value', unicode(returnValue))
                 elif strTyp == 'ip':
+                    if strValue == '':
+                        strValue = '0.0.0.0'
                     xbmcDialog = xbmcgui.Dialog()
                     returnValue = xbmcDialog.numeric(3, 'LibreELEC.tv', strValue)
                     if returnValue != '':


### PR DESCRIPTION
When i.e. Default Gateway is omitted the address is not set [(see forum)](https://forum.libreelec.tv/thread/22441-can-not-manual-set-ip-address/). The error reported by connman is `Invalid arguments`:

```
2020-08-07 00:29:33.440 T:139995591505664   ERROR: ## LibreELEC Addon ## connmanService::save_network ## ERROR: (DBusException('Invalid arguments',))
2020-08-07 00:29:33.442 T:139995591505664   ERROR: Traceback (most recent call last):
                                              File "/storage/.kodi/addons/service.libreelec.settings/resources/lib/modules/connman.py", line 426, in save_network
                                                self.service.SetProperty(dbus.String(category), value)
                                              File "/usr/lib/python2.7/site-packages/dbus/proxies.py", line 145, in __call__
                                              File "/usr/lib/python2.7/site-packages/dbus/connection.py", line 651, in call_blocking
                                            DBusException: net.connman.Error.InvalidArguments: Invalid arguments
```

According to the [connman docu](https://git.kernel.org/pub/scm/network/connman/connman.git/tree/doc/advanced-configuration.txt?h=1.38#n56) the fields can be omitted but must not be empty.

First commit is fixing an and/or precedence error in parent setting test.

Second commit is adding a optional `notempty` attribute.

Third commit is a cosmetic change presetting an empty address with 0.0.0.0

Backport of #165