### PR TITLE
Remove connman network cache on connection error

### DIFF
--- a/src/resources/lib/modules/connman.py
+++ b/src/resources/lib/modules/connman.py
@@ -1242,6 +1242,8 @@ class connman:
             if listItem == None:
                 listItem = self.oe.winOeMain.getControl(self.oe.listObject['netlist']).getSelectedItem()
             service_object = self.oe.dbusSystemBus.get_object('net.connman', listItem.getProperty('entry'))
+            global try_service_path
+            try_service_path = listItem.getProperty('entry')
             dbus.Interface(service_object, 'net.connman.Service').Connect(reply_handler=self.connect_reply_handler,
                     error_handler=self.dbus_error_handler)
             service_object = None
@@ -1282,6 +1284,9 @@ class connman:
                     else:
                         self.log_error = 1
                         self.notify_error = 1
+                        clean_service_path = try_service_path.split('/')
+                        wifi_cache = 'rm -rf /storage/.cache/connman/' + clean_service_path[-1]
+                        self.oe.execute(str(wifi_cache))
                 elif 'Did not receive a reply' in err_message:
                     self.log_error = 1
                     self.notify_error = 0


### PR DESCRIPTION
Fixes an issue where if the wifi PSK is entered incorrectly, the network config info is not removed from the cache which blocks the ability to enter the correct PSK.

This was tested on LE 9.2.4 for RPi3.

If @MilhouseVH wants to add to nightlies - perhaps the originator of the issue (arminfuerst) can test.
https://github.com/LibreELEC/LibreELEC.tv/issues/4534