### PR TITLE
Fix title (msg ID) of wizard language select dialog

### DIFF
--- a/src/resources/lib/oeWindows.py
+++ b/src/resources/lib/oeWindows.py
@@ -506,7 +506,7 @@ class wizard(xbmcgui.WindowXMLDialog):
                     break
                 else:
                     pass
-            selLanguage = xbmcDialog.select(self.oe._(32193), languagesList, preselect=langIndex)
+            selLanguage = xbmcDialog.select(self.oe._(32310), languagesList, preselect=langIndex)
             if selLanguage >= 0:
                 langKey = languagesList[selLanguage]
                 lang_new = langCodes[langKey]


### PR DESCRIPTION
Replace "Enable LibreELEC Settings PIN Lock" with "Language:"

Partial backport of #167