### PR TITLE
Fix wizard language selection

### DIFF
--- a/src/oe.py
+++ b/src/oe.py
@@ -282,8 +282,8 @@ def _(code):
         curLang = read_setting("system", "language")
         if curLang is not None:
             lang_file = os.path.join(__cwd__, 'resources', 'language', str(curLang), 'strings.po')
-            with open(lang_file) as fp:
-                contents = fp.read().decode('utf-8').split('\n\n')
+            with open(lang_file, encoding='utf-8') as fp:
+                contents = fp.read().split('\n\n')
                 for strings in contents:
                     if str(code) in strings:
                         subString = strings.split('msgstr ')[1]

--- a/src/resources/lib/oeWindows.py
+++ b/src/resources/lib/oeWindows.py
@@ -507,7 +507,7 @@ class wizard(xbmcgui.WindowXMLDialog):
                     break
                 else:
                     pass
-            selLanguage = xbmcDialog.select(self.oe._(32193), languagesList, preselect=langIndex)
+            selLanguage = xbmcDialog.select(self.oe._(32310), languagesList, preselect=langIndex)
             if selLanguage >= 0:
                 langKey = languagesList[selLanguage]
                 lang_new = langCodes[langKey]


### PR DESCRIPTION
As reported in the [forum](https://forum.libreelec.tv/thread/21832-libreelec-wizard/) Language selection in nightly builds is crashing when selecting any language with non-ASCII UTF-8 characters.

Open the file in UTF-8 mode and remove function str.decode('UTF-8') not existing in Python 3.

Second commit is fixing dialog title from "Enable LibreELEC Settings PIN Lock" to "Language:"
