### PR TITLE
Use symbolic log level definitions instead of numbers

### DIFF
--- a/src/oe.py
+++ b/src/oe.py
@@ -26,6 +26,8 @@ import hashlib, binascii
 from xml.dom import minidom
 import imp
 
+from xbmc import LOGDEBUG, LOGINFO, LOGWARNING, LOGERROR
+
 __author__ = 'LibreELEC'
 __scriptid__ = 'service.libreelec.settings'
 __addon__ = xbmcaddon.Addon(id=__scriptid__)
@@ -310,7 +312,7 @@ def dbg_log(source, text, level=4):
 
 def notify(title, message, icon='icon'):
     try:
-        dbg_log('oe::notify', 'enter_function', 0)
+        dbg_log('oe::notify', 'enter_function', LOGDEBUG)
         msg = 'Notification("%s", "%s", 5000, "%s/%s.png")' % (
             title,
             message[0:64],
@@ -318,15 +320,15 @@ def notify(title, message, icon='icon'):
             icon,
             )
         xbmc.executebuiltin(msg)
-        dbg_log('oe::notify', 'exit_function', 0)
+        dbg_log('oe::notify', 'exit_function', LOGDEBUG)
     except Exception as e:
         dbg_log('oe::notify', 'ERROR: (' + repr(e) + ')')
 
 
 def execute(command_line, get_result=0):
     try:
-        dbg_log('oe::execute', 'enter_function', 0)
-        dbg_log('oe::execute::command', command_line, 0)
+        dbg_log('oe::execute', 'enter_function', LOGDEBUG)
+        dbg_log('oe::execute::command', command_line, LOGDEBUG)
         if get_result == 0:
             process = subprocess.Popen(command_line, shell=True, close_fds=True)
             process.wait()
@@ -337,7 +339,7 @@ def execute(command_line, get_result=0):
             for line in process.stdout.readlines():
                 result = result + line.decode('utf-8')
             return result
-        dbg_log('oe::execute', 'exit_function', 0)
+        dbg_log('oe::execute', 'exit_function', LOGDEBUG)
     except Exception as e:
         dbg_log('oe::execute', 'ERROR: (' + repr(e) + ')')
 
@@ -404,10 +406,10 @@ def get_service_state(service):
 
 def set_service(service, options, state):
     try:
-        dbg_log('oe::set_service', 'enter_function', 0)
-        dbg_log('oe::set_service::service', repr(service), 0)
-        dbg_log('oe::set_service::options', repr(options), 0)
-        dbg_log('oe::set_service::state', repr(state), 0)
+        dbg_log('oe::set_service', 'enter_function', LOGDEBUG)
+        dbg_log('oe::set_service::service', repr(service), LOGDEBUG)
+        dbg_log('oe::set_service::options', repr(options), LOGDEBUG)
+        dbg_log('oe::set_service::state', repr(state), LOGDEBUG)
         config = {}
         changed = False
 
@@ -440,7 +442,7 @@ def set_service(service, options, state):
             if service in defaults._services:
                 for svc in defaults._services[service]:
                     execute('systemctl restart %s' % svc)
-        dbg_log('oe::set_service', 'exit_function', 0)
+        dbg_log('oe::set_service', 'exit_function', LOGDEBUG)
     except Exception as e:
         dbg_log('oe::set_service', 'ERROR: (' + repr(e) + ')')
 
@@ -576,9 +578,9 @@ def set_busy(state):
                 __busy__ = __busy__ + 1
             else:
                 __busy__ = __busy__ - 1
-            dbg_log('oe::set_busy', '__busy__ = ' + str(__busy__), 0)
+            dbg_log('oe::set_busy', '__busy__ = ' + str(__busy__), LOGDEBUG)
     except Exception as e:
-        dbg_log('oe::set_busy', 'ERROR: (' + repr(e) + ')', 4)
+        dbg_log('oe::set_busy', 'ERROR: (' + repr(e) + ')', LOGERROR)
 
 
 def start_service():

--- a/src/resources/lib/modules/about.py
+++ b/src/resources/lib/modules/about.py
@@ -15,55 +15,55 @@ class about:
 
     def __init__(self, oeMain):
         try:
-            oeMain.dbg_log('about::__init__', 'enter_function', 0)
+            oeMain.dbg_log('about::__init__', 'enter_function', oeMain.LOGDEBUG)
             self.oe = oeMain
             self.controls = {}
-            self.oe.dbg_log('about::__init__', 'exit_function', 0)
+            self.oe.dbg_log('about::__init__', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.dbg_log('about::__init__', 'ERROR: (' + repr(e) + ')')
 
     def menu_loader(self, menuItem):
         try:
-            self.oe.dbg_log('about::menu_loader', 'enter_function', 0)
+            self.oe.dbg_log('about::menu_loader', 'enter_function', self.oe.LOGDEBUG)
             if len(self.controls) == 0:
                 self.init_controls()
-            self.oe.dbg_log('about::menu_loader', 'exit_function', 0)
+            self.oe.dbg_log('about::menu_loader', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('about::menu_loader', 'ERROR: (' + repr(e) + ')', 4)
+            self.oe.dbg_log('about::menu_loader', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
     def exit_addon(self):
         try:
-            self.oe.dbg_log('about::exit_addon', 'enter_function', 0)
+            self.oe.dbg_log('about::exit_addon', 'enter_function', self.oe.LOGDEBUG)
             self.oe.winOeMain.close()
-            self.oe.dbg_log('about::exit_addon', 'exit_function', 0)
+            self.oe.dbg_log('about::exit_addon', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.dbg_log('about::exit_addon', 'ERROR: (' + repr(e) + ')')
 
     def init_controls(self):
         try:
-            self.oe.dbg_log('about::init_controls', 'enter_function', 0)
-            self.oe.dbg_log('about::init_controls', 'exit_function', 0)
+            self.oe.dbg_log('about::init_controls', 'enter_function', self.oe.LOGDEBUG)
+            self.oe.dbg_log('about::init_controls', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.dbg_log('about::init_controls', 'ERROR: (' + repr(e) + ')')
 
     def exit(self):
         try:
-            self.oe.dbg_log('about::exit', 'enter_function', 0)
+            self.oe.dbg_log('about::exit', 'enter_function', self.oe.LOGDEBUG)
             for control in self.controls:
                 try:
                     self.oe.winOeMain.removeControl(self.controls[control])
                 except:
                     pass
             self.controls = {}
-            self.oe.dbg_log('about::exit', 'exit_function', 0)
+            self.oe.dbg_log('about::exit', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.dbg_log('about::exit', 'ERROR: (' + repr(e) + ')')
 
     def do_wizard(self):
         try:
-            self.oe.dbg_log('about::do_wizard', 'enter_function', 0)
+            self.oe.dbg_log('about::do_wizard', 'enter_function', self.oe.LOGDEBUG)
             self.oe.winOeMain.set_wizard_title(self.oe._(32317))
             self.oe.winOeMain.set_wizard_text(self.oe._(32318))
-            self.oe.dbg_log('about::do_wizard', 'exit_function', 0)
+            self.oe.dbg_log('about::do_wizard', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.dbg_log('about::do_wizard', 'ERROR: (' + repr(e) + ')')

--- a/src/resources/lib/modules/bluetooth.py
+++ b/src/resources/lib/modules/bluetooth.py
@@ -30,35 +30,35 @@ class bluetooth:
 
     def __init__(self, oeMain):
         try:
-            oeMain.dbg_log('bluetooth::__init__', 'enter_function', 0)
+            oeMain.dbg_log('bluetooth::__init__', 'enter_function', oeMain.LOGDEBUG)
             self.oe = oeMain
             self.visible = False
             self.listItems = {}
             self.dbusBluezAdapter = None
-            self.oe.dbg_log('bluetooth::__init__', 'exit_function', 0)
+            self.oe.dbg_log('bluetooth::__init__', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('bluetooth::__init__', 'ERROR: (' + repr(e) + ')', 4)
+            self.oe.dbg_log('bluetooth::__init__', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
     def do_init(self):
         try:
-            self.oe.dbg_log('bluetooth::do_init', 'enter_function', 0)
+            self.oe.dbg_log('bluetooth::do_init', 'enter_function', self.oe.LOGDEBUG)
             self.visible = True
-            self.oe.dbg_log('bluetooth::do_init', 'exit_function', 0)
+            self.oe.dbg_log('bluetooth::do_init', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('bluetooth::do_init', 'ERROR: (' + repr(e) + ')', 4)
+            self.oe.dbg_log('bluetooth::do_init', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
     def start_service(self):
         try:
-            self.oe.dbg_log('bluetooth::start_service', 'enter_function', 0)
+            self.oe.dbg_log('bluetooth::start_service', 'enter_function', self.oe.LOGDEBUG)
             if 'org.bluez' in self.oe.dbusSystemBus.list_names():
                 self.init_adapter()
-            self.oe.dbg_log('bluetooth::start_service', 'exit_function', 0)
+            self.oe.dbg_log('bluetooth::start_service', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('bluetooth::start_service', 'ERROR: (' + repr(e) + ')', 4)
+            self.oe.dbg_log('bluetooth::start_service', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
     def stop_service(self):
         try:
-            self.oe.dbg_log('bluetooth::stop_service', 'enter_function', 0)
+            self.oe.dbg_log('bluetooth::stop_service', 'enter_function', self.oe.LOGDEBUG)
             if hasattr(self, 'discovery_thread'):
                 try:
                     self.discovery_thread.stop()
@@ -67,13 +67,13 @@ class bluetooth:
                     pass
             if hasattr(self, 'dbusBluezAdapter'):
                 self.dbusBluezAdapter = None
-            self.oe.dbg_log('bluetooth::stop_service', 'exit_function', 0)
+            self.oe.dbg_log('bluetooth::stop_service', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('bluetooth::stop_service', 'ERROR: (' + repr(e) + ')', 4)
+            self.oe.dbg_log('bluetooth::stop_service', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
     def exit(self):
         try:
-            self.oe.dbg_log('bluetooth::exit', 'enter_function', 0)
+            self.oe.dbg_log('bluetooth::exit', 'enter_function', self.oe.LOGDEBUG)
             if hasattr(self, 'discovery_thread'):
                 try:
                     self.discovery_thread.stop()
@@ -82,10 +82,10 @@ class bluetooth:
                     pass
             self.clear_list()
             self.visible = False
-            self.oe.dbg_log('bluetooth::exit', 'exit_function', 0)
+            self.oe.dbg_log('bluetooth::exit', 'exit_function', self.oe.LOGDEBUG)
             pass
         except Exception as e:
-            self.oe.dbg_log('bluetooth::exit', 'ERROR: (' + repr(e) + ')', 4)
+            self.oe.dbg_log('bluetooth::exit', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
     # ###################################################################
     # # Bluetooth Adapter
@@ -93,7 +93,7 @@ class bluetooth:
 
     def init_adapter(self):
         try:
-            self.oe.dbg_log('bluetooth::init_adapter', 'enter_function', 0)
+            self.oe.dbg_log('bluetooth::init_adapter', 'enter_function', self.oe.LOGDEBUG)
             dbusBluezManager = dbus.Interface(self.oe.dbusSystemBus.get_object('org.bluez', '/'), 'org.freedesktop.DBus.ObjectManager')
             dbusManagedObjects = dbusBluezManager.GetManagedObjects()
             for (path, ifaces) in dbusManagedObjects.items():
@@ -105,64 +105,64 @@ class bluetooth:
             dbusBluezManager = None
             if self.dbusBluezAdapter != None:
                 self.adapter_powered(self.dbusBluezAdapter, 1)
-            self.oe.dbg_log('bluetooth::init_adapter', 'exit_function', 0)
+            self.oe.dbg_log('bluetooth::init_adapter', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.dbg_log('bluetooth::init_adapter', 'ERROR: (' + repr(e) + ')')
 
     def adapter_powered(self, adapter, state=1):
         try:
-            self.oe.dbg_log('bluetooth::adapter_powered', 'enter_function', 0)
-            self.oe.dbg_log('bluetooth::adapter_powered::adapter', repr(adapter), 0)
-            self.oe.dbg_log('bluetooth::adapter_powered::state', repr(state), 0)
+            self.oe.dbg_log('bluetooth::adapter_powered', 'enter_function', self.oe.LOGDEBUG)
+            self.oe.dbg_log('bluetooth::adapter_powered::adapter', repr(adapter), self.oe.LOGDEBUG)
+            self.oe.dbg_log('bluetooth::adapter_powered::state', repr(state), self.oe.LOGDEBUG)
             if int(self.adapter_info(self.dbusBluezAdapter, 'Powered')) != state:
-                self.oe.dbg_log('bluetooth::adapter_powered', 'set state (' + str(state) + ')', 0)
+                self.oe.dbg_log('bluetooth::adapter_powered', 'set state (' + str(state) + ')', self.oe.LOGDEBUG)
                 adapter_interface = dbus.Interface(self.oe.dbusSystemBus.get_object('org.bluez', adapter.object_path),
                                                    'org.freedesktop.DBus.Properties')
                 adapter_interface.Set('org.bluez.Adapter1', 'Alias', dbus.String(os.environ.get('HOSTNAME', 'libreelec')))
                 adapter_interface.Set('org.bluez.Adapter1', 'Powered', dbus.Boolean(state))
                 adapter_interface = None
-            self.oe.dbg_log('bluetooth::adapter_powered', 'exit_function', 0)
+            self.oe.dbg_log('bluetooth::adapter_powered', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('bluetooth::adapter_powered', 'ERROR: (' + repr(e) + ')', 4)
+            self.oe.dbg_log('bluetooth::adapter_powered', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
     def adapter_info(self, adapter, name):
         try:
-            self.oe.dbg_log('bluetooth::adapter_info', 'enter_function', 0)
-            self.oe.dbg_log('bluetooth::adapter_info::adapter', repr(adapter), 0)
-            self.oe.dbg_log('bluetooth::adapter_info::name', repr(name), 0)
+            self.oe.dbg_log('bluetooth::adapter_info', 'enter_function', self.oe.LOGDEBUG)
+            self.oe.dbg_log('bluetooth::adapter_info::adapter', repr(adapter), self.oe.LOGDEBUG)
+            self.oe.dbg_log('bluetooth::adapter_info::name', repr(name), self.oe.LOGDEBUG)
             adapter_interface = dbus.Interface(self.oe.dbusSystemBus.get_object('org.bluez', adapter.object_path),
                                                'org.freedesktop.DBus.Properties')
             res = adapter_interface.Get('org.bluez.Adapter1', name)
             adapter_interface = None
-            self.oe.dbg_log('bluetooth::adapter_info', 'exit_function', 0)
+            self.oe.dbg_log('bluetooth::adapter_info', 'exit_function', self.oe.LOGDEBUG)
             return res
         except Exception as e:
-            self.oe.dbg_log('bluetooth::adapter_info', 'ERROR: (' + repr(e) + ')', 4)
+            self.oe.dbg_log('bluetooth::adapter_info', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
     def start_discovery(self, listItem=None):
         try:
-            self.oe.dbg_log('bluetooth::start_discovery', 'enter_function', 0)
+            self.oe.dbg_log('bluetooth::start_discovery', 'enter_function', self.oe.LOGDEBUG)
             self.oe.set_busy(1)
             self.dbusBluezAdapter.StartDiscovery()
             self.discovering = True
             self.oe.set_busy(0)
-            self.oe.dbg_log('bluetooth::start_discovery', 'exit_function', 0)
+            self.oe.dbg_log('bluetooth::start_discovery', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.set_busy(0)
-            self.oe.dbg_log('bluetooth::start_discovery', 'ERROR: (' + repr(e) + ')', 4)
+            self.oe.dbg_log('bluetooth::start_discovery', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
     def stop_discovery(self, listItem=None):
         try:
-            self.oe.dbg_log('bluetooth::stop_discovery', 'enter_function', 0)
+            self.oe.dbg_log('bluetooth::stop_discovery', 'enter_function', self.oe.LOGDEBUG)
             self.oe.set_busy(1)
             if hasattr(self, 'discovering'):
                 del self.discovering
                 self.dbusBluezAdapter.StopDiscovery()
             self.oe.set_busy(0)
-            self.oe.dbg_log('bluetooth::stop_discovery', 'exit_function', 0)
+            self.oe.dbg_log('bluetooth::stop_discovery', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.set_busy(0)
-            self.oe.dbg_log('bluetooth::stop_discovery', 'ERROR: (' + repr(e) + ')', 4)
+            self.oe.dbg_log('bluetooth::stop_discovery', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
     # ###################################################################
     # # Bluetooth Device
@@ -170,7 +170,7 @@ class bluetooth:
 
     def get_devices(self):
         try:
-            self.oe.dbg_log('bluetooth::get_devices', 'enter_function', 0)
+            self.oe.dbg_log('bluetooth::get_devices', 'enter_function', self.oe.LOGDEBUG)
             devices = {}
             dbusBluezManager = dbus.Interface(self.oe.dbusSystemBus.get_object('org.bluez', '/'), 'org.freedesktop.DBus.ObjectManager')
             managedObjects = dbusBluezManager.GetManagedObjects()
@@ -179,14 +179,14 @@ class bluetooth:
                     devices[path] = interfaces['org.bluez.Device1']
             managedObjects = None
             dbusBluezManager = None
-            self.oe.dbg_log('bluetooth::get_devices', 'exit_function', 0)
+            self.oe.dbg_log('bluetooth::get_devices', 'exit_function', self.oe.LOGDEBUG)
             return devices
         except Exception as e:
-            self.oe.dbg_log('bluetooth::get_devices::__init__', 'ERROR: (' + repr(e) + ')', 4)
+            self.oe.dbg_log('bluetooth::get_devices::__init__', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
     def init_device(self, listItem=None):
         try:
-            self.oe.dbg_log('bluetooth::init_device', 'exit_function', 0)
+            self.oe.dbg_log('bluetooth::init_device', 'exit_function', self.oe.LOGDEBUG)
             if listItem is None:
                 listItem = self.oe.winOeMain.getControl(self.oe.listObject['btlist']).getSelectedItem()
             if listItem is None:
@@ -195,9 +195,9 @@ class bluetooth:
                 self.pair_device(listItem.getProperty('entry'))
             else:
                 self.connect_device(listItem.getProperty('entry'))
-            self.oe.dbg_log('bluetooth::init_device', 'exit_function', 0)
+            self.oe.dbg_log('bluetooth::init_device', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('bluetooth::init_device', 'ERROR: (' + repr(e) + ')', 4)
+            self.oe.dbg_log('bluetooth::init_device', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
     def trust_connect_device(self, listItem=None):
         try:
@@ -206,20 +206,20 @@ class bluetooth:
             # # This function is used to Pair PS3 Remote without auth
             # ########################################################
 
-            self.oe.dbg_log('bluetooth::trust_connect_device', 'exit_function', 0)
+            self.oe.dbg_log('bluetooth::trust_connect_device', 'exit_function', self.oe.LOGDEBUG)
             if listItem is None:
                 listItem = self.oe.winOeMain.getControl(self.oe.listObject['btlist']).getSelectedItem()
             if listItem is None:
                 return
             self.trust_device(listItem.getProperty('entry'))
             self.connect_device(listItem.getProperty('entry'))
-            self.oe.dbg_log('bluetooth::trust_connect_device', 'exit_function', 0)
+            self.oe.dbg_log('bluetooth::trust_connect_device', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('bluetooth::trust_connect_device', 'ERROR: (' + repr(e) + ')', 4)
+            self.oe.dbg_log('bluetooth::trust_connect_device', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
     def enable_device_standby(self, listItem=None):
         try:
-            self.oe.dbg_log('bluetooth::enable_device_standby', 'exit_function', 0)
+            self.oe.dbg_log('bluetooth::enable_device_standby', 'exit_function', self.oe.LOGDEBUG)
             devices = self.oe.read_setting('bluetooth', 'standby')
             if not devices == None:
                 devices = devices.split(',')
@@ -228,13 +228,13 @@ class bluetooth:
             if not listItem.getProperty('entry') in devices:
                 devices.append(listItem.getProperty('entry'))
             self.oe.write_setting('bluetooth', 'standby', ','.join(devices))
-            self.oe.dbg_log('bluetooth::enable_device_standby', 'exit_function', 0)
+            self.oe.dbg_log('bluetooth::enable_device_standby', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('bluetooth::enable_device_standby', 'ERROR: (' + repr(e) + ')', 4)
+            self.oe.dbg_log('bluetooth::enable_device_standby', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
     def disable_device_standby(self, listItem=None):
         try:
-            self.oe.dbg_log('bluetooth::disable_device_standby', 'exit_function', 0)
+            self.oe.dbg_log('bluetooth::disable_device_standby', 'exit_function', self.oe.LOGDEBUG)
             devices = self.oe.read_setting('bluetooth', 'standby')
             if not devices == None:
                 devices = devices.split(',')
@@ -243,26 +243,26 @@ class bluetooth:
             if listItem.getProperty('entry') in devices:
                 devices.remove(listItem.getProperty('entry'))
             self.oe.write_setting('bluetooth', 'standby', ','.join(devices))
-            self.oe.dbg_log('bluetooth::disable_device_standby', 'exit_function', 0)
+            self.oe.dbg_log('bluetooth::disable_device_standby', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('bluetooth::disable_device_standby', 'ERROR: (' + repr(e) + ')', 4)
+            self.oe.dbg_log('bluetooth::disable_device_standby', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
     def pair_device(self, path):
         try:
-            self.oe.dbg_log('bluetooth::pair_device', 'enter_function', 0)
-            self.oe.dbg_log('bluetooth::pair_device::path', repr(path), 0)
+            self.oe.dbg_log('bluetooth::pair_device', 'enter_function', self.oe.LOGDEBUG)
+            self.oe.dbg_log('bluetooth::pair_device::path', repr(path), self.oe.LOGDEBUG)
             self.oe.set_busy(1)
             device = dbus.Interface(self.oe.dbusSystemBus.get_object('org.bluez', path), 'org.bluez.Device1')
             device.Pair(reply_handler=self.pair_reply_handler, error_handler=self.dbus_error_handler)
             device = None
-            self.oe.dbg_log('bluetooth::pair_device', 'exit_function', 0)
+            self.oe.dbg_log('bluetooth::pair_device', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.set_busy(0)
-            self.oe.dbg_log('bluetooth::pair_device', 'ERROR: (' + repr(e) + ')', 4)
+            self.oe.dbg_log('bluetooth::pair_device', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
     def pair_reply_handler(self):
         try:
-            self.oe.dbg_log('bluetooth::pair_reply_handler', 'enter_function', 0)
+            self.oe.dbg_log('bluetooth::pair_reply_handler', 'enter_function', self.oe.LOGDEBUG)
             self.oe.set_busy(0)
             listItem = self.oe.winOeMain.getControl(self.oe.listObject['btlist']).getSelectedItem()
             if listItem is None:
@@ -270,114 +270,114 @@ class bluetooth:
             self.trust_device(listItem.getProperty('entry'))
             self.connect_device(listItem.getProperty('entry'))
             self.menu_connections()
-            self.oe.dbg_log('bluetooth::pair_reply_handler', 'exit_function', 0)
+            self.oe.dbg_log('bluetooth::pair_reply_handler', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('bluetooth::pair_reply_handler', 'ERROR: (' + repr(e) + ')', 4)
+            self.oe.dbg_log('bluetooth::pair_reply_handler', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
     def trust_device(self, path):
         try:
-            self.oe.dbg_log('bluetooth::trust_device', 'enter_function', 0)
-            self.oe.dbg_log('bluetooth::trust_device::path', repr(path), 0)
+            self.oe.dbg_log('bluetooth::trust_device', 'enter_function', self.oe.LOGDEBUG)
+            self.oe.dbg_log('bluetooth::trust_device::path', repr(path), self.oe.LOGDEBUG)
             self.oe.set_busy(1)
             prop = dbus.Interface(self.oe.dbusSystemBus.get_object('org.bluez', path), 'org.freedesktop.DBus.Properties')
             prop.Set('org.bluez.Device1', 'Trusted', dbus.Boolean(1))
             prop = None
             self.oe.set_busy(0)
-            self.oe.dbg_log('bluetooth::trust_device', 'exit_function', 0)
+            self.oe.dbg_log('bluetooth::trust_device', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.set_busy(0)
-            self.oe.dbg_log('bluetooth::trust_device', 'ERROR: (' + repr(e) + ')', 4)
+            self.oe.dbg_log('bluetooth::trust_device', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
     def is_device_connected(self, path):
         try:
-            self.oe.dbg_log('bluetooth::is_device_connected', 'enter_function', 0)
+            self.oe.dbg_log('bluetooth::is_device_connected', 'enter_function', self.oe.LOGDEBUG)
             self.oe.set_busy(1)
             props = dbus.Interface(self.oe.dbusSystemBus.get_object('org.bluez', path), 'org.freedesktop.DBus.Properties')
             res = props.Get('org.bluez.Device1', 'Connected')
             props = None
             self.oe.set_busy(0)
-            self.oe.dbg_log('bluetooth::is_device_connected', 'exit_function', 0)
+            self.oe.dbg_log('bluetooth::is_device_connected', 'exit_function', self.oe.LOGDEBUG)
             return res
         except Exception as e:
             self.oe.set_busy(0)
-            self.oe.dbg_log('bluetooth::is_device_connected', 'ERROR: (' + repr(e) + ')', 4)
+            self.oe.dbg_log('bluetooth::is_device_connected', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
     def connect_device(self, path):
         try:
-            self.oe.dbg_log('bluetooth::connect_device', 'enter_function', 0)
-            self.oe.dbg_log('bluetooth::connect_device::path', repr(path), 0)
+            self.oe.dbg_log('bluetooth::connect_device', 'enter_function', self.oe.LOGDEBUG)
+            self.oe.dbg_log('bluetooth::connect_device::path', repr(path), self.oe.LOGDEBUG)
             self.oe.set_busy(1)
             device = dbus.Interface(self.oe.dbusSystemBus.get_object('org.bluez', path), 'org.bluez.Device1')
             device.Connect(reply_handler=self.connect_reply_handler, error_handler=self.dbus_error_handler)
             device = None
-            self.oe.dbg_log('bluetooth::connect_device', 'exit_function', 0)
+            self.oe.dbg_log('bluetooth::connect_device', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.set_busy(0)
-            self.oe.dbg_log('bluetooth::connect_device', 'ERROR: (' + repr(e) + ')', 4)
+            self.oe.dbg_log('bluetooth::connect_device', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
     def connect_reply_handler(self):
         try:
-            self.oe.dbg_log('bluetooth::connect_reply_handler', 'enter_function', 0)
+            self.oe.dbg_log('bluetooth::connect_reply_handler', 'enter_function', self.oe.LOGDEBUG)
             self.oe.set_busy(0)
             self.menu_connections()
-            self.oe.dbg_log('bluetooth::connect_reply_handler', 'exit_function', 0)
+            self.oe.dbg_log('bluetooth::connect_reply_handler', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.set_busy(0)
-            self.oe.dbg_log('bluetooth::connect_reply_handler', 'ERROR: (' + repr(e) + ')', 4)
+            self.oe.dbg_log('bluetooth::connect_reply_handler', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
     def disconnect_device_by_path(self, path):
         try:
-            self.oe.dbg_log('bluetooth::disconnect_device_by_path', 'enter_function', 0)
+            self.oe.dbg_log('bluetooth::disconnect_device_by_path', 'enter_function', self.oe.LOGDEBUG)
             self.oe.set_busy(1)
             device = dbus.Interface(self.oe.dbusSystemBus.get_object('org.bluez', path), 'org.bluez.Device1')
             device.Disconnect(reply_handler=self.disconnect_reply_handler, error_handler=self.dbus_error_handler)
             device = None
-            self.oe.dbg_log('bluetooth::disconnect_device_by_path', 'exit_function', 0)
+            self.oe.dbg_log('bluetooth::disconnect_device_by_path', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.set_busy(0)
-            self.oe.dbg_log('bluetooth::disconnect_device_by_path', 'ERROR: (' + repr(e) + ')', 4)
+            self.oe.dbg_log('bluetooth::disconnect_device_by_path', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
     def disconnect_device_by(self, listItem=None):
         try:
-            self.oe.dbg_log('bluetooth::disconnect_device', 'enter_function', 0)
+            self.oe.dbg_log('bluetooth::disconnect_device', 'enter_function', self.oe.LOGDEBUG)
             if listItem is None:
                 listItem = self.oe.winOeMain.getControl(self.oe.listObject['btlist']).getSelectedItem()
             if listItem is None:
                 return
             self.disconnect_device_by_path(listItem.getProperty('entry'))
-            self.oe.dbg_log('bluetooth::disconnect_device', 'exit_function', 0)
+            self.oe.dbg_log('bluetooth::disconnect_device', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.set_busy(0)
-            self.oe.dbg_log('bluetooth::disconnect_device', 'ERROR: (' + repr(e) + ')', 4)
+            self.oe.dbg_log('bluetooth::disconnect_device', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
     def disconnect_reply_handler(self):
         try:
-            self.oe.dbg_log('bluetooth::disconnect_reply_handler', 'enter_function', 0)
+            self.oe.dbg_log('bluetooth::disconnect_reply_handler', 'enter_function', self.oe.LOGDEBUG)
             self.oe.set_busy(0)
             self.menu_connections()
-            self.oe.dbg_log('bluetooth::disconnect_reply_handler', 'exit_function', 0)
+            self.oe.dbg_log('bluetooth::disconnect_reply_handler', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.set_busy(0)
-            self.oe.dbg_log('bluetooth::disconnect_reply_handler', 'ERROR: (' + repr(e) + ')', 4)
+            self.oe.dbg_log('bluetooth::disconnect_reply_handler', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
     def remove_device(self, listItem=None):
         try:
-            self.oe.dbg_log('bluetooth::remove_device', 'enter_function', 0)
+            self.oe.dbg_log('bluetooth::remove_device', 'enter_function', self.oe.LOGDEBUG)
             if listItem is None:
                 listItem = self.oe.winOeMain.getControl(self.oe.listObject['btlist']).getSelectedItem()
             if listItem is None:
                 return
             self.oe.set_busy(1)
-            self.oe.dbg_log('bluetooth::remove_device->entry::', listItem.getProperty('entry'), 0)
+            self.oe.dbg_log('bluetooth::remove_device->entry::', listItem.getProperty('entry'), self.oe.LOGDEBUG)
             path = listItem.getProperty('entry')
             self.dbusBluezAdapter.RemoveDevice(path)
             self.disable_device_standby(listItem)
             self.menu_connections(None)
             self.oe.set_busy(0)
-            self.oe.dbg_log('bluetooth::remove_device', 'exit_function', 0)
+            self.oe.dbg_log('bluetooth::remove_device', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.set_busy(0)
-            self.oe.dbg_log('bluetooth::remove_device', 'ERROR: (' + repr(e) + ')', 4)
+            self.oe.dbg_log('bluetooth::remove_device', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
     # ###################################################################
     # # Bluetooth Error Handler
@@ -385,18 +385,18 @@ class bluetooth:
 
     def dbus_error_handler(self, error):
         try:
-            self.oe.dbg_log('bluetooth::dbus_error_handler', 'enter_function', 0)
-            self.oe.dbg_log('bluetooth::dbus_error_handler::error', repr(error), 0)
+            self.oe.dbg_log('bluetooth::dbus_error_handler', 'enter_function', self.oe.LOGDEBUG)
+            self.oe.dbg_log('bluetooth::dbus_error_handler::error', repr(error), self.oe.LOGDEBUG)
             self.oe.set_busy(0)
             err_message = error.get_dbus_message()
-            self.oe.dbg_log('bluetooth::dbus_error_handler::err_message', repr(err_message), 0)
+            self.oe.dbg_log('bluetooth::dbus_error_handler::err_message', repr(err_message), self.oe.LOGDEBUG)
             self.oe.notify('Bluetooth error', err_message.split('.')[0], 'bt')
             if hasattr(self, 'pinkey_window'):
                 self.close_pinkey_window()
-            self.oe.dbg_log('bluetooth::dbus_error_handler', 'ERROR: (' + err_message + ')', 4)
-            self.oe.dbg_log('bluetooth::dbus_error_handler', 'exit_function', 0)
+            self.oe.dbg_log('bluetooth::dbus_error_handler', 'ERROR: (' + err_message + ')', self.oe.LOGERROR)
+            self.oe.dbg_log('bluetooth::dbus_error_handler', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('bluetooth::dbus_error_handler', 'ERROR: (' + repr(e) + ')', 4)
+            self.oe.dbg_log('bluetooth::dbus_error_handler', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
     # ###################################################################
     # # Bluetooth GUI
@@ -404,13 +404,13 @@ class bluetooth:
 
     def clear_list(self):
         try:
-            self.oe.dbg_log('bluetooth::clear_list', 'enter_function', 0)
+            self.oe.dbg_log('bluetooth::clear_list', 'enter_function', self.oe.LOGDEBUG)
             remove = [entry for entry in self.listItems]
             for entry in remove:
                 del self.listItems[entry]
-            self.oe.dbg_log('bluetooth::clear_list', 'exit_function', 0)
+            self.oe.dbg_log('bluetooth::clear_list', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('bluetooth::clear_list', 'ERROR: (' + repr(e) + ')', 4)
+            self.oe.dbg_log('bluetooth::clear_list', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
     def menu_connections(self, focusItem=None):
         try:
@@ -420,24 +420,24 @@ class bluetooth:
                 return 0
             if not self.oe.winOeMain.visible:
                 return 0
-            self.oe.dbg_log('bluetooth::menu_connections', 'enter_function', 0)
+            self.oe.dbg_log('bluetooth::menu_connections', 'enter_function', self.oe.LOGDEBUG)
             if not 'org.bluez' in self.oe.dbusSystemBus.list_names():
                 self.oe.winOeMain.getControl(1301).setLabel(self.oe._(32346))
                 self.clear_list()
                 self.oe.winOeMain.getControl(int(self.oe.listObject['btlist'])).reset()
-                self.oe.dbg_log('bluetooth::menu_connections', 'exit_function (BT Disabled)', 0)
+                self.oe.dbg_log('bluetooth::menu_connections', 'exit_function (BT Disabled)', self.oe.LOGDEBUG)
                 return
             if self.dbusBluezAdapter == None:
                 self.oe.winOeMain.getControl(1301).setLabel(self.oe._(32338))
                 self.clear_list()
                 self.oe.winOeMain.getControl(int(self.oe.listObject['btlist'])).reset()
-                self.oe.dbg_log('bluetooth::menu_connections', 'exit_function (No Adapter)', 0)
+                self.oe.dbg_log('bluetooth::menu_connections', 'exit_function (No Adapter)', self.oe.LOGDEBUG)
                 return
             if int(self.adapter_info(self.dbusBluezAdapter, 'Powered')) != 1:
                 self.oe.winOeMain.getControl(1301).setLabel(self.oe._(32338))
                 self.clear_list()
                 self.oe.winOeMain.getControl(int(self.oe.listObject['btlist'])).reset()
-                self.oe.dbg_log('bluetooth::menu_connections', 'exit_function (No Adapter Powered)', 0)
+                self.oe.dbg_log('bluetooth::menu_connections', 'exit_function (No Adapter Powered)', self.oe.LOGDEBUG)
                 return
             self.oe.winOeMain.getControl(1301).setLabel(self.oe._(32339))
             if not hasattr(self, 'discovery_thread'):
@@ -527,13 +527,13 @@ class bluetooth:
                         self.listItems[dbusDevice].setLabel(apName)
                         for dictProperty in dictProperties:
                             self.listItems[dbusDevice].setProperty(dictProperty, dictProperties[dictProperty])
-            self.oe.dbg_log('bluetooth::menu_connections', 'exit_function', 0)
+            self.oe.dbg_log('bluetooth::menu_connections', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('bluetooth::menu_connections', 'ERROR: (' + repr(e) + ')', 4)
+            self.oe.dbg_log('bluetooth::menu_connections', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
     def open_context_menu(self, listItem):
         try:
-            self.oe.dbg_log('bluetooth::show_options', 'enter_function', 0)
+            self.oe.dbg_log('bluetooth::show_options', 'enter_function', self.oe.LOGDEBUG)
             values = {}
             if listItem is None:
                 listItem = self.oe.winOeMain.getControl(self.oe.listObject['btlist']).getSelectedItem()
@@ -595,25 +595,25 @@ class bluetooth:
             result = select_window.select(title, items)
             if result >= 0:
                 getattr(self, actions[result])(listItem)
-            self.oe.dbg_log('bluetooth::show_options', 'exit_function', 0)
+            self.oe.dbg_log('bluetooth::show_options', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('bluetooth::show_options', 'ERROR: (' + repr(e) + ')', 4)
+            self.oe.dbg_log('bluetooth::show_options', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
     def open_pinkey_window(self, runtime=60, title=32343):
         try:
-            self.oe.dbg_log('bluetooth::open_pinkey_window', 'enter_function', 0)
+            self.oe.dbg_log('bluetooth::open_pinkey_window', 'enter_function', self.oe.LOGDEBUG)
             self.pinkey_window = oeWindows.pinkeyWindow('service-LibreELEC-Settings-getPasskey.xml', self.oe.__cwd__, 'Default')
             self.pinkey_window.show()
             self.pinkey_window.set_title(self.oe._(title))
             self.pinkey_timer = pinkeyTimer(self, runtime)
             self.pinkey_timer.start()
-            self.oe.dbg_log('bluetooth::open_pinkey_window', 'exit_function', 0)
+            self.oe.dbg_log('bluetooth::open_pinkey_window', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('bluetooth::open_pinkey_window', 'ERROR: (' + repr(e) + ')', 4)
+            self.oe.dbg_log('bluetooth::open_pinkey_window', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
     def close_pinkey_window(self):
         try:
-            self.oe.dbg_log('bluetooth::close_pinkey_window', 'enter_function', 0)
+            self.oe.dbg_log('bluetooth::close_pinkey_window', 'enter_function', self.oe.LOGDEBUG)
             if hasattr(self, 'pinkey_timer'):
                 self.pinkey_timer.stop()
                 self.pinkey_timer = None
@@ -622,13 +622,13 @@ class bluetooth:
                 self.pinkey_window.close()
                 self.pinkey_window = None
                 del self.pinkey_window
-            self.oe.dbg_log('bluetooth::close_pinkey_window', 'exit_function', 0)
+            self.oe.dbg_log('bluetooth::close_pinkey_window', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('bluetooth::close_pinkey_window', 'ERROR: (' + repr(e) + ')', 4)
+            self.oe.dbg_log('bluetooth::close_pinkey_window', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
     def standby_devices(self):
         try:
-            self.oe.dbg_log('bluetooth::standby_devices', 'enter_function', 0)
+            self.oe.dbg_log('bluetooth::standby_devices', 'enter_function', self.oe.LOGDEBUG)
             if self.dbusBluezAdapter != None:
                 devices = self.oe.read_setting('bluetooth', 'standby')
                 if not devices == None:
@@ -637,9 +637,9 @@ class bluetooth:
                         if self.is_device_connected(device):
                             self.disconnect_device_by_path(device)
                     self.oe.input_request = False
-            self.oe.dbg_log('bluetooth::standby_devices', 'exit_function', 0)
+            self.oe.dbg_log('bluetooth::standby_devices', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('bluetooth::standby_devices', 'ERROR: (' + repr(e) + ')', 4)
+            self.oe.dbg_log('bluetooth::standby_devices', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
     # ###################################################################
     # # Bluetooth monitor and agent subclass
@@ -649,7 +649,7 @@ class bluetooth:
 
         def __init__(self, oeMain, parent):
             try:
-                oeMain.dbg_log('bluetooth::monitor::__init__', 'enter_function', 0)
+                oeMain.dbg_log('bluetooth::monitor::__init__', 'enter_function', oeMain.LOGDEBUG)
                 self.oe = oeMain
                 self.signal_receivers = []
                 self.NameOwnerWatch = None
@@ -657,13 +657,13 @@ class bluetooth:
                 self.btAgentPath = '/LibreELEC/bt_agent'
                 self.obAgentPath = '/LibreELEC/ob_agent'
                 self.parent = parent
-                self.oe.dbg_log('bluetooth::monitor::__init__', 'exit_function', 0)
+                self.oe.dbg_log('bluetooth::monitor::__init__', 'exit_function', self.oe.LOGDEBUG)
             except Exception as e:
                 self.oe.dbg_log('bluetooth::monitor::__init__', 'ERROR: (' + repr(e) + ')')
 
         def add_signal_receivers(self):
             try:
-                self.oe.dbg_log('bluetooth::monitor::add_signal_receivers', 'enter_function', 0)
+                self.oe.dbg_log('bluetooth::monitor::add_signal_receivers', 'enter_function', self.oe.LOGDEBUG)
                 self.signal_receivers.append(self.oe.dbusSystemBus.add_signal_receiver(self.InterfacesAdded, bus_name='org.bluez',
                                              dbus_interface='org.freedesktop.DBus.ObjectManager', signal_name='InterfacesAdded'))
                 self.signal_receivers.append(self.oe.dbusSystemBus.add_signal_receiver(self.InterfacesRemoved, bus_name='org.bluez',
@@ -678,13 +678,13 @@ class bluetooth:
                                              dbus_interface='org.freedesktop.DBus.Properties', arg0='org.bluez.obex.Transfer1'))
                 self.NameOwnerWatch = self.oe.dbusSystemBus.watch_name_owner('org.bluez', self.bluezNameOwnerChanged)
                 self.ObexNameOwnerWatch = self.oe.dbusSystemBus.watch_name_owner('org.bluez.obex', self.bluezObexNameOwnerChanged)
-                self.oe.dbg_log('bluetooth::monitor::add_signal_receivers', 'exit_function', 0)
+                self.oe.dbg_log('bluetooth::monitor::add_signal_receivers', 'exit_function', self.oe.LOGDEBUG)
             except Exception as e:
-                self.oe.dbg_log('bluetooth::monitor::add_signal_receivers', 'ERROR: (' + repr(e) + ')', 4)
+                self.oe.dbg_log('bluetooth::monitor::add_signal_receivers', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
         def remove_signal_receivers(self):
             try:
-                self.oe.dbg_log('bluetooth::monitor::remove_signal_receivers', 'enter_function', 0)
+                self.oe.dbg_log('bluetooth::monitor::remove_signal_receivers', 'enter_function', self.oe.LOGDEBUG)
                 for signal_receiver in self.signal_receivers:
                     signal_receiver.remove()
                     signal_receiver = None
@@ -701,24 +701,24 @@ class bluetooth:
                     self.remove_obex_agent()
                 if hasattr(self, 'btAgent'):
                     self.remove_agent()
-                self.oe.dbg_log('bluetooth::monitor::remove_signal_receivers', 'exit_function', 0)
+                self.oe.dbg_log('bluetooth::monitor::remove_signal_receivers', 'exit_function', self.oe.LOGDEBUG)
             except Exception as e:
-                self.oe.dbg_log('bluetooth::monitor::remove_signal_receivers', 'ERROR: (' + repr(e) + ')', 4)
+                self.oe.dbg_log('bluetooth::monitor::remove_signal_receivers', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
         def bluezNameOwnerChanged(self, proxy):
             try:
-                self.oe.dbg_log('bluetooth::monitorLoop::bluezNameOwnerChanged', 'enter_function', 0)
+                self.oe.dbg_log('bluetooth::monitorLoop::bluezNameOwnerChanged', 'enter_function', self.oe.LOGDEBUG)
                 if proxy:
                     self.initialize_agent()
                 else:
                     self.remove_agent()
-                self.oe.dbg_log('bluetooth::monitor::bluezNameOwnerChanged', 'exit_function', 0)
+                self.oe.dbg_log('bluetooth::monitor::bluezNameOwnerChanged', 'exit_function', self.oe.LOGDEBUG)
             except Exception as e:
-                self.oe.dbg_log('bluetooth::monitor::bluezNameOwnerChanged', 'ERROR: (' + repr(e) + ')', 4)
+                self.oe.dbg_log('bluetooth::monitor::bluezNameOwnerChanged', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
         def initialize_agent(self):
             try:
-                self.oe.dbg_log('bluetooth::monitor::initialize_agent', 'enter_function', 0)
+                self.oe.dbg_log('bluetooth::monitor::initialize_agent', 'enter_function', self.oe.LOGDEBUG)
                 self.btAgent = bluetoothAgent(self.oe.dbusSystemBus, self.btAgentPath)
                 self.btAgent.oe = self.oe
                 self.btAgent.parent = self.parent
@@ -726,13 +726,13 @@ class bluetooth:
                 dbusBluezManager.RegisterAgent(self.btAgentPath, 'KeyboardDisplay')
                 dbusBluezManager.RequestDefaultAgent(self.btAgentPath)
                 dbusBluezManager = None
-                self.oe.dbg_log('bluetooth::monitor::initialize_agent', 'exit_function', 0)
+                self.oe.dbg_log('bluetooth::monitor::initialize_agent', 'exit_function', self.oe.LOGDEBUG)
             except Exception as e:
-                self.oe.dbg_log('bluetooth::monitor::initialize_agent', 'ERROR: (' + repr(e) + ')', 4)
+                self.oe.dbg_log('bluetooth::monitor::initialize_agent', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
         def remove_agent(self):
             try:
-                self.oe.dbg_log('bluetooth::monitor::remove_agent', 'enter_function', 0)
+                self.oe.dbg_log('bluetooth::monitor::remove_agent', 'enter_function', self.oe.LOGDEBUG)
                 if hasattr(self, 'btAgent'):
                     self.btAgent.remove_from_connection(self.oe.dbusSystemBus, self.btAgentPath)
                     try:
@@ -743,24 +743,24 @@ class bluetooth:
                         dbusBluezManager = None
                         pass
                     del self.btAgent
-                self.oe.dbg_log('bluetooth::monitor::remove_agent', 'exit_function', 0)
+                self.oe.dbg_log('bluetooth::monitor::remove_agent', 'exit_function', self.oe.LOGDEBUG)
             except Exception as e:
-                self.oe.dbg_log('bluetooth::monitor::remove_agent', 'ERROR: (' + repr(e) + ')', 4)
+                self.oe.dbg_log('bluetooth::monitor::remove_agent', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
         def bluezObexNameOwnerChanged(self, proxy):
             try:
-                self.oe.dbg_log('bluetooth::monitorLoop::bluezObexNameOwnerChanged', 'enter_function', 0)
+                self.oe.dbg_log('bluetooth::monitorLoop::bluezObexNameOwnerChanged', 'enter_function', self.oe.LOGDEBUG)
                 if proxy:
                     self.initialize_obex_agent()
                 else:
                     self.remove_obex_agent()
-                self.oe.dbg_log('bluetooth::monitor::bluezObexNameOwnerChanged', 'exit_function', 0)
+                self.oe.dbg_log('bluetooth::monitor::bluezObexNameOwnerChanged', 'exit_function', self.oe.LOGDEBUG)
             except Exception as e:
-                self.oe.dbg_log('bluetooth::monitor::bluezObexNameOwnerChanged', 'ERROR: (' + repr(e) + ')', 4)
+                self.oe.dbg_log('bluetooth::monitor::bluezObexNameOwnerChanged', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
         def initialize_obex_agent(self):
             try:
-                self.oe.dbg_log('bluetooth::monitor::initialize_obex_agent', 'enter_function', 0)
+                self.oe.dbg_log('bluetooth::monitor::initialize_obex_agent', 'enter_function', self.oe.LOGDEBUG)
                 self.obAgent = obexAgent(self.oe.dbusSystemBus, self.obAgentPath)
                 self.obAgent.oe = self.oe
                 self.obAgent.parent = self.parent
@@ -768,13 +768,13 @@ class bluetooth:
                                                       'org.bluez.obex.AgentManager1')
                 dbusBluezObexManager.RegisterAgent(self.obAgentPath)
                 dbusBluezObexManager = None
-                self.oe.dbg_log('bluetooth::monitor::initialize_obex_agent', 'exit_function', 0)
+                self.oe.dbg_log('bluetooth::monitor::initialize_obex_agent', 'exit_function', self.oe.LOGDEBUG)
             except Exception as e:
-                self.oe.dbg_log('bluetooth::monitor::initialize_obex_agent', 'ERROR: (' + repr(e) + ')', 4)
+                self.oe.dbg_log('bluetooth::monitor::initialize_obex_agent', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
         def remove_obex_agent(self):
             try:
-                self.oe.dbg_log('bluetooth::monitor::remove_obex_agent', 'enter_function', 0)
+                self.oe.dbg_log('bluetooth::monitor::remove_obex_agent', 'enter_function', self.oe.LOGDEBUG)
                 if hasattr(self, 'obAgent'):
                     self.obAgent.remove_from_connection(self.oe.dbusSystemBus, self.obAgentPath)
                     try:
@@ -786,15 +786,15 @@ class bluetooth:
                         dbusBluezObexManager = None
                         pass
                     del self.obAgent
-                self.oe.dbg_log('bluetooth::monitor::remove_obex_agent', 'exit_function', 0)
+                self.oe.dbg_log('bluetooth::monitor::remove_obex_agent', 'exit_function', self.oe.LOGDEBUG)
             except Exception as e:
-                self.oe.dbg_log('bluetooth::monitor::remove_obex_agent', 'ERROR: (' + repr(e) + ')', 4)
+                self.oe.dbg_log('bluetooth::monitor::remove_obex_agent', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
         def InterfacesAdded(self, path, interfaces):
             try:
-                self.oe.dbg_log('bluetooth::monitor::InterfacesAdded', 'enter_function', 0)
-                self.oe.dbg_log('bluetooth::monitor::InterfacesAdded::path', repr(path), 0)
-                self.oe.dbg_log('bluetooth::monitor::InterfacesAdded::interfaces', repr(interfaces), 0)
+                self.oe.dbg_log('bluetooth::monitor::InterfacesAdded', 'enter_function', self.oe.LOGDEBUG)
+                self.oe.dbg_log('bluetooth::monitor::InterfacesAdded::path', repr(path), self.oe.LOGDEBUG)
+                self.oe.dbg_log('bluetooth::monitor::InterfacesAdded::interfaces', repr(interfaces), self.oe.LOGDEBUG)
                 if 'org.bluez.Adapter1' in interfaces:
                     self.parent.dbusBluezAdapter = dbus.Interface(self.oe.dbusSystemBus.get_object('org.bluez', path), 'org.bluez.Adapter1')
                     self.parent.adapter_powered(self.parent.dbusBluezAdapter, 1)
@@ -803,41 +803,41 @@ class bluetooth:
                         self.parent.close_pinkey_window()
                 if self.parent.visible:
                     self.parent.menu_connections()
-                self.oe.dbg_log('bluetooth::monitor::InterfacesAdded', 'exit_function', 0)
+                self.oe.dbg_log('bluetooth::monitor::InterfacesAdded', 'exit_function', self.oe.LOGDEBUG)
             except Exception as e:
-                self.oe.dbg_log('bluetooth::monitor::InterfacesAdded', 'ERROR: (' + repr(e) + ')', 4)
+                self.oe.dbg_log('bluetooth::monitor::InterfacesAdded', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
         def InterfacesRemoved(self, path, interfaces):
             try:
-                self.oe.dbg_log('bluetooth::monitor::InterfacesRemoved', 'enter_function', 0)
-                self.oe.dbg_log('bluetooth::monitor::InterfacesRemoved::path', repr(path), 0)
-                self.oe.dbg_log('bluetooth::monitor::InterfacesRemoved::interfaces', repr(interfaces), 0)
+                self.oe.dbg_log('bluetooth::monitor::InterfacesRemoved', 'enter_function', self.oe.LOGDEBUG)
+                self.oe.dbg_log('bluetooth::monitor::InterfacesRemoved::path', repr(path), self.oe.LOGDEBUG)
+                self.oe.dbg_log('bluetooth::monitor::InterfacesRemoved::interfaces', repr(interfaces), self.oe.LOGDEBUG)
                 if 'org.bluez.Adapter1' in interfaces:
                     self.parent.dbusBluezAdapter = None
                 if self.parent.visible and not hasattr(self.parent, 'discovery_thread'):
                     self.parent.menu_connections()
-                self.oe.dbg_log('bluetooth::monitor::InterfacesRemoved', 'exit_function', 0)
+                self.oe.dbg_log('bluetooth::monitor::InterfacesRemoved', 'exit_function', self.oe.LOGDEBUG)
             except Exception as e:
-                self.oe.dbg_log('bluetooth::monitor::InterfacesRemoved', 'ERROR: (' + repr(e) + ')', 4)
+                self.oe.dbg_log('bluetooth::monitor::InterfacesRemoved', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
         def AdapterChanged(self, interface, changed, invalidated, path):
             try:
-                self.oe.dbg_log('bluetooth::monitor::AdapterChanged', 'enter_function', 0)
-                self.oe.dbg_log('bluetooth::monitor::AdapterChanged::interface', repr(interface), 0)
-                self.oe.dbg_log('bluetooth::monitor::AdapterChanged::changed', repr(changed), 0)
-                self.oe.dbg_log('bluetooth::monitor::AdapterChanged::invalidated', repr(invalidated), 0)
-                self.oe.dbg_log('bluetooth::monitor::AdapterChanged::path', repr(path), 0)
-                self.oe.dbg_log('bluetooth::monitor::AdapterChanged', 'exit_function', 0)
+                self.oe.dbg_log('bluetooth::monitor::AdapterChanged', 'enter_function', self.oe.LOGDEBUG)
+                self.oe.dbg_log('bluetooth::monitor::AdapterChanged::interface', repr(interface), self.oe.LOGDEBUG)
+                self.oe.dbg_log('bluetooth::monitor::AdapterChanged::changed', repr(changed), self.oe.LOGDEBUG)
+                self.oe.dbg_log('bluetooth::monitor::AdapterChanged::invalidated', repr(invalidated), self.oe.LOGDEBUG)
+                self.oe.dbg_log('bluetooth::monitor::AdapterChanged::path', repr(path), self.oe.LOGDEBUG)
+                self.oe.dbg_log('bluetooth::monitor::AdapterChanged', 'exit_function', self.oe.LOGDEBUG)
             except Exception as e:
-                self.oe.dbg_log('bluetooth::monitor::AdapterChanged', 'ERROR: (' + repr(e) + ')', 4)
+                self.oe.dbg_log('bluetooth::monitor::AdapterChanged', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
         def PropertiesChanged(self, interface, changed, invalidated, path):
             try:
-                self.oe.dbg_log('bluetooth::monitor::PropertiesChanged', 'enter_function', 0)
-                self.oe.dbg_log('bluetooth::monitor::PropertiesChanged::interface', repr(interface), 0)
-                self.oe.dbg_log('bluetooth::monitor::PropertiesChanged::changed', repr(changed), 0)
-                self.oe.dbg_log('bluetooth::monitor::PropertiesChanged::invalidated', repr(invalidated), 0)
-                self.oe.dbg_log('bluetooth::monitor::PropertiesChanged::path', repr(path), 0)
+                self.oe.dbg_log('bluetooth::monitor::PropertiesChanged', 'enter_function', self.oe.LOGDEBUG)
+                self.oe.dbg_log('bluetooth::monitor::PropertiesChanged::interface', repr(interface), self.oe.LOGDEBUG)
+                self.oe.dbg_log('bluetooth::monitor::PropertiesChanged::changed', repr(changed), self.oe.LOGDEBUG)
+                self.oe.dbg_log('bluetooth::monitor::PropertiesChanged::invalidated', repr(invalidated), self.oe.LOGDEBUG)
+                self.oe.dbg_log('bluetooth::monitor::PropertiesChanged::path', repr(path), self.oe.LOGDEBUG)
                 if self.parent.visible:
                     properties = [
                         'Paired',
@@ -854,16 +854,16 @@ class bluetooth:
                                 self.parent.listItems[path].setProperty(str(prop), str(changed[prop]))
                     else:
                         self.parent.menu_connections()
-                self.oe.dbg_log('bluetooth::monitor::PropertiesChanged', 'exit_function', 0)
+                self.oe.dbg_log('bluetooth::monitor::PropertiesChanged', 'exit_function', self.oe.LOGDEBUG)
             except Exception as e:
-                self.oe.dbg_log('bluetooth::monitor::PropertiesChanged', 'ERROR: (' + repr(e) + ')', 4)
+                self.oe.dbg_log('bluetooth::monitor::PropertiesChanged', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
         def TransferChanged(self, path, interface, dummy):
             try:
-                self.oe.dbg_log('bluetooth::monitor::TransferChanged', 'enter_function', 0)
-                self.oe.dbg_log('bluetooth::monitor::TransferChanged::path', repr(path), 0)
-                self.oe.dbg_log('bluetooth::monitor::TransferChanged::interface', repr(interface), 0)
-                self.oe.dbg_log('bluetooth::monitor::TransferChanged::dummy', repr(dummy), 0)
+                self.oe.dbg_log('bluetooth::monitor::TransferChanged', 'enter_function', self.oe.LOGDEBUG)
+                self.oe.dbg_log('bluetooth::monitor::TransferChanged::path', repr(path), self.oe.LOGDEBUG)
+                self.oe.dbg_log('bluetooth::monitor::TransferChanged::interface', repr(interface), self.oe.LOGDEBUG)
+                self.oe.dbg_log('bluetooth::monitor::TransferChanged::dummy', repr(dummy), self.oe.LOGDEBUG)
                 if 'Status' in interface:
                     if interface['Status'] == 'active':
                         self.parent.download_start = time.time()
@@ -900,9 +900,9 @@ class bluetooth:
                         itf.Cancel()
                         obj = None
                         itf = None
-                self.oe.dbg_log('bluetooth::monitor::TransferChanged', 'exit_function', 0)
+                self.oe.dbg_log('bluetooth::monitor::TransferChanged', 'exit_function', self.oe.LOGDEBUG)
             except Exception as e:
-                self.oe.dbg_log('bluetooth::monitor::TransferChanged', 'ERROR: (' + repr(e) + ')', 4)
+                self.oe.dbg_log('bluetooth::monitor::TransferChanged', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
 
 ####################################################################
@@ -922,137 +922,137 @@ class bluetoothAgent(dbus.service.Object):
     @dbus.service.method('org.bluez.Agent1', in_signature='', out_signature='')
     def Release(self):
         try:
-            self.oe.dbg_log('bluetooth::btAgent::Release', 'enter_function', 0)
-            self.oe.dbg_log('bluetooth::btAgent::Release', 'exit_function', 0)
+            self.oe.dbg_log('bluetooth::btAgent::Release', 'enter_function', self.oe.LOGDEBUG)
+            self.oe.dbg_log('bluetooth::btAgent::Release', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('bluetooth::btAgent::Release', 'ERROR: (' + repr(e) + ')', 4)
+            self.oe.dbg_log('bluetooth::btAgent::Release', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
     @dbus.service.method('org.bluez.Agent1', in_signature='os', out_signature='')
     def AuthorizeService(self, device, uuid):
         try:
-            self.oe.dbg_log('bluetooth::btAgent::AuthorizeService', 'enter_function', 0)
-            self.oe.dbg_log('bluetooth::btAgent::AuthorizeService::device=', repr(device), 0)
-            self.oe.dbg_log('bluetooth::btAgent::AuthorizeService::uuid=', repr(uuid), 0)
+            self.oe.dbg_log('bluetooth::btAgent::AuthorizeService', 'enter_function', self.oe.LOGDEBUG)
+            self.oe.dbg_log('bluetooth::btAgent::AuthorizeService::device=', repr(device), self.oe.LOGDEBUG)
+            self.oe.dbg_log('bluetooth::btAgent::AuthorizeService::uuid=', repr(uuid), self.oe.LOGDEBUG)
             self.oe.input_request = True
             xbmcDialog = xbmcgui.Dialog()
             answer = xbmcDialog.yesno('Bluetooth', 'Authorize service %s?' % uuid)
-            self.oe.dbg_log('bluetooth::btAgent::AuthorizeService::answer=', repr(answer), 0)
+            self.oe.dbg_log('bluetooth::btAgent::AuthorizeService::answer=', repr(answer), self.oe.LOGDEBUG)
             self.busy()
-            self.oe.dbg_log('bluetooth::btAgent::AuthorizeService', 'exit_function', 0)
+            self.oe.dbg_log('bluetooth::btAgent::AuthorizeService', 'exit_function', self.oe.LOGDEBUG)
             if answer == 1:
                 self.oe.dictModules['bluetooth'].trust_device(device)
                 return
             raise Rejected('Connection rejected!')
         except Exception as e:
-            self.oe.dbg_log('bluetooth::btAgent::AuthorizeService', 'ERROR: (' + repr(e) + ')', 4)
+            self.oe.dbg_log('bluetooth::btAgent::AuthorizeService', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
     @dbus.service.method('org.bluez.Agent1', in_signature='o', out_signature='s')
     def RequestPinCode(self, device):
         try:
-            self.oe.dbg_log('bluetooth::btAgent::RequestPinCode', 'enter_function', 0)
-            self.oe.dbg_log('bluetooth::btAgent::RequestPinCode::device=', repr(device), 0)
+            self.oe.dbg_log('bluetooth::btAgent::RequestPinCode', 'enter_function', self.oe.LOGDEBUG)
+            self.oe.dbg_log('bluetooth::btAgent::RequestPinCode::device=', repr(device), self.oe.LOGDEBUG)
             self.oe.input_request = True
             xbmcKeyboard = xbmc.Keyboard('', 'Enter PIN code')
             xbmcKeyboard.doModal()
             pincode = xbmcKeyboard.getText()
             self.busy()
-            self.oe.dbg_log('bluetooth::btAgent::RequestPinCode', 'return->' + pincode, 0)
-            self.oe.dbg_log('bluetooth::btAgent::RequestPinCode', 'exit_function', 0)
+            self.oe.dbg_log('bluetooth::btAgent::RequestPinCode', 'return->' + pincode, self.oe.LOGDEBUG)
+            self.oe.dbg_log('bluetooth::btAgent::RequestPinCode', 'exit_function', self.oe.LOGDEBUG)
             return dbus.String(pincode)
         except Exception as e:
-            self.oe.dbg_log('bluetooth::btAgent::RequestPinCode', 'ERROR: (' + repr(e) + ')', 4)
+            self.oe.dbg_log('bluetooth::btAgent::RequestPinCode', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
     @dbus.service.method('org.bluez.Agent1', in_signature='o', out_signature='u')
     def RequestPasskey(self, device):
         try:
-            self.oe.dbg_log('bluetooth::btAgent::RequestPasskey', 'enter_function', 0)
-            self.oe.dbg_log('bluetooth::btAgent::RequestPasskey::device=', repr(device), 0)
+            self.oe.dbg_log('bluetooth::btAgent::RequestPasskey', 'enter_function', self.oe.LOGDEBUG)
+            self.oe.dbg_log('bluetooth::btAgent::RequestPasskey::device=', repr(device), self.oe.LOGDEBUG)
             self.oe.input_request = True
             xbmcDialog = xbmcgui.Dialog()
             passkey = int(xbmcDialog.numeric(0, 'Enter passkey (number in 0-999999)', '0'))
-            self.oe.dbg_log('bluetooth::btAgent::RequestPasskey::passkey=', repr(passkey), 0)
+            self.oe.dbg_log('bluetooth::btAgent::RequestPasskey::passkey=', repr(passkey), self.oe.LOGDEBUG)
             self.busy()
-            self.oe.dbg_log('bluetooth::btAgent::RequestPasskey', 'exit_function', 0)
+            self.oe.dbg_log('bluetooth::btAgent::RequestPasskey', 'exit_function', self.oe.LOGDEBUG)
             return dbus.UInt32(passkey)
         except Exception as e:
-            self.oe.dbg_log('bluetooth::btAgent::RequestPasskey', 'ERROR: (' + repr(e) + ')', 4)
+            self.oe.dbg_log('bluetooth::btAgent::RequestPasskey', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
     @dbus.service.method('org.bluez.Agent1', in_signature='ouq', out_signature='')
     def DisplayPasskey(self, device, passkey, entered):
         try:
-            self.oe.dbg_log('bluetooth::btAgent::DisplayPasskey', 'enter_function', 0)
-            self.oe.dbg_log('bluetooth::btAgent::DisplayPasskey::device=', repr(device), 0)
-            self.oe.dbg_log('bluetooth::btAgent::DisplayPasskey::passkey=', repr(passkey), 0)
-            self.oe.dbg_log('bluetooth::btAgent::DisplayPasskey::entered=', repr(entered), 0)
+            self.oe.dbg_log('bluetooth::btAgent::DisplayPasskey', 'enter_function', self.oe.LOGDEBUG)
+            self.oe.dbg_log('bluetooth::btAgent::DisplayPasskey::device=', repr(device), self.oe.LOGDEBUG)
+            self.oe.dbg_log('bluetooth::btAgent::DisplayPasskey::passkey=', repr(passkey), self.oe.LOGDEBUG)
+            self.oe.dbg_log('bluetooth::btAgent::DisplayPasskey::entered=', repr(entered), self.oe.LOGDEBUG)
             if not hasattr(self.parent, 'pinkey_window'):
                 self.parent.open_pinkey_window()
                 self.parent.pinkey_window.device = device
                 self.parent.pinkey_window.set_label1('Passkey: %06u' % (passkey))
-            self.oe.dbg_log('bluetooth::btAgent::DisplayPasskey', 'exit_function', 0)
+            self.oe.dbg_log('bluetooth::btAgent::DisplayPasskey', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('bluetooth::btAgent::DisplayPasskey', 'ERROR: (' + repr(e) + ')', 4)
+            self.oe.dbg_log('bluetooth::btAgent::DisplayPasskey', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
     @dbus.service.method('org.bluez.Agent1', in_signature='os', out_signature='')
     def DisplayPinCode(self, device, pincode):
         try:
-            self.oe.dbg_log('bluetooth::btAgent::DisplayPinCode', 'enter_function', 0)
-            self.oe.dbg_log('bluetooth::btAgent::DisplayPinCode::device=', repr(device), 0)
-            self.oe.dbg_log('bluetooth::btAgent::DisplayPinCode::pincode=', repr(pincode), 0)
+            self.oe.dbg_log('bluetooth::btAgent::DisplayPinCode', 'enter_function', self.oe.LOGDEBUG)
+            self.oe.dbg_log('bluetooth::btAgent::DisplayPinCode::device=', repr(device), self.oe.LOGDEBUG)
+            self.oe.dbg_log('bluetooth::btAgent::DisplayPinCode::pincode=', repr(pincode), self.oe.LOGDEBUG)
             if hasattr(self.parent, 'pinkey_window'):
                 self.parent.close_pinkey_window()
             self.parent.open_pinkey_window(runtime=30)
             self.parent.pinkey_window.device = device
             self.parent.pinkey_window.set_label1('PIN code: %s' % (pincode))
-            self.oe.dbg_log('bluetooth::btAgent::DisplayPinCode', 'exit_function', 0)
+            self.oe.dbg_log('bluetooth::btAgent::DisplayPinCode', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('bluetooth::btAgent::DisplayPinCode', 'ERROR: (' + repr(e) + ')', 4)
+            self.oe.dbg_log('bluetooth::btAgent::DisplayPinCode', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
     @dbus.service.method('org.bluez.Agent1', in_signature='ou', out_signature='')
     def RequestConfirmation(self, device, passkey):
         try:
-            self.oe.dbg_log('bluetooth::btAgent::RequestConfirmation', 'enter_function', 0)
-            self.oe.dbg_log('bluetooth::btAgent::RequestConfirmation::device=', repr(device), 0)
-            self.oe.dbg_log('bluetooth::btAgent::RequestConfirmation::passkey=', repr(passkey), 0)
+            self.oe.dbg_log('bluetooth::btAgent::RequestConfirmation', 'enter_function', self.oe.LOGDEBUG)
+            self.oe.dbg_log('bluetooth::btAgent::RequestConfirmation::device=', repr(device), self.oe.LOGDEBUG)
+            self.oe.dbg_log('bluetooth::btAgent::RequestConfirmation::passkey=', repr(passkey), self.oe.LOGDEBUG)
             self.oe.input_request = True
             xbmcDialog = xbmcgui.Dialog()
             answer = xbmcDialog.yesno('Bluetooth', 'Confirm passkey %06u' % passkey)
-            self.oe.dbg_log('bluetooth::btAgent::RequestConfirmation::answer=', repr(answer), 0)
+            self.oe.dbg_log('bluetooth::btAgent::RequestConfirmation::answer=', repr(answer), self.oe.LOGDEBUG)
             self.busy()
-            self.oe.dbg_log('bluetooth::btAgent::RequestConfirmation', 'exit_function', 0)
+            self.oe.dbg_log('bluetooth::btAgent::RequestConfirmation', 'exit_function', self.oe.LOGDEBUG)
             if answer == 1:
                 self.oe.dictModules['bluetooth'].trust_device(device)
                 return
             raise Rejected("Passkey doesn't match")
         except Exception as e:
-            self.oe.dbg_log('bluetooth::btAgent::RequestConfirmation', 'ERROR: (' + repr(e) + ')', 4)
+            self.oe.dbg_log('bluetooth::btAgent::RequestConfirmation', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
     @dbus.service.method('org.bluez.Agent1', in_signature='o', out_signature='')
     def RequestAuthorization(self, device):
         try:
-            self.oe.dbg_log('bluetooth::btAgent::RequestAuthorization', 'enter_function', 0)
-            self.oe.dbg_log('bluetooth::btAgent::RequestAuthorization::device=', repr(device), 0)
+            self.oe.dbg_log('bluetooth::btAgent::RequestAuthorization', 'enter_function', self.oe.LOGDEBUG)
+            self.oe.dbg_log('bluetooth::btAgent::RequestAuthorization::device=', repr(device), self.oe.LOGDEBUG)
             self.oe.input_request = True
             xbmcDialog = xbmcgui.Dialog()
             answer = xbmcDialog.yesno('Bluetooth', 'Accept pairing?')
-            self.oe.dbg_log('bluetooth::btAgent::RequestAuthorization::answer=', repr(answer), 0)
+            self.oe.dbg_log('bluetooth::btAgent::RequestAuthorization::answer=', repr(answer), self.oe.LOGDEBUG)
             self.busy()
-            self.oe.dbg_log('bluetooth::btAgent::RequestAuthorization', 'exit_function', 0)
+            self.oe.dbg_log('bluetooth::btAgent::RequestAuthorization', 'exit_function', self.oe.LOGDEBUG)
             if answer == 1:
                 self.oe.dictModules['bluetooth'].trust_device(device)
                 return
             raise Rejected('Pairing rejected')
         except Exception as e:
-            self.oe.dbg_log('bluetooth::btAgent::RequestAuthorization', 'ERROR: (' + repr(e) + ')', 4)
+            self.oe.dbg_log('bluetooth::btAgent::RequestAuthorization', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
     @dbus.service.method('org.bluez.Agent1', in_signature='', out_signature='')
     def Cancel(self):
         try:
-            self.oe.dbg_log('bluetooth::btAgent::Cancel', 'enter_function', 0)
+            self.oe.dbg_log('bluetooth::btAgent::Cancel', 'enter_function', self.oe.LOGDEBUG)
             if hasattr(self.parent, 'pinkey_window'):
                 self.parent.close_pinkey_window()
-            self.oe.dbg_log('bluetooth::btAgent::Cancel', 'exit_function', 0)
+            self.oe.dbg_log('bluetooth::btAgent::Cancel', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('bluetooth::btAgent::Cancel', 'ERROR: (' + repr(e) + ')', 4)
+            self.oe.dbg_log('bluetooth::btAgent::Cancel', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
 
 ####################################################################
@@ -1067,22 +1067,22 @@ class obexAgent(dbus.service.Object):
     @dbus.service.method('org.bluez.obex.Agent1', in_signature='', out_signature='')
     def Release(self):
         try:
-            self.oe.dbg_log('bluetooth::obexAgent::Release', 'enter_function', 0)
-            self.oe.dbg_log('bluetooth::obexAgent::Release', 'exit_function', 0)
+            self.oe.dbg_log('bluetooth::obexAgent::Release', 'enter_function', self.oe.LOGDEBUG)
+            self.oe.dbg_log('bluetooth::obexAgent::Release', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('bluetooth::obexAgent::Release', 'ERROR: (' + repr(e) + ')', 4)
+            self.oe.dbg_log('bluetooth::obexAgent::Release', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
     @dbus.service.method('org.bluez.obex.Agent1', in_signature='o', out_signature='s')
     def AuthorizePush(self, path):
         try:
-            self.oe.dbg_log('bluetooth::obexAgent::AuthorizePush', 'enter_function', 0)
-            self.oe.dbg_log('bluetooth::obexAgent::AuthorizePush::path=', repr(path), 0)
+            self.oe.dbg_log('bluetooth::obexAgent::AuthorizePush', 'enter_function', self.oe.LOGDEBUG)
+            self.oe.dbg_log('bluetooth::obexAgent::AuthorizePush::path=', repr(path), self.oe.LOGDEBUG)
             transfer = dbus.Interface(self.oe.dbusSystemBus.get_object('org.bluez.obex', path), 'org.freedesktop.DBus.Properties')
             properties = transfer.GetAll('org.bluez.obex.Transfer1')
             self.oe.input_request = True
             xbmcDialog = xbmcgui.Dialog()
             answer = xbmcDialog.yesno('Bluetooth', "%s\n\n%s" % (self.oe._(32381), properties['Name']))
-            self.oe.dbg_log('bluetooth::obexAgent::AuthorizePush::answer=', repr(answer), 0)
+            self.oe.dbg_log('bluetooth::obexAgent::AuthorizePush::answer=', repr(answer), self.oe.LOGDEBUG)
             self.busy()
             if answer != 1:
                 properties = None
@@ -1098,33 +1098,33 @@ class obexAgent(dbus.service.Object):
             res = properties['Name']
             properties = None
             transfer = None
-            self.oe.dbg_log('bluetooth::obexAgent::AuthorizePush', 'exit_function', 0)
+            self.oe.dbg_log('bluetooth::obexAgent::AuthorizePush', 'exit_function', self.oe.LOGDEBUG)
             return res
         except Exception as e:
-            self.oe.dbg_log('bluetooth::obexAgent::AuthorizePush', 'ERROR: (' + repr(e) + ')', 4)
+            self.oe.dbg_log('bluetooth::obexAgent::AuthorizePush', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
     @dbus.service.method('org.bluez.obex.Agent1', in_signature='', out_signature='')
     def Cancel(self):
         try:
-            self.oe.dbg_log('bluetooth::obexAgent::Cancel', 'enter_function', 0)
-            self.oe.dbg_log('bluetooth::obexAgent::Cancel', 'exit_function', 0)
+            self.oe.dbg_log('bluetooth::obexAgent::Cancel', 'enter_function', self.oe.LOGDEBUG)
+            self.oe.dbg_log('bluetooth::obexAgent::Cancel', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('bluetooth::obexAgent::Cancel', 'ERROR: (' + repr(e) + ')', 4)
+            self.oe.dbg_log('bluetooth::obexAgent::Cancel', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
 
 class discoveryThread(threading.Thread):
 
     def __init__(self, oeMain):
         try:
-            oeMain.dbg_log('bluetooth::discoveryThread::__init__', 'enter_function', 0)
+            oeMain.dbg_log('bluetooth::discoveryThread::__init__', 'enter_function', oeMain.LOGDEBUG)
             self.oe = oeMain
             self.last_run = 0
             self.stopped = False
             self.main_menu = self.oe.winOeMain.getControl(self.oe.winOeMain.guiMenList)
             threading.Thread.__init__(self)
-            self.oe.dbg_log('bluetooth::discoveryThread::__init__', 'exit_function', 0)
+            self.oe.dbg_log('bluetooth::discoveryThread::__init__', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('bluetooth::discoveryThread::__init__', 'ERROR: (' + repr(e) + ')', 4)
+            self.oe.dbg_log('bluetooth::discoveryThread::__init__', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
     def stop(self):
         self.stopped = True
@@ -1132,7 +1132,7 @@ class discoveryThread(threading.Thread):
 
     def run(self):
         try:
-            self.oe.dbg_log('bluetooth::discoveryThread::run', 'enter_function', 0)
+            self.oe.dbg_log('bluetooth::discoveryThread::run', 'enter_function', self.oe.LOGDEBUG)
             while not self.stopped and not self.oe.xbmcm.abortRequested():
                 current_time = time.time()
                 if current_time > self.last_run + 5:
@@ -1142,16 +1142,16 @@ class discoveryThread(threading.Thread):
                 if self.main_menu.getSelectedItem().getProperty('modul') != 'bluetooth':
                     self.stop()
                 self.oe.xbmcm.waitForAbort(1)
-            self.oe.dbg_log('bluetooth::discoveryThread::run', 'exit_function', 0)
+            self.oe.dbg_log('bluetooth::discoveryThread::run', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('bluetooth::discoveryThread::run', 'ERROR: (' + repr(e) + ')', 4)
+            self.oe.dbg_log('bluetooth::discoveryThread::run', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
 
 class pinkeyTimer(threading.Thread):
 
     def __init__(self, parent, runtime=60):
         try:
-            parent.oe.dbg_log('bluetooth::pinkeyTimer::__init__', 'enter_function', 0)
+            parent.oe.dbg_log('bluetooth::pinkeyTimer::__init__', 'enter_function', parent.oe.LOGDEBUG)
             self.parent = parent
             self.oe = parent.oe
             self.start_time = time.time()
@@ -1159,16 +1159,16 @@ class pinkeyTimer(threading.Thread):
             self.stopped = False
             self.runtime = runtime
             threading.Thread.__init__(self)
-            self.oe.dbg_log('bluetooth::pinkeyTimer::__init__', 'exit_function', 0)
+            self.oe.dbg_log('bluetooth::pinkeyTimer::__init__', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('bluetooth::pinkeyTimer::__init__', 'ERROR: (' + repr(e) + ')', 4)
+            self.oe.dbg_log('bluetooth::pinkeyTimer::__init__', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
     def stop(self):
         self.stopped = True
 
     def run(self):
         try:
-            self.oe.dbg_log('bluetooth::pinkeyTimer::run', 'enter_function', 0)
+            self.oe.dbg_log('bluetooth::pinkeyTimer::run', 'enter_function', self.oe.LOGDEBUG)
             self.endtime = self.start_time + self.runtime
             while not self.stopped and not self.oe.xbmcm.abortRequested():
                 current_time = time.time()
@@ -1179,6 +1179,6 @@ class pinkeyTimer(threading.Thread):
                     self.parent.close_pinkey_window()
                 else:
                     self.oe.xbmcm.waitForAbort(1)
-            self.oe.dbg_log('bluetooth::pinkeyTimer::run', 'exit_function', 0)
+            self.oe.dbg_log('bluetooth::pinkeyTimer::run', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('bluetooth::pinkeyTimer::run', 'ERROR: (' + repr(e) + ')', 4)
+            self.oe.dbg_log('bluetooth::pinkeyTimer::run', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)

--- a/src/resources/lib/modules/connman.py
+++ b/src/resources/lib/modules/connman.py
@@ -26,7 +26,7 @@ class connmanService(object):
 
     def __init__(self, servicePath, oeMain):
         try:
-            oeMain.dbg_log('connmanService::__init__', 'enter_function', 0)
+            oeMain.dbg_log('connmanService::__init__', 'enter_function', oeMain.LOGDEBUG)
             oeMain.set_busy(1)
             self.struct = {
                 'AutoConnect': {
@@ -318,31 +318,31 @@ class connmanService(object):
             self.winOeCon.doModal()
             del self.winOeCon
             del self.oe.dictModules['connmanNetworkConfig']
-            self.oe.dbg_log('connmanService::__init__', 'exit_function', 0)
+            self.oe.dbg_log('connmanService::__init__', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.set_busy(0)
-            self.oe.dbg_log('connmanService::__init__', 'ERROR: (' + repr(e) + ')', 4)
+            self.oe.dbg_log('connmanService::__init__', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
     def cancel(self):
         try:
-            self.oe.dbg_log('connmanService::cancel', 'exit_function', 0)
+            self.oe.dbg_log('connmanService::cancel', 'exit_function', self.oe.LOGDEBUG)
             self.oe.set_busy(1)
             self.winOeCon.close()
             self.oe.set_busy(0)
-            self.oe.dbg_log('connmanService::cancel', 'exit_function', 0)
+            self.oe.dbg_log('connmanService::cancel', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.set_busy(0)
-            self.oe.dbg_log('connmanService::cancel', 'ERROR: (' + repr(e) + ')', 4)
+            self.oe.dbg_log('connmanService::cancel', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
     def menu_loader(self, menuItem):
         try:
-            self.oe.dbg_log('connmanService::menu_loader', 'enter_function', 0)
+            self.oe.dbg_log('connmanService::menu_loader', 'enter_function', self.oe.LOGDEBUG)
             self.winOeCon.showButton(1, 32140, 'connmanNetworkConfig', 'save_network')
             self.winOeCon.showButton(2, 32212, 'connmanNetworkConfig', 'cancel')
             self.winOeCon.build_menu(self.struct, fltr=[menuItem.getProperty('category')])
-            self.oe.dbg_log('connmanService::menu_loader', 'exit_function', 0)
+            self.oe.dbg_log('connmanService::menu_loader', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('connmanService::menu_loader', 'ERROR: (' + repr(e) + ')', 4)
+            self.oe.dbg_log('connmanService::menu_loader', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
     def set_value_checkdhcp(self, listItem):
         try:
@@ -350,21 +350,21 @@ class connmanService(object):
                 ok_window = xbmcgui.Dialog()
                 answer = ok_window.ok('Not allowed', 'IPv4 method is set to DHCP.\n\nChanging this option is not allowed')
                 return
-            self.oe.dbg_log('connmanService::set_value_checkdhcp', 'enter_function', 0)
+            self.oe.dbg_log('connmanService::set_value_checkdhcp', 'enter_function', self.oe.LOGDEBUG)
             self.struct[listItem.getProperty('category')]['settings'][listItem.getProperty('entry')]['value'] = listItem.getProperty('value')
             self.struct[listItem.getProperty('category')]['settings'][listItem.getProperty('entry')]['changed'] = True
-            self.oe.dbg_log('connmanService::set_value_checkdhcp', 'exit_function', 0)
+            self.oe.dbg_log('connmanService::set_value_checkdhcp', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('connmanService::set_value_checkdhcp', 'ERROR: (' + repr(e) + ')', 4)
+            self.oe.dbg_log('connmanService::set_value_checkdhcp', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
     def set_value(self, listItem):
         try:
-            self.oe.dbg_log('connmanService::set_value', 'enter_function', 0)
+            self.oe.dbg_log('connmanService::set_value', 'enter_function', self.oe.LOGDEBUG)
             self.struct[listItem.getProperty('category')]['settings'][listItem.getProperty('entry')]['value'] = listItem.getProperty('value')
             self.struct[listItem.getProperty('category')]['settings'][listItem.getProperty('entry')]['changed'] = True
-            self.oe.dbg_log('connmanService::set_value', 'exit_function', 0)
+            self.oe.dbg_log('connmanService::set_value', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('connmanService::set_value', 'ERROR: (' + repr(e) + ')', 4)
+            self.oe.dbg_log('connmanService::set_value', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
     def dbus_config(self, category):
         try:
@@ -397,12 +397,12 @@ class connmanService(object):
                             value.append(getattr(dbus, setting['dbus'])(setting['value'], variant_level=1))
             return (category + postfix, value)
         except Exception as e:
-            self.oe.dbg_log('connmanService::dbus_config', 'ERROR: (' + repr(e) + ')', 4)
+            self.oe.dbg_log('connmanService::dbus_config', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
     def save_network(self):
         try:
             self.oe.set_busy(1)
-            self.oe.dbg_log('connmanService::save_network', 'enter_function', 0)
+            self.oe.dbg_log('connmanService::save_network', 'enter_function', self.oe.LOGDEBUG)
             if self.struct['IPv4']['settings']['Method']['value'] == 'dhcp':
                 for setting in self.struct['Nameservers']['settings']:
                     self.struct['Nameservers']['settings'][setting]['changed'] = True
@@ -424,42 +424,42 @@ class connmanService(object):
                 (category, value) = self.dbus_config(category)
                 if value != None:
                     self.service.SetProperty(dbus.String(category), value)
-            self.oe.dbg_log('connmanService::save_network', 'exit_function', 0)
+            self.oe.dbg_log('connmanService::save_network', 'exit_function', self.oe.LOGDEBUG)
             self.oe.set_busy(0)
             return 'close'
         except Exception as e:
             self.oe.set_busy(0)
-            self.oe.dbg_log('connmanService::save_network', 'ERROR: (' + repr(e) + ')', 4)
+            self.oe.dbg_log('connmanService::save_network', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
             return 'close'
 
     def delete_network(self):
         try:
-            self.oe.dbg_log('connmanService::delete_network', 'enter_function', 0)
+            self.oe.dbg_log('connmanService::delete_network', 'enter_function', self.oe.LOGDEBUG)
             self.oe.dictModules['connman'].delete_network(None)
-            self.oe.dbg_log('connmanService::delete_network', 'exit_function', 0)
+            self.oe.dbg_log('connmanService::delete_network', 'exit_function', self.oe.LOGDEBUG)
             return 'close'
         except Exception as e:
-            self.oe.dbg_log('connmanService::delete_network', 'ERROR: (' + repr(e) + ')', 4)
+            self.oe.dbg_log('connmanService::delete_network', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
             return 'close'
 
     def connect_network(self):
         try:
-            self.oe.dbg_log('connmanService::connect_network', 'enter_function', 0)
+            self.oe.dbg_log('connmanService::connect_network', 'enter_function', self.oe.LOGDEBUG)
             self.oe.dictModules['connman'].connect_network(None)
-            self.oe.dbg_log('connmanService::connect_network', 'exit_function', 0)
+            self.oe.dbg_log('connmanService::connect_network', 'exit_function', self.oe.LOGDEBUG)
             return 'close'
         except Exception as e:
-            self.oe.dbg_log('connmanService::connect_network', 'ERROR: (' + repr(e) + ')', 4)
+            self.oe.dbg_log('connmanService::connect_network', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
             return 'close'
 
     def disconnect_network(self):
         try:
-            self.oe.dbg_log('connmanService::disconnect_network', 'enter_function', 0)
+            self.oe.dbg_log('connmanService::disconnect_network', 'enter_function', self.oe.LOGDEBUG)
             self.oe.dictModules['connman'].disconnect_network(None)
-            self.oe.dbg_log('connmanService::disconnect_network', 'exit_function', 0)
+            self.oe.dbg_log('connmanService::disconnect_network', 'exit_function', self.oe.LOGDEBUG)
             return 'close'
         except Exception as e:
-            self.oe.dbg_log('connmanService::disconnect_network', 'ERROR: (' + repr(e) + ')', 4)
+            self.oe.dbg_log('connmanService::disconnect_network', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
             return 'close'
 
 
@@ -496,7 +496,7 @@ class connman:
 
     def __init__(self, oeMain):
         try:
-            oeMain.dbg_log('connman::__init__', 'enter_function', 0)
+            oeMain.dbg_log('connman::__init__', 'enter_function', oeMain.LOGDEBUG)
             self.listItems = {}
             self.struct = {
                 '/net/connman/technology/wifi': {
@@ -665,9 +665,9 @@ class connman:
             self.busy = 0
             self.oe = oeMain
             self.visible = False
-            self.oe.dbg_log('connman::__init__', 'exit_function', 0)
+            self.oe.dbg_log('connman::__init__', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('connman::__init__', 'ERROR: (' + repr(e) + ')', 4)
+            self.oe.dbg_log('connman::__init__', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
     def clear_list(self):
         try:
@@ -676,28 +676,28 @@ class connman:
                 self.listItems[entry] = None
                 del self.listItems[entry]
         except Exception as e:
-            self.oe.dbg_log('connman::clear_list', 'ERROR: (' + repr(e) + ')', 4)
+            self.oe.dbg_log('connman::clear_list', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
     def do_init(self):
         try:
-            self.oe.dbg_log('connman::do_init', 'enter_function', 0)
+            self.oe.dbg_log('connman::do_init', 'enter_function', self.oe.LOGDEBUG)
             self.visible = True
-            self.oe.dbg_log('connman::do_init', 'exit_function', 0)
+            self.oe.dbg_log('connman::do_init', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('connman::do_init', 'ERROR: (' + repr(e) + ')', 4)
+            self.oe.dbg_log('connman::do_init', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
     def exit(self):
         try:
-            self.oe.dbg_log('connman::exit', 'enter_function', 0)
+            self.oe.dbg_log('connman::exit', 'enter_function', self.oe.LOGDEBUG)
             self.visible = False
             self.clear_list()
-            self.oe.dbg_log('connman::exit', 'exit_function', 0)
+            self.oe.dbg_log('connman::exit', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('connman::exit', 'ERROR: (' + repr(e) + ')', 4)
+            self.oe.dbg_log('connman::exit', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
     def load_values(self):
         try:
-            self.oe.dbg_log('connman::load_values', 'enter_function', 0)
+            self.oe.dbg_log('connman::load_values', 'enter_function', self.oe.LOGDEBUG)
 
             # Network Wait
 
@@ -915,14 +915,14 @@ class connman:
             else:
                 regValue = self.REGDOMAIN_DEFAULT
             self.struct['/net/connman/technology/wifi']['settings']['regdom']['value'] = str(regValue)
-            self.oe.dbg_log('connman::load_values', 'exit_function', 0)
+            self.oe.dbg_log('connman::load_values', 'exit_function', self.oe.LOGDEBUG)
 
         except Exception as e:
             self.oe.dbg_log('connman::load_values', 'ERROR: (' + repr(e) + ')')
 
     def menu_connections(self, focusItem, services={}, removed={}, force=False):
         try:
-            self.oe.dbg_log('connman::menu_connections', 'enter_function', 0)
+            self.oe.dbg_log('connman::menu_connections', 'enter_function', self.oe.LOGDEBUG)
             self.oe.set_busy(1)
 
             # type 1=int, 2=string, 3=array
@@ -1032,14 +1032,14 @@ class connman:
                 if rebuildList == 1:
                     self.listItems[dbusServicePath] = self.oe.winOeMain.addConfigItem(apName, dictProperties, self.oe.listObject['netlist'])
             self.oe.set_busy(0)
-            self.oe.dbg_log('connman::menu_connections', 'exit_function', 0)
+            self.oe.dbg_log('connman::menu_connections', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.set_busy(0)
-            self.oe.dbg_log('connman::menu_connections', 'ERROR: (' + repr(e) + ')', 4)
+            self.oe.dbg_log('connman::menu_connections', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
     def menu_loader(self, menuItem=None):
         try:
-            self.oe.dbg_log('connman::menu_loader', 'enter_function0', 0)
+            self.oe.dbg_log('connman::menu_loader', 'enter_function0', self.oe.LOGDEBUG)
             self.oe.set_busy(1)
             if menuItem == None:
                 menuItem = self.oe.winOeMain.getControl(self.oe.winOeMain.guiMenList).getSelectedItem()
@@ -1065,19 +1065,19 @@ class connman:
                     self.struct['Timeservers']['settings'][setting]['value'] = ''
             self.oe.winOeMain.build_menu(self.struct)
             self.oe.set_busy(0)
-            self.oe.dbg_log('connman::menu_loader', 'exit_function', 0)
+            self.oe.dbg_log('connman::menu_loader', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.set_busy(0)
-            self.oe.dbg_log('connman::menu_loader', 'ERROR: (' + repr(e) + ')', 4)
+            self.oe.dbg_log('connman::menu_loader', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
     def open_context_menu(self, listItem):
         try:
-            self.oe.dbg_log('connman::open_context_menu', 'enter_function', 0)
+            self.oe.dbg_log('connman::open_context_menu', 'enter_function', self.oe.LOGDEBUG)
             values = {}
             if listItem is None:
                 listItem = self.oe.winOeMain.getControl(self.oe.listObject['netlist']).getSelectedItem()
             if listItem is None:
-                self.oe.dbg_log('connman::open_context_menu', 'exit_function (listItem=None)', 0)
+                self.oe.dbg_log('connman::open_context_menu', 'exit_function (listItem=None)', self.oe.LOGDEBUG)
                 return
             if listItem.getProperty('State') in ['ready', 'online']:
                 values[1] = {
@@ -1117,40 +1117,40 @@ class connman:
             result = select_window.select(title, items)
             if result >= 0:
                 getattr(self, actions[result])(listItem)
-            self.oe.dbg_log('connman::open_context_menu', 'exit_function', 0)
+            self.oe.dbg_log('connman::open_context_menu', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('connman::open_context_menu', 'ERROR: (' + repr(e) + ')', 4)
+            self.oe.dbg_log('connman::open_context_menu', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
     def set_timeservers(self, **kwargs):
         try:
             self.oe.set_busy(1)
             if 'listItem' in kwargs:
                 self.set_value(kwargs['listItem'])
-            self.oe.dbg_log('connman::set_timeservers', 'enter_function', 0)
+            self.oe.dbg_log('connman::set_timeservers', 'enter_function', self.oe.LOGDEBUG)
             self.clock = dbus.Interface(self.oe.dbusSystemBus.get_object('net.connman', '/'), 'net.connman.Clock')
             timeservers = dbus.Array([], signature=dbus.Signature('s'), variant_level=1)
             for setting in sorted(self.struct['Timeservers']['settings']):
                 if self.struct['Timeservers']['settings'][setting]['value'] != '':
                     timeservers.append(self.struct['Timeservers']['settings'][setting]['value'])
             self.clock.SetProperty(dbus.String('Timeservers'), timeservers)
-            self.oe.dbg_log('connman::set_timeservers', 'exit_function', 0)
+            self.oe.dbg_log('connman::set_timeservers', 'exit_function', self.oe.LOGDEBUG)
             self.oe.set_busy(0)
         except Exception as e:
             self.oe.set_busy(0)
-            self.oe.dbg_log('connman::set_timeservers', 'ERROR: (' + repr(e) + ')', 4)
+            self.oe.dbg_log('connman::set_timeservers', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
     def set_value(self, listItem=None):
         try:
-            self.oe.dbg_log('connman::set_value', 'enter_function', 0)
+            self.oe.dbg_log('connman::set_value', 'enter_function', self.oe.LOGDEBUG)
             self.struct[listItem.getProperty('category')]['settings'][listItem.getProperty('entry')]['value'] = listItem.getProperty('value')
             self.struct[listItem.getProperty('category')]['settings'][listItem.getProperty('entry')]['changed'] = True
-            self.oe.dbg_log('connman::set_value', 'exit_function', 0)
+            self.oe.dbg_log('connman::set_value', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('connman::set_value', 'ERROR: (' + repr(e) + ')', 4)
+            self.oe.dbg_log('connman::set_value', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
     def set_technologie(self, **kwargs):
         try:
-            self.oe.dbg_log('connman::set_technologies', 'enter_function', 0)
+            self.oe.dbg_log('connman::set_technologies', 'enter_function', self.oe.LOGDEBUG)
             self.oe.set_busy(1)
             if 'listItem' in kwargs:
                 self.set_value(kwargs['listItem'])
@@ -1199,14 +1199,14 @@ class connman:
             self.technologie_properties = None
             self.menu_loader(None)
             self.oe.set_busy(0)
-            self.oe.dbg_log('connman::set_technologies', 'exit_function', 0)
+            self.oe.dbg_log('connman::set_technologies', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.set_busy(0)
-            self.oe.dbg_log('connman::set_technologies', 'ERROR: (' + repr(e) + ')', 4)
+            self.oe.dbg_log('connman::set_technologies', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
     def custom_regdom(self, **kwargs):
         try:
-            self.oe.dbg_log('connman::custom_regdom', 'enter_function', 0)
+            self.oe.dbg_log('connman::custom_regdom', 'enter_function', self.oe.LOGDEBUG)
             self.oe.set_busy(1)
             if 'listItem' in kwargs:
                 if str((kwargs['listItem']).getProperty('value')) == self.REGDOMAIN_DEFAULT:
@@ -1221,26 +1221,26 @@ class connman:
                 self.oe.execute(regScript)
                 self.set_value(kwargs['listItem'])
             self.oe.set_busy(0)
-            self.oe.dbg_log('connman::custom_regdom', 'exit_function', 0)
+            self.oe.dbg_log('connman::custom_regdom', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.set_busy(0)
-            self.oe.dbg_log('connman::custom_regdom', 'ERROR: (' + repr(e) + ')', 4)
+            self.oe.dbg_log('connman::custom_regdom', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
     def configure_network(self, listItem=None):
         try:
-            self.oe.dbg_log('connman::configure_network', 'enter_function', 0)
+            self.oe.dbg_log('connman::configure_network', 'enter_function', self.oe.LOGDEBUG)
             if listItem == None:
                 listItem = self.oe.winOeMain.getControl(self.oe.listObject['netlist']).getSelectedItem()
             self.configureService = connmanService(listItem.getProperty('entry'), self.oe)
             del self.configureService
             self.menu_connections(None)
-            self.oe.dbg_log('connman::configure_network', 'exit_function', 0)
+            self.oe.dbg_log('connman::configure_network', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('connman::configure_network', 'ERROR: (' + repr(e) + ')', 4)
+            self.oe.dbg_log('connman::configure_network', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
     def connect_network(self, listItem=None):
         try:
-            self.oe.dbg_log('connman::connect_network', 'enter_function', 0)
+            self.oe.dbg_log('connman::connect_network', 'enter_function', self.oe.LOGDEBUG)
             self.oe.set_busy(1)
             self.connect_attempt += 1
             if listItem == None:
@@ -1249,24 +1249,24 @@ class connman:
             dbus.Interface(service_object, 'net.connman.Service').Connect(reply_handler=self.connect_reply_handler,
                     error_handler=self.dbus_error_handler)
             service_object = None
-            self.oe.dbg_log('connman::connect_network', 'exit_function', 0)
+            self.oe.dbg_log('connman::connect_network', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.set_busy(0)
-            self.oe.dbg_log('connman::connect_network', 'ERROR: (' + repr(e) + ')', 4)
+            self.oe.dbg_log('connman::connect_network', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
     def connect_reply_handler(self):
         try:
-            self.oe.dbg_log('connman::connect_reply_handler', 'enter_function', 0)
+            self.oe.dbg_log('connman::connect_reply_handler', 'enter_function', self.oe.LOGDEBUG)
             self.oe.set_busy(0)
             self.menu_connections(None)
-            self.oe.dbg_log('connman::connect_reply_handler', 'exit_function', 0)
+            self.oe.dbg_log('connman::connect_reply_handler', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.set_busy(0)
-            self.oe.dbg_log('connman::connect_reply_handler', 'ERROR: (' + repr(e) + ')', 4)
+            self.oe.dbg_log('connman::connect_reply_handler', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
     def dbus_error_handler(self, error):
         try:
-            self.oe.dbg_log('connman::dbus_error_handler', 'enter_function', 0)
+            self.oe.dbg_log('connman::dbus_error_handler', 'enter_function', self.oe.LOGDEBUG)
             self.oe.set_busy(0)
             err_name = error.get_dbus_name()
             if 'InProgress' in err_name:
@@ -1297,17 +1297,17 @@ class connman:
                 else:
                     self.notify_error = 1
                 if self.log_error == 1:
-                    self.oe.dbg_log('connman::dbus_error_handler', 'ERROR: (' + err_message + ')', 4)
+                    self.oe.dbg_log('connman::dbus_error_handler', 'ERROR: (' + err_message + ')', self.oe.LOGERROR)
                 else:
                     self.log_error = 1
-            self.oe.dbg_log('connman::dbus_error_handler', 'exit_function', 0)
+            self.oe.dbg_log('connman::dbus_error_handler', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.set_busy(0)
-            self.oe.dbg_log('connman::dbus_error_handler', 'ERROR: (' + repr(e) + ')', 4)
+            self.oe.dbg_log('connman::dbus_error_handler', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
     def disconnect_network(self, listItem=None):
         try:
-            self.oe.dbg_log('connman::disconnect_network', 'enter_function', 0)
+            self.oe.dbg_log('connman::disconnect_network', 'enter_function', self.oe.LOGDEBUG)
             self.oe.set_busy(1)
             self.connect_attempt = 0
             self.net_disconnected = 1
@@ -1318,14 +1318,14 @@ class connman:
             service_object = None
             del service_object
             self.oe.set_busy(0)
-            self.oe.dbg_log('connman::disconnect_network', 'exit_function', 0)
+            self.oe.dbg_log('connman::disconnect_network', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.set_busy(0)
-            self.oe.dbg_log('connman::disconnect_network', 'ERROR: (' + repr(e) + ')', 4)
+            self.oe.dbg_log('connman::disconnect_network', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
     def delete_network(self, listItem=None):
         try:
-            self.oe.dbg_log('connman::delete_network', 'enter_function', 0)
+            self.oe.dbg_log('connman::delete_network', 'enter_function', self.oe.LOGDEBUG)
             self.oe.set_busy(1)
             self.connect_attempt = 0
             if listItem == None:
@@ -1337,14 +1337,14 @@ class connman:
             service_object = None
             del service_object
             self.oe.set_busy(0)
-            self.oe.dbg_log('connman::delete_network', 'exit_function', 0)
+            self.oe.dbg_log('connman::delete_network', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.set_busy(0)
-            self.oe.dbg_log('connman::delete_network', 'ERROR: (' + repr(e) + ')', 4)
+            self.oe.dbg_log('connman::delete_network', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
     def refresh_network(self, listItem=None):
         try:
-            self.oe.dbg_log('connman::refresh_network', 'enter_function', 0)
+            self.oe.dbg_log('connman::refresh_network', 'enter_function', self.oe.LOGDEBUG)
             self.oe.set_busy(1)
             wifi = self.oe.dbusSystemBus.get_object('net.connman', '/net/connman/technology/wifi')
             dbus.Interface(wifi, 'net.connman.Technology').Scan()
@@ -1352,45 +1352,45 @@ class connman:
             del wifi
             self.oe.set_busy(0)
             self.menu_connections(None)
-            self.oe.dbg_log('connman::refresh_network', 'exit_function', 0)
+            self.oe.dbg_log('connman::refresh_network', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.set_busy(0)
-            self.oe.dbg_log('connman::refresh_network', 'ERROR: (' + repr(e) + ')', 4)
+            self.oe.dbg_log('connman::refresh_network', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
     def get_service_path(self):
         try:
-            self.oe.dbg_log('connman::get_service_path', 'enter_function', 0)
+            self.oe.dbg_log('connman::get_service_path', 'enter_function', self.oe.LOGDEBUG)
             if hasattr(self, 'winOeCon'):
                 return self.winOeCon.service_path
             else:
                 listItem = self.oe.winOeMain.getControl(self.oe.listObject['netlist']).getSelectedItem()
                 return listItem.getProperty('entry')
-            self.oe.dbg_log('connman::get_service_path', 'exit_function', 0)
+            self.oe.dbg_log('connman::get_service_path', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('connman::get_service_path', 'ERROR: (' + repr(e) + ')', 4)
+            self.oe.dbg_log('connman::get_service_path', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
     def start_service(self):
         try:
-            self.oe.dbg_log('connman::start_service', 'enter_function', 0)
+            self.oe.dbg_log('connman::start_service', 'enter_function', self.oe.LOGDEBUG)
             self.load_values()
             self.init_netfilter(service=1)
-            self.oe.dbg_log('connman::start_service', 'exit_function', 0)
+            self.oe.dbg_log('connman::start_service', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.dbg_log('connman::start_service', 'ERROR: (' + repr(e) + ')')
 
     def stop_service(self):
         try:
-            self.oe.dbg_log('connman::stop_service', 'enter_function', 0)
+            self.oe.dbg_log('connman::stop_service', 'enter_function', self.oe.LOGDEBUG)
             if hasattr(self, 'dbusConnmanManager'):
                 self.dbusConnmanManager = None
                 del self.dbusConnmanManager
-            self.oe.dbg_log('connman::stop_service', 'exit_function', 0)
+            self.oe.dbg_log('connman::stop_service', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.dbg_log('system::stop_service', 'ERROR: (' + repr(e) + ')')
 
     def set_network_wait(self, **kwargs):
         try:
-            self.oe.dbg_log('connman::set_network_wait', 'enter_function', 0)
+            self.oe.dbg_log('connman::set_network_wait', 'enter_function', self.oe.LOGDEBUG)
             if 'listItem' in kwargs:
                 self.set_value(kwargs['listItem'])
             if self.struct['advanced']['settings']['wait_for_network']['value'] == '0':
@@ -1404,13 +1404,13 @@ class connman:
                 wait_conf.write('WAIT_NETWORK="true"\n')
                 wait_conf.write('WAIT_NETWORK_TIME="%s"\n' % self.struct['advanced']['settings']['wait_for_network_time']['value'])
                 wait_conf.close()
-            self.oe.dbg_log('connman::set_network_wait', 'exit_function', 0)
+            self.oe.dbg_log('connman::set_network_wait', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.dbg_log('system::set_network_wait', 'ERROR: (' + repr(e) + ')')
 
     def init_netfilter(self, **kwargs):
         try:
-            self.oe.dbg_log('connman::init_netfilter', 'enter_function', 0)
+            self.oe.dbg_log('connman::init_netfilter', 'enter_function', self.oe.LOGDEBUG)
             self.oe.set_busy(1)
             if 'listItem' in kwargs:
                 self.set_value(kwargs['listItem'])
@@ -1426,13 +1426,13 @@ class connman:
                 state = 0
             self.oe.set_service('iptables', options, state)
             self.oe.set_busy(0)
-            self.oe.dbg_log('connman::init_netfilter', 'exit_function', 0)
+            self.oe.dbg_log('connman::init_netfilter', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.dbg_log('system::init_netfilter', 'ERROR: (' + repr(e) + ')')
 
     def do_wizard(self):
         try:
-            self.oe.dbg_log('connman::do_wizard', 'enter_function', 0)
+            self.oe.dbg_log('connman::do_wizard', 'enter_function', self.oe.LOGDEBUG)
             self.oe.winOeMain.set_wizard_title(self.oe._(32305))
             self.oe.winOeMain.set_wizard_text(self.oe._(32306))
             self.oe.winOeMain.set_wizard_button_title('')
@@ -1449,7 +1449,7 @@ class connman:
                                          ]).controlLeft(self.oe.winOeMain.getControl(self.oe.winOeMain.buttons[2]['id']))
 
             self.menu_connections(None)
-            self.oe.dbg_log('connman::do_wizard', 'exit_function', 0)
+            self.oe.dbg_log('connman::do_wizard', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.dbg_log('connman::do_wizard', 'ERROR: (' + repr(e) + ')')
 
@@ -1457,19 +1457,19 @@ class connman:
 
         def __init__(self, oeMain, parent):
             try:
-                oeMain.dbg_log('connman::monitor::__init__', 'enter_function', 0)
+                oeMain.dbg_log('connman::monitor::__init__', 'enter_function', oeMain.LOGDEBUG)
                 self.oe = oeMain
                 self.signal_receivers = []
                 self.NameOwnerWatch = None
                 self.parent = parent
                 self.wifiAgentPath = '/LibreELEC/agent_wifi'
-                self.oe.dbg_log('connman::monitor::__init__', 'exit_function', 0)
+                self.oe.dbg_log('connman::monitor::__init__', 'exit_function', self.oe.LOGDEBUG)
             except Exception as e:
                 self.oe.dbg_log('connman::monitor::__init__', 'ERROR: (' + repr(e) + ')')
 
         def add_signal_receivers(self):
             try:
-                self.oe.dbg_log('connman::monitor::add_signal_receivers', 'enter_function', 0)
+                self.oe.dbg_log('connman::monitor::add_signal_receivers', 'enter_function', self.oe.LOGDEBUG)
                 self.signal_receivers.append(self.oe.dbusSystemBus.add_signal_receiver(self.propertyChanged, bus_name='net.connman',
                                              dbus_interface='net.connman.Manager', signal_name='PropertyChanged', path_keyword='path'))
                 self.signal_receivers.append(self.oe.dbusSystemBus.add_signal_receiver(self.servicesChanged, bus_name='net.connman',
@@ -1481,13 +1481,13 @@ class connman:
                 self.signal_receivers.append(self.oe.dbusSystemBus.add_signal_receiver(self.managerPropertyChanged, bus_name='net.connman',
                                              signal_name='PropertyChanged', path_keyword='path', interface_keyword='interface'))
                 self.conNameOwnerWatch = self.oe.dbusSystemBus.watch_name_owner('net.connman', self.conNameOwnerChanged)
-                self.oe.dbg_log('connman::monitor::add_signal_receivers', 'exit_function', 0)
+                self.oe.dbg_log('connman::monitor::add_signal_receivers', 'exit_function', self.oe.LOGDEBUG)
             except Exception as e:
-                self.oe.dbg_log('connman::monitor::add_signal_receivers', 'ERROR: (' + repr(e) + ')', 4)
+                self.oe.dbg_log('connman::monitor::add_signal_receivers', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
         def remove_signal_receivers(self):
             try:
-                self.oe.dbg_log('connman::monitor::remove_signal_receivers', 'enter_function', 0)
+                self.oe.dbg_log('connman::monitor::remove_signal_receivers', 'enter_function', self.oe.LOGDEBUG)
                 for signal_receiver in self.signal_receivers:
                     signal_receiver.remove()
                     signal_receiver = None
@@ -1495,37 +1495,37 @@ class connman:
                 self.conNameOwnerWatch = None
                 if hasattr(self, 'wifiAgent'):
                     self.remove_agent()
-                self.oe.dbg_log('connman::monitor::remove_signal_receivers', 'exit_function', 0)
+                self.oe.dbg_log('connman::monitor::remove_signal_receivers', 'exit_function', self.oe.LOGDEBUG)
             except Exception as e:
-                self.oe.dbg_log('connman::monitor::remove_signal_receivers', 'ERROR: (' + repr(e) + ')', 4)
+                self.oe.dbg_log('connman::monitor::remove_signal_receivers', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
         def conNameOwnerChanged(self, proxy):
             try:
-                self.oe.dbg_log('connman::monitor::nameOwnerChanged', 'enter_function', 0)
+                self.oe.dbg_log('connman::monitor::nameOwnerChanged', 'enter_function', self.oe.LOGDEBUG)
                 if proxy:
                     self.initialize_agent()
                 else:
                     self.remove_agent()
-                self.oe.dbg_log('connman::monitor::nameOwnerChanged', 'exit_function', 0)
+                self.oe.dbg_log('connman::monitor::nameOwnerChanged', 'exit_function', self.oe.LOGDEBUG)
             except Exception as e:
-                self.oe.dbg_log('connman::monitor::nameOwnerChanged', 'ERROR: (' + repr(e) + ')', 4)
+                self.oe.dbg_log('connman::monitor::nameOwnerChanged', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
         def initialize_agent(self):
             try:
-                self.oe.dbg_log('connman::monitor::initialize_agent', 'enter_function', 0)
+                self.oe.dbg_log('connman::monitor::initialize_agent', 'enter_function', self.oe.LOGDEBUG)
                 if not hasattr(self, 'wifiAgent'):
                     dbusConnmanManager = dbus.Interface(self.oe.dbusSystemBus.get_object('net.connman', '/'), 'net.connman.Manager')
                     self.wifiAgent = connmanWifiAgent(self.oe.dbusSystemBus, self.wifiAgentPath)
                     self.wifiAgent.oe = self.oe
                     dbusConnmanManager.RegisterAgent(self.wifiAgentPath)
                     dbusConnmanManager = None
-                self.oe.dbg_log('connman::monitor::initialize_agent', 'exit_function', 0)
+                self.oe.dbg_log('connman::monitor::initialize_agent', 'exit_function', self.oe.LOGDEBUG)
             except Exception as e:
-                self.oe.dbg_log('connman::monitor::initialize_agent', 'ERROR: (' + repr(e) + ')', 4)
+                self.oe.dbg_log('connman::monitor::initialize_agent', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
         def remove_agent(self):
             try:
-                self.oe.dbg_log('connman::monitor::remove_agent', 'enter_function', 0)
+                self.oe.dbg_log('connman::monitor::remove_agent', 'enter_function', self.oe.LOGDEBUG)
                 if hasattr(self, 'wifiAgent'):
                     self.wifiAgent.remove_from_connection(self.oe.dbusSystemBus, self.wifiAgentPath)
                     try:
@@ -1535,63 +1535,63 @@ class connman:
                     except:
                         dbusConnmanManager = None
                     del self.wifiAgent
-                self.oe.dbg_log('connman::monitor::remove_agent', 'exit_function', 0)
+                self.oe.dbg_log('connman::monitor::remove_agent', 'exit_function', self.oe.LOGDEBUG)
             except Exception as e:
-                self.oe.dbg_log('connman::monitor::remove_agent', 'ERROR: (' + repr(e) + ')', 4)
+                self.oe.dbg_log('connman::monitor::remove_agent', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
         def managerPropertyChanged(self, name, value, path, interface):
             try:
-                self.oe.dbg_log('connman::monitor::managerPropertyChanged', 'enter_function', 0)
-                self.oe.dbg_log('connman::monitor::managerPropertyChanged::name', repr(name), 0)
-                self.oe.dbg_log('connman::monitor::managerPropertyChanged::value', repr(value), 0)
-                self.oe.dbg_log('connman::monitor::managerPropertyChanged::path', repr(path), 0)
-                self.oe.dbg_log('connman::monitor::managerPropertyChanged::interface', repr(interface), 0)
-                self.oe.dbg_log('connman::monitor::managerPropertyChanged', 'exit_function', 0)
+                self.oe.dbg_log('connman::monitor::managerPropertyChanged', 'enter_function', self.oe.LOGDEBUG)
+                self.oe.dbg_log('connman::monitor::managerPropertyChanged::name', repr(name), self.oe.LOGDEBUG)
+                self.oe.dbg_log('connman::monitor::managerPropertyChanged::value', repr(value), self.oe.LOGDEBUG)
+                self.oe.dbg_log('connman::monitor::managerPropertyChanged::path', repr(path), self.oe.LOGDEBUG)
+                self.oe.dbg_log('connman::monitor::managerPropertyChanged::interface', repr(interface), self.oe.LOGDEBUG)
+                self.oe.dbg_log('connman::monitor::managerPropertyChanged', 'exit_function', self.oe.LOGDEBUG)
             except Exception as e:
-                self.oe.dbg_log('connman::monitor::managerPropertyChanged', 'ERROR: (' + repr(e) + ')', 4)
+                self.oe.dbg_log('connman::monitor::managerPropertyChanged', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
         def propertyChanged(self, name, value, path):
             try:
-                self.oe.dbg_log('connman::monitor::propertyChanged', 'enter_function', 0)
-                self.oe.dbg_log('connman::monitor::propertyChanged::name', repr(name), 0)
-                self.oe.dbg_log('connman::monitor::propertyChanged::value', repr(value), 0)
-                self.oe.dbg_log('connman::monitor::propertyChanged::path', repr(path), 0)
+                self.oe.dbg_log('connman::monitor::propertyChanged', 'enter_function', self.oe.LOGDEBUG)
+                self.oe.dbg_log('connman::monitor::propertyChanged::name', repr(name), self.oe.LOGDEBUG)
+                self.oe.dbg_log('connman::monitor::propertyChanged::value', repr(value), self.oe.LOGDEBUG)
+                self.oe.dbg_log('connman::monitor::propertyChanged::path', repr(path), self.oe.LOGDEBUG)
                 if self.parent.visible:
                     self.updateGui(name, value, path)
-                self.oe.dbg_log('connman::monitor::propertyChanged', 'exit_function', 0)
+                self.oe.dbg_log('connman::monitor::propertyChanged', 'exit_function', self.oe.LOGDEBUG)
             except Exception as e:
-                self.oe.dbg_log('connman::monitor::propertyChanged', 'ERROR: (' + repr(e) + ')', 4)
+                self.oe.dbg_log('connman::monitor::propertyChanged', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
         def technologyChanged(self, name, value, path):
             try:
-                self.oe.dbg_log('connman::monitor::technologyChanged', 'enter_function', 0)
-                self.oe.dbg_log('connman::monitor::technologyChanged::name', repr(name), 0)
-                self.oe.dbg_log('connman::monitor::technologyChanged::value', repr(value), 0)
-                self.oe.dbg_log('connman::monitor::technologyChanged::path', repr(path), 0)
+                self.oe.dbg_log('connman::monitor::technologyChanged', 'enter_function', self.oe.LOGDEBUG)
+                self.oe.dbg_log('connman::monitor::technologyChanged::name', repr(name), self.oe.LOGDEBUG)
+                self.oe.dbg_log('connman::monitor::technologyChanged::value', repr(value), self.oe.LOGDEBUG)
+                self.oe.dbg_log('connman::monitor::technologyChanged::path', repr(path), self.oe.LOGDEBUG)
                 if self.parent.visible:
                     if self.parent.oe.winOeMain.lastMenu == 1:
                         self.parent.oe.winOeMain.lastMenu = -1
                         self.parent.oe.winOeMain.onFocus(self.parent.oe.winOeMain.guiMenList)
                     else:
                         self.updateGui(name, value, path)
-                self.oe.dbg_log('connman::monitor::technologyChanged', 'exit_function', 0)
+                self.oe.dbg_log('connman::monitor::technologyChanged', 'exit_function', self.oe.LOGDEBUG)
             except Exception as e:
-                self.oe.dbg_log('connman::monitor::technologyChanged', 'ERROR: (' + repr(e) + ')', 4)
+                self.oe.dbg_log('connman::monitor::technologyChanged', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
         def servicesChanged(self, services, removed):
             try:
-                self.oe.dbg_log('connman::monitor::servicesChanged', 'enter_function', 0)
-                self.oe.dbg_log('connman::monitor::servicesChanged::services', repr(services), 0)
-                self.oe.dbg_log('connman::monitor::servicesChanged::removed', repr(removed), 0)
+                self.oe.dbg_log('connman::monitor::servicesChanged', 'enter_function', self.oe.LOGDEBUG)
+                self.oe.dbg_log('connman::monitor::servicesChanged::services', repr(services), self.oe.LOGDEBUG)
+                self.oe.dbg_log('connman::monitor::servicesChanged::removed', repr(removed), self.oe.LOGDEBUG)
                 if self.parent.visible:
                     self.parent.menu_connections(None, services, removed, force=True)
-                self.oe.dbg_log('connman::monitor::servicesChanged', 'exit_function', 0)
+                self.oe.dbg_log('connman::monitor::servicesChanged', 'exit_function', self.oe.LOGDEBUG)
             except Exception as e:
-                self.oe.dbg_log('connman::monitor::servicesChanged', 'ERROR: (' + repr(e) + ')', 4)
+                self.oe.dbg_log('connman::monitor::servicesChanged', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
         def updateGui(self, name, value, path):
             try:
-                self.oe.dbg_log('connman::monitor::updateGui', 'enter_function', 0)
+                self.oe.dbg_log('connman::monitor::updateGui', 'enter_function', self.oe.LOGDEBUG)
                 if name == 'Strength':
                     value = str(int(value))
                     self.parent.listItems[path].setProperty(name, value)
@@ -1614,22 +1614,22 @@ class connman:
                     self.forceRender()
                 if hasattr(self.parent, 'is_wizard'):
                     self.parent.menu_connections(None, {}, {}, force=True)
-                self.oe.dbg_log('connman::monitor::updateGui', 'exit_function', 0)
+                self.oe.dbg_log('connman::monitor::updateGui', 'exit_function', self.oe.LOGDEBUG)
             except KeyError:
-                self.oe.dbg_log('connman::monitor::updateGui', 'exit_function (KeyError)', 0)
+                self.oe.dbg_log('connman::monitor::updateGui', 'exit_function (KeyError)', self.oe.LOGDEBUG)
                 self.parent.menu_connections(None, {}, {}, force=True)
             except Exception as e:
-                self.oe.dbg_log('connman::monitor::updateGui', 'ERROR: (' + repr(e) + ')', 4)
+                self.oe.dbg_log('connman::monitor::updateGui', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
         def forceRender(self):
             try:
-                self.oe.dbg_log('connman::monitor::forceRender', 'enter_function', 0)
+                self.oe.dbg_log('connman::monitor::forceRender', 'enter_function', self.oe.LOGDEBUG)
                 focusId = self.oe.winOeMain.getFocusId()
                 self.oe.winOeMain.setFocusId(self.oe.listObject['netlist'])
                 self.oe.winOeMain.setFocusId(focusId)
-                self.oe.dbg_log('connman::monitor::forceRender', 'exit_function', 0)
+                self.oe.dbg_log('connman::monitor::forceRender', 'exit_function', self.oe.LOGDEBUG)
             except Exception as e:
-                self.oe.dbg_log('connman::monitor::forceRender', 'ERROR: (' + repr(e) + ')', 4)
+                self.oe.dbg_log('connman::monitor::forceRender', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
 
 class Failed(dbus.DBusException):
@@ -1659,14 +1659,14 @@ class connmanWifiAgent(dbus.service.Object):
 
     @dbus.service.method('net.connman.Agent', in_signature='', out_signature='')
     def Release(self):
-        self.oe.dbg_log('connman::connmanWifiAgent::Release', 'enter_function', 0)
-        self.oe.dbg_log('connman::connmanWifiAgent::Release', 'exit_function', 0)
+        self.oe.dbg_log('connman::connmanWifiAgent::Release', 'enter_function', self.oe.LOGDEBUG)
+        self.oe.dbg_log('connman::connmanWifiAgent::Release', 'exit_function', self.oe.LOGDEBUG)
         return {}
 
     @dbus.service.method('net.connman.Agent', in_signature='oa{sv}', out_signature='a{sv}')
     def RequestInput(self, path, fields):
         try:
-            self.oe.dbg_log('connman::connmanWifiAgent::RequestInput', 'enter_function', 0)
+            self.oe.dbg_log('connman::connmanWifiAgent::RequestInput', 'enter_function', self.oe.LOGDEBUG)
             self.oe.input_request = True
             response = {}
             if 'Name' in fields:
@@ -1730,26 +1730,26 @@ class connmanWifiAgent(dbus.service.Object):
                     raise Canceled('canceled')
                     return response
             self.busy()
-            self.oe.dbg_log('connman::connmanWifiAgent::RequestInput', 'exit_function', 0)
+            self.oe.dbg_log('connman::connmanWifiAgent::RequestInput', 'exit_function', self.oe.LOGDEBUG)
             return response
         except Exception as e:
-            self.oe.dbg_log('connman::connmanWifiAgent::RequestInput', 'ERROR: (' + repr(e) + ')', 4)
+            self.oe.dbg_log('connman::connmanWifiAgent::RequestInput', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
     @dbus.service.method('net.connman.Agent', in_signature='os', out_signature='')
     def RequestBrowser(self, path, url):
-        self.oe.dbg_log('connman::connmanWifiAgent::RequestBrowser', 'enter_function', 0)
-        self.oe.dbg_log('connman::connmanWifiAgent::RequestBrowser', 'exit_function', 0)
+        self.oe.dbg_log('connman::connmanWifiAgent::RequestBrowser', 'enter_function', self.oe.LOGDEBUG)
+        self.oe.dbg_log('connman::connmanWifiAgent::RequestBrowser', 'exit_function', self.oe.LOGDEBUG)
         return
 
     @dbus.service.method('net.connman.Agent', in_signature='os', out_signature='')
     def ReportError(self, path, error):
-        self.oe.dbg_log('connman::connmanWifiAgent::ReportError', 'enter_function', 0)
-        self.oe.dbg_log('connman::connmanWifiAgent::ReportError', 'exit_function (CANCELED)', 0)
+        self.oe.dbg_log('connman::connmanWifiAgent::ReportError', 'enter_function', self.oe.LOGDEBUG)
+        self.oe.dbg_log('connman::connmanWifiAgent::ReportError', 'exit_function (CANCELED)', self.oe.LOGDEBUG)
         raise Failed()
         return
 
     @dbus.service.method('net.connman.Agent', in_signature='', out_signature='')
     def Cancel(self):
-        self.oe.dbg_log('connman::connmanWifiAgent::Cancel', 'enter_function', 0)
-        self.oe.dbg_log('connman::connmanWifiAgent::Cancel', 'exit_function', 0)
+        self.oe.dbg_log('connman::connmanWifiAgent::Cancel', 'enter_function', self.oe.LOGDEBUG)
+        self.oe.dbg_log('connman::connmanWifiAgent::Cancel', 'exit_function', self.oe.LOGDEBUG)
         return

--- a/src/resources/lib/modules/services.py
+++ b/src/resources/lib/modules/services.py
@@ -41,7 +41,7 @@ class services:
 
     def __init__(self, oeMain):
         try:
-            oeMain.dbg_log('services::__init__', 'enter_function', 0)
+            oeMain.dbg_log('services::__init__', 'enter_function', oeMain.LOGDEBUG)
             self.struct = {
                 'samba': {
                     'order': 1,
@@ -280,57 +280,57 @@ class services:
                 }
 
             self.oe = oeMain
-            oeMain.dbg_log('services::__init__', 'exit_function', 0)
+            oeMain.dbg_log('services::__init__', 'exit_function', oeMain.LOGDEBUG)
         except Exception as e:
             self.oe.dbg_log('services::__init__', 'ERROR: (%s)' % repr(e))
 
     def start_service(self):
         try:
-            self.oe.dbg_log('services::start_service', 'enter_function', 0)
+            self.oe.dbg_log('services::start_service', 'enter_function', self.oe.LOGDEBUG)
             self.load_values()
             self.initialize_samba(service=1)
             self.initialize_ssh(service=1)
             self.initialize_avahi(service=1)
             self.initialize_cron(service=1)
             self.init_bluetooth(service=1)
-            self.oe.dbg_log('services::start_service', 'exit_function', 0)
+            self.oe.dbg_log('services::start_service', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.dbg_log('services::start_service', 'ERROR: (%s)' % repr(e))
 
     def stop_service(self):
         try:
-            self.oe.dbg_log('services::stop_service', 'enter_function', 0)
-            self.oe.dbg_log('services::stop_service', 'exit_function', 0)
+            self.oe.dbg_log('services::stop_service', 'enter_function', self.oe.LOGDEBUG)
+            self.oe.dbg_log('services::stop_service', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.dbg_log('services::stop_service', 'ERROR: (' + repr(e) + ')')
 
     def do_init(self):
         try:
-            self.oe.dbg_log('services::do_init', 'exit_function', 0)
+            self.oe.dbg_log('services::do_init', 'exit_function', self.oe.LOGDEBUG)
             self.load_values()
-            self.oe.dbg_log('services::do_init', 'exit_function', 0)
+            self.oe.dbg_log('services::do_init', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.dbg_log('services::do_init', 'ERROR: (%s)' % repr(e))
 
     def set_value(self, listItem):
         try:
-            self.oe.dbg_log('services::set_value', 'enter_function', 0)
+            self.oe.dbg_log('services::set_value', 'enter_function', self.oe.LOGDEBUG)
             self.struct[listItem.getProperty('category')]['settings'][listItem.getProperty('entry')]['value'] = listItem.getProperty('value')
-            self.oe.dbg_log('services::set_value', 'exit_function', 0)
+            self.oe.dbg_log('services::set_value', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.dbg_log('services::set_value', 'ERROR: (' + repr(e) + ')')
 
     def load_menu(self, focusItem):
         try:
-            self.oe.dbg_log('services::load_menu', 'enter_function', 0)
+            self.oe.dbg_log('services::load_menu', 'enter_function', self.oe.LOGDEBUG)
             self.oe.winOeMain.build_menu(self.struct)
-            self.oe.dbg_log('services::load_menu', 'exit_function', 0)
+            self.oe.dbg_log('services::load_menu', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.dbg_log('services::load_menu', 'ERROR: (%s)' % repr(e))
 
     def load_values(self):
         try:
-            self.oe.dbg_log('services::load_values', 'enter_function', 0)
+            self.oe.dbg_log('services::load_values', 'enter_function', self.oe.LOGDEBUG)
 
             # SAMBA
 
@@ -405,13 +405,13 @@ class services:
                 else:
                     self.struct['bluez']['hidden'] = 'true'
 
-            self.oe.dbg_log('services::load_values', 'exit_function', 0)
+            self.oe.dbg_log('services::load_values', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.dbg_log('services::load_values', 'ERROR: (%s)' % repr(e))
 
     def initialize_samba(self, **kwargs):
         try:
-            self.oe.dbg_log('services::initialize_samba', 'enter_function', 0)
+            self.oe.dbg_log('services::initialize_samba', 'enter_function', self.oe.LOGDEBUG)
             self.oe.set_busy(1)
             if 'listItem' in kwargs:
                 self.set_value(kwargs['listItem'])
@@ -443,14 +443,14 @@ class services:
                 self.struct['samba']['settings']['samba_password']['hidden'] = True
             self.oe.set_service('samba', options, state)
             self.oe.set_busy(0)
-            self.oe.dbg_log('services::initialize_samba', 'exit_function', 0)
+            self.oe.dbg_log('services::initialize_samba', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.set_busy(0)
-            self.oe.dbg_log('services::initialize_samba', 'ERROR: (%s)' % repr(e), 4)
+            self.oe.dbg_log('services::initialize_samba', 'ERROR: (%s)' % repr(e), self.oe.LOGERROR)
 
     def initialize_ssh(self, **kwargs):
         try:
-            self.oe.dbg_log('services::initialize_ssh', 'enter_function', 0)
+            self.oe.dbg_log('services::initialize_ssh', 'enter_function', self.oe.LOGDEBUG)
             self.oe.set_busy(1)
             if 'listItem' in kwargs:
                 self.set_value(kwargs['listItem'])
@@ -468,14 +468,14 @@ class services:
                 state = 0
             self.oe.set_service('sshd', options, state)
             self.oe.set_busy(0)
-            self.oe.dbg_log('services::initialize_ssh', 'exit_function', 0)
+            self.oe.dbg_log('services::initialize_ssh', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.set_busy(0)
-            self.oe.dbg_log('services::initialize_ssh', 'ERROR: (%s)' % repr(e), 4)
+            self.oe.dbg_log('services::initialize_ssh', 'ERROR: (%s)' % repr(e), self.oe.LOGERROR)
 
     def initialize_avahi(self, **kwargs):
         try:
-            self.oe.dbg_log('services::initialize_avahi', 'enter_function', 0)
+            self.oe.dbg_log('services::initialize_avahi', 'enter_function', self.oe.LOGDEBUG)
             self.oe.set_busy(1)
             if 'listItem' in kwargs:
                 self.set_value(kwargs['listItem'])
@@ -485,14 +485,14 @@ class services:
                 state = 0
             self.oe.set_service('avahi', options, state)
             self.oe.set_busy(0)
-            self.oe.dbg_log('services::initialize_avahi', 'exit_function', 0)
+            self.oe.dbg_log('services::initialize_avahi', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.set_busy(0)
-            self.oe.dbg_log('services::initialize_avahi', 'ERROR: (%s)' % repr(e), 4)
+            self.oe.dbg_log('services::initialize_avahi', 'ERROR: (%s)' % repr(e), self.oe.LOGERROR)
 
     def initialize_cron(self, **kwargs):
         try:
-            self.oe.dbg_log('services::initialize_cron', 'enter_function', 0)
+            self.oe.dbg_log('services::initialize_cron', 'enter_function', self.oe.LOGDEBUG)
             self.oe.set_busy(1)
             if 'listItem' in kwargs:
                 self.set_value(kwargs['listItem'])
@@ -502,14 +502,14 @@ class services:
                 state = 0
             self.oe.set_service('crond', options, state)
             self.oe.set_busy(0)
-            self.oe.dbg_log('services::initialize_cron', 'exit_function', 0)
+            self.oe.dbg_log('services::initialize_cron', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.set_busy(0)
-            self.oe.dbg_log('services::initialize_cron', 'ERROR: (%s)' % repr(e), 4)
+            self.oe.dbg_log('services::initialize_cron', 'ERROR: (%s)' % repr(e), self.oe.LOGERROR)
 
     def init_bluetooth(self, **kwargs):
         try:
-            self.oe.dbg_log('services::init_bluetooth', 'enter_function', 0)
+            self.oe.dbg_log('services::init_bluetooth', 'enter_function', self.oe.LOGDEBUG)
             self.oe.set_busy(1)
             if 'listItem' in kwargs:
                 self.set_value(kwargs['listItem'])
@@ -526,14 +526,14 @@ class services:
                     del self.struct['bluez']['settings']['obex_root']['hidden']
             self.oe.set_service('bluez', options, state)
             self.oe.set_busy(0)
-            self.oe.dbg_log('services::init_bluetooth', 'exit_function', 0)
+            self.oe.dbg_log('services::init_bluetooth', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.set_busy(0)
-            self.oe.dbg_log('services::init_bluetooth', 'ERROR: (' + repr(e) + ')', 4)
+            self.oe.dbg_log('services::init_bluetooth', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
     def init_obex(self, **kwargs):
         try:
-            self.oe.dbg_log('services::init_obex', 'enter_function', 0)
+            self.oe.dbg_log('services::init_obex', 'enter_function', self.oe.LOGDEBUG)
             self.oe.set_busy(1)
             if 'listItem' in kwargs:
                 self.set_value(kwargs['listItem'])
@@ -545,34 +545,34 @@ class services:
                 state = 0
             self.oe.set_service('obexd', options, state)
             self.oe.set_busy(0)
-            self.oe.dbg_log('services::init_obex', 'exit_function', 0)
+            self.oe.dbg_log('services::init_obex', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.set_busy(0)
-            self.oe.dbg_log('services::init_obex', 'ERROR: (' + repr(e) + ')', 4)
+            self.oe.dbg_log('services::init_obex', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
     def idle_timeout(self, **kwargs):
         try:
-            self.oe.dbg_log('services::idle_timeout', 'enter_function', 0)
+            self.oe.dbg_log('services::idle_timeout', 'enter_function', self.oe.LOGDEBUG)
             self.oe.set_busy(1)
             if 'listItem' in kwargs:
                 self.set_value(kwargs['listItem'])
             self.oe.write_setting('bluetooth', 'idle_timeout', self.struct['bluez']['settings']['idle_timeout']['value'])
             self.oe.set_busy(0)
-            self.oe.dbg_log('services::idle_timeout', 'exit_function', 0)
+            self.oe.dbg_log('services::idle_timeout', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.set_busy(0)
-            self.oe.dbg_log('services::idle_timeout', 'ERROR: (' + repr(e) + ')', 4)
+            self.oe.dbg_log('services::idle_timeout', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
     def exit(self):
         try:
-            self.oe.dbg_log('services::exit', 'enter_function', 0)
-            self.oe.dbg_log('services::exit', 'exit_function', 0)
+            self.oe.dbg_log('services::exit', 'enter_function', self.oe.LOGDEBUG)
+            self.oe.dbg_log('services::exit', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('services::exit', 'ERROR: (%s)' % repr(e), 4)
+            self.oe.dbg_log('services::exit', 'ERROR: (%s)' % repr(e), self.oe.LOGERROR)
 
     def do_wizard(self):
         try:
-            self.oe.dbg_log('services::do_wizard', 'enter_function', 0)
+            self.oe.dbg_log('services::do_wizard', 'enter_function', self.oe.LOGDEBUG)
             self.oe.winOeMain.set_wizard_title(self.oe._(32311))
 
             # Enable samba
@@ -585,13 +585,13 @@ class services:
                 self.oe.winOeMain.set_wizard_text(self.oe._(32312))
             self.oe.winOeMain.set_wizard_button_title(self.oe._(32316))
             self.set_wizard_buttons()
-            self.oe.dbg_log('services::do_wizard', 'exit_function', 0)
+            self.oe.dbg_log('services::do_wizard', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.dbg_log('services::do_wizard', 'ERROR: (%s)' % repr(e))
 
     def set_wizard_buttons(self):
         try:
-            self.oe.dbg_log('services::set_wizard_buttons', 'enter_function', 0)
+            self.oe.dbg_log('services::set_wizard_buttons', 'enter_function', self.oe.LOGDEBUG)
             if self.struct['ssh']['settings']['ssh_autostart']['value'] == '1':
                 self.oe.winOeMain.set_wizard_radiobutton_1(self.oe._(32201), self, 'wizard_set_ssh', True)
             else:
@@ -601,13 +601,13 @@ class services:
                     self.oe.winOeMain.set_wizard_radiobutton_2(self.oe._(32200), self, 'wizard_set_samba', True)
                 else:
                     self.oe.winOeMain.set_wizard_radiobutton_2(self.oe._(32200), self, 'wizard_set_samba')
-            self.oe.dbg_log('services::set_wizard_buttons', 'exit_function', 0)
+            self.oe.dbg_log('services::set_wizard_buttons', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.dbg_log('services::set_wizard_buttons', 'ERROR: (%s)' % repr(e))
 
     def wizard_set_ssh(self):
         try:
-            self.oe.dbg_log('services::wizard_set_ssh', 'enter_function', 0)
+            self.oe.dbg_log('services::wizard_set_ssh', 'enter_function', self.oe.LOGDEBUG)
             if self.struct['ssh']['settings']['ssh_autostart']['value'] == '1':
                 self.struct['ssh']['settings']['ssh_autostart']['value'] = '0'
             else:
@@ -625,13 +625,13 @@ class services:
             if self.struct['ssh']['settings']['ssh_autostart']['value'] == '1':
                 self.wizard_sshpasswd()
             self.set_wizard_buttons()
-            self.oe.dbg_log('services::wizard_set_ssh', 'exit_function', 0)
+            self.oe.dbg_log('services::wizard_set_ssh', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.dbg_log('services::wizard_set_ssh', 'ERROR: (%s)' % repr(e))
 
     def wizard_set_samba(self):
         try:
-            self.oe.dbg_log('services::wizard_set_samba', 'enter_function', 0)
+            self.oe.dbg_log('services::wizard_set_samba', 'enter_function', self.oe.LOGDEBUG)
             if self.struct['samba']['settings']['samba_autostart']['value'] == '1':
                 self.struct['samba']['settings']['samba_autostart']['value'] = '0'
             else:
@@ -639,7 +639,7 @@ class services:
             self.initialize_samba()
             self.load_values()
             self.set_wizard_buttons()
-            self.oe.dbg_log('services::wizard_set_samba', 'exit_function', 0)
+            self.oe.dbg_log('services::wizard_set_samba', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.dbg_log('services::wizard_set_samba', 'ERROR: (%s)' % repr(e))
 
@@ -657,7 +657,7 @@ class services:
 
     def do_sshpasswd(self, **kwargs):
         try:
-            self.oe.dbg_log('system::do_sshpasswd', 'enter_function', 0)
+            self.oe.dbg_log('system::do_sshpasswd', 'enter_function', self.oe.LOGDEBUG)
             SSHchange = False
             newpwd = xbmcDialog.input(self.oe._(746))
             if newpwd:
@@ -673,16 +673,16 @@ class services:
                     readout3 = ssh.stdout.readline()
                 if "Bad password" in readout3:
                     xbmcDialog.ok(self.oe._(32220), self.oe._(32221))
-                    self.oe.dbg_log('system::do_sshpasswd', 'exit_function password too weak', 0)
+                    self.oe.dbg_log('system::do_sshpasswd', 'exit_function password too weak', self.oe.LOGDEBUG)
                     return
                 elif "Retype password" in readout3:
                     xbmcDialog.ok(self.oe._(32222), self.oe._(32223))
                     SSHchange = True
                 else:
                     xbmcDialog.ok(self.oe._(32224), self.oe._(32225))
-                self.oe.dbg_log('system::do_sshpasswd', 'exit_function', 0)
+                self.oe.dbg_log('system::do_sshpasswd', 'exit_function', self.oe.LOGDEBUG)
             else:
-                self.oe.dbg_log('system::do_sshpasswd', 'user_cancelled', 0)
+                self.oe.dbg_log('system::do_sshpasswd', 'user_cancelled', self.oe.LOGDEBUG)
             return SSHchange
         except Exception as e:
             self.oe.dbg_log('system::do_sshpasswd', 'ERROR: (' + repr(e) + ')')

--- a/src/resources/lib/modules/system.py
+++ b/src/resources/lib/modules/system.py
@@ -41,7 +41,7 @@ class system:
 
     def __init__(self, oeMain):
         try:
-            oeMain.dbg_log('system::__init__', 'enter_function', 0)
+            oeMain.dbg_log('system::__init__', 'enter_function', oeMain.LOGDEBUG)
             self.oe = oeMain
             self.struct = {
                 'ident': {
@@ -206,47 +206,47 @@ class system:
             self.keyboard_layouts = False
             self.nox_keyboard_layouts = False
             self.arrVariants = {}
-            self.oe.dbg_log('system::__init__', 'exit_function', 0)
+            self.oe.dbg_log('system::__init__', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.dbg_log('system::__init__', 'ERROR: (' + repr(e) + ')')
 
     def start_service(self):
         try:
-            self.oe.dbg_log('system::start_service', 'enter_function', 0)
+            self.oe.dbg_log('system::start_service', 'enter_function', self.oe.LOGDEBUG)
             self.is_service = True
             self.load_values()
             self.set_hostname()
             self.set_keyboard_layout()
             self.set_hw_clock()
             del self.is_service
-            self.oe.dbg_log('system::start_service', 'exit_function', 0)
+            self.oe.dbg_log('system::start_service', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.dbg_log('system::start_service', 'ERROR: (' + repr(e) + ')')
 
     def stop_service(self):
         try:
-            self.oe.dbg_log('system::stop_service', 'enter_function', 0)
+            self.oe.dbg_log('system::stop_service', 'enter_function', self.oe.LOGDEBUG)
             if hasattr(self, 'update_thread'):
                 self.update_thread.stop()
-            self.oe.dbg_log('system::stop_service', 'exit_function', 0)
+            self.oe.dbg_log('system::stop_service', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.dbg_log('system::stop_service', 'ERROR: (' + repr(e) + ')')
 
     def do_init(self):
         try:
-            self.oe.dbg_log('system::do_init', 'enter_function', 0)
-            self.oe.dbg_log('system::do_init', 'exit_function', 0)
+            self.oe.dbg_log('system::do_init', 'enter_function', self.oe.LOGDEBUG)
+            self.oe.dbg_log('system::do_init', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.dbg_log('system::do_init', 'ERROR: (' + repr(e) + ')')
 
     def exit(self):
-        self.oe.dbg_log('system::exit', 'enter_function', 0)
-        self.oe.dbg_log('system::exit', 'exit_function', 0)
+        self.oe.dbg_log('system::exit', 'enter_function', self.oe.LOGDEBUG)
+        self.oe.dbg_log('system::exit', 'exit_function', self.oe.LOGDEBUG)
         pass
 
     def load_values(self):
         try:
-            self.oe.dbg_log('system::load_values', 'enter_function', 0)
+            self.oe.dbg_log('system::load_values', 'enter_function', self.oe.LOGDEBUG)
 
             # Keyboard Layout
             (
@@ -300,24 +300,24 @@ class system:
 
     def load_menu(self, focusItem):
         try:
-            self.oe.dbg_log('system::load_menu', 'enter_function', 0)
+            self.oe.dbg_log('system::load_menu', 'enter_function', self.oe.LOGDEBUG)
             self.oe.winOeMain.build_menu(self.struct)
-            self.oe.dbg_log('system::load_menu', 'exit_function', 0)
+            self.oe.dbg_log('system::load_menu', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.dbg_log('system::load_menu', 'ERROR: (' + repr(e) + ')')
 
     def set_value(self, listItem):
         try:
-            self.oe.dbg_log('system::set_value', 'enter_function', 0)
+            self.oe.dbg_log('system::set_value', 'enter_function', self.oe.LOGDEBUG)
             self.struct[listItem.getProperty('category')]['settings'][listItem.getProperty('entry')]['value'] = listItem.getProperty('value')
             self.oe.write_setting('system', listItem.getProperty('entry'), str(listItem.getProperty('value')))
-            self.oe.dbg_log('system::set_value', 'exit_function', 0)
+            self.oe.dbg_log('system::set_value', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.dbg_log('system::set_value', 'ERROR: (' + repr(e) + ')')
 
     def set_keyboard_layout(self, listItem=None):
         try:
-            self.oe.dbg_log('system::set_keyboard_layout', 'enter_function', 0)
+            self.oe.dbg_log('system::set_keyboard_layout', 'enter_function', self.oe.LOGDEBUG)
             if not listItem == None:
                 if listItem.getProperty('entry') == 'KeyboardLayout1':
                     if self.struct['keyboard']['settings']['KeyboardLayout1']['value'] != listItem.getProperty('value'):
@@ -333,7 +333,7 @@ class system:
                         ]['KeyboardLayout2']['value']]
                 self.oe.dbg_log('system::set_keyboard_layout', str(self.struct['keyboard']['settings']['KeyboardLayout1']['value']) + ','
                                 + str(self.struct['keyboard']['settings']['KeyboardLayout2']['value']) + ' ' + '-model '
-                                + str(self.struct['keyboard']['settings']['KeyboardType']['value']), 1)
+                                + str(self.struct['keyboard']['settings']['KeyboardType']['value']), self.oe.LOGINFO)
                 if not os.path.exists(os.path.dirname(self.UDEV_KEYBOARD_INFO)):
                     os.makedirs(os.path.dirname(self.UDEV_KEYBOARD_INFO))
                 config_file = open(self.UDEV_KEYBOARD_INFO, 'w')
@@ -355,24 +355,24 @@ class system:
                     ]
                 self.oe.execute('setxkbmap ' + ' '.join(parameters))
             elif self.nox_keyboard_layouts == True:
-                self.oe.dbg_log('system::set_keyboard_layout', str(self.struct['keyboard']['settings']['KeyboardLayout1']['value']), 1)
+                self.oe.dbg_log('system::set_keyboard_layout', str(self.struct['keyboard']['settings']['KeyboardLayout1']['value']), self.oe.LOGINFO)
                 parameter = self.struct['keyboard']['settings']['KeyboardLayout1']['value']
                 command = 'loadkmap < `ls -1 %s/*/%s.bmap`' % (self.NOX_KEYBOARD_INFO, parameter)
-                self.oe.dbg_log('system::set_keyboard_layout', command, 1)
+                self.oe.dbg_log('system::set_keyboard_layout', command, self.oe.LOGINFO)
                 self.oe.execute(command)
-            self.oe.dbg_log('system::set_keyboard_layout', 'exit_function', 0)
+            self.oe.dbg_log('system::set_keyboard_layout', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.dbg_log('system::set_keyboard_layout', 'ERROR: (' + repr(e) + ')')
 
     def set_hostname(self, listItem=None):
         try:
-            self.oe.dbg_log('system::set_hostname', 'enter_function', 0)
+            self.oe.dbg_log('system::set_hostname', 'enter_function', self.oe.LOGDEBUG)
             self.oe.set_busy(1)
             if not listItem == None:
                 self.set_value(listItem)
             if not self.struct['ident']['settings']['hostname']['value'] is None and not self.struct['ident']['settings']['hostname']['value'] \
                 == '':
-                self.oe.dbg_log('system::set_hostname', self.struct['ident']['settings']['hostname']['value'], 1)
+                self.oe.dbg_log('system::set_hostname', self.struct['ident']['settings']['hostname']['value'], self.oe.LOGINFO)
                 hostname = open('/proc/sys/kernel/hostname', 'w')
                 hostname.write(self.struct['ident']['settings']['hostname']['value'])
                 hostname.close()
@@ -389,16 +389,16 @@ class system:
                 hosts.write('::1\tlocalhost ip6-localhost ip6-loopback %s\n' % self.struct['ident']['settings']['hostname']['value'])
                 hosts.close()
             else:
-                self.oe.dbg_log('system::set_hostname', 'is empty', 1)
+                self.oe.dbg_log('system::set_hostname', 'is empty', self.oe.LOGINFO)
             self.oe.set_busy(0)
-            self.oe.dbg_log('system::set_hostname', 'exit_function', 0)
+            self.oe.dbg_log('system::set_hostname', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.set_busy(0)
             self.oe.dbg_log('system::set_hostname', 'ERROR: (' + repr(e) + ')')
 
     def get_keyboard_layouts(self):
         try:
-            self.oe.dbg_log('system::get_keyboard_layouts', 'enter_function', 0)
+            self.oe.dbg_log('system::get_keyboard_layouts', 'enter_function', self.oe.LOGDEBUG)
             arrLayouts = []
             arrVariants = {}
             arrTypes = []
@@ -452,9 +452,9 @@ class system:
                 arrLayouts.sort()
                 arrTypes.sort()
             else:
-                self.oe.dbg_log('system::get_keyboard_layouts', 'exit_function (no keyboard layouts found)', 0)
+                self.oe.dbg_log('system::get_keyboard_layouts', 'exit_function (no keyboard layouts found)', self.oe.LOGDEBUG)
                 return (None, None, None)
-            self.oe.dbg_log('system::get_keyboard_layouts', 'exit_function', 0)
+            self.oe.dbg_log('system::get_keyboard_layouts', 'exit_function', self.oe.LOGDEBUG)
             return (
                 arrLayouts,
                 arrTypes,
@@ -466,15 +466,15 @@ class system:
 
     def set_hw_clock(self):
         try:
-            self.oe.dbg_log('system::set_hw_clock', 'enter_function', 0)
+            self.oe.dbg_log('system::set_hw_clock', 'enter_function', self.oe.LOGDEBUG)
             self.oe.execute('%s 2>/dev/null' % self.SET_CLOCK_CMD)
-            self.oe.dbg_log('system::set_hw_clock', 'exit_function', 0)
+            self.oe.dbg_log('system::set_hw_clock', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('system::set_hw_clock', 'ERROR: (' + repr(e) + ')', 4)
+            self.oe.dbg_log('system::set_hw_clock', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
     def reset_xbmc(self, listItem=None):
         try:
-            self.oe.dbg_log('system::reset_xbmc', 'enter_function', 0)
+            self.oe.dbg_log('system::reset_xbmc', 'enter_function', self.oe.LOGDEBUG)
             if self.ask_sure_reset('Soft') == 1:
                 self.oe.set_busy(1)
                 reset_file = open(self.XBMC_RESET_FILE, 'w')
@@ -484,14 +484,14 @@ class system:
                 self.oe.xbmcm.waitForAbort(1)
                 xbmc.executebuiltin('Reboot')
             self.oe.set_busy(0)
-            self.oe.dbg_log('system::reset_xbmc', 'exit_function', 0)
+            self.oe.dbg_log('system::reset_xbmc', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.set_busy(0)
-            self.oe.dbg_log('system::reset_xbmc', 'ERROR: (' + repr(e) + ')', 4)
+            self.oe.dbg_log('system::reset_xbmc', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
     def reset_oe(self, listItem=None):
         try:
-            self.oe.dbg_log('system::reset_oe', 'enter_function', 0)
+            self.oe.dbg_log('system::reset_oe', 'enter_function', self.oe.LOGDEBUG)
             if self.ask_sure_reset('Hard') == 1:
                 self.oe.set_busy(1)
                 reset_file = open(self.LIBREELEC_RESET_FILE, 'w')
@@ -501,14 +501,14 @@ class system:
                 self.oe.xbmcm.waitForAbort(1)
                 xbmc.executebuiltin('Reboot')
                 self.oe.set_busy(0)
-            self.oe.dbg_log('system::reset_oe', 'exit_function', 0)
+            self.oe.dbg_log('system::reset_oe', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.set_busy(0)
-            self.oe.dbg_log('system::reset_oe', 'ERROR: (' + repr(e) + ')', 4)
+            self.oe.dbg_log('system::reset_oe', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
     def ask_sure_reset(self, part):
         try:
-            self.oe.dbg_log('system::ask_sure_reset', 'enter_function', 0)
+            self.oe.dbg_log('system::ask_sure_reset', 'enter_function', self.oe.LOGDEBUG)
             xbmcDialog = xbmcgui.Dialog()
             answer = xbmcDialog.yesno(part + ' Reset', '%s\n\n%s' % (self.oe._(32326), self.oe._(32328)))
             if answer == 1:
@@ -516,14 +516,14 @@ class system:
                     return 1
                 else:
                     return 0
-            self.oe.dbg_log('system::ask_sure_reset', 'exit_function', 0)
+            self.oe.dbg_log('system::ask_sure_reset', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.set_busy(0)
-            self.oe.dbg_log('system::ask_sure_reset', 'ERROR: (' + repr(e) + ')', 4)
+            self.oe.dbg_log('system::ask_sure_reset', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
     def do_backup(self, listItem=None):
         try:
-            self.oe.dbg_log('system::do_backup', 'enter_function', 0)
+            self.oe.dbg_log('system::do_backup', 'enter_function', self.oe.LOGDEBUG)
             self.total_backup_size = 1
             self.done_backup_size = 1
 
@@ -568,7 +568,7 @@ class system:
                 tar.close()
                 self.backup_dlg.close()
                 del self.backup_dlg
-            self.oe.dbg_log('system::do_backup', 'exit_function', 0)
+            self.oe.dbg_log('system::do_backup', 'exit_function', self.oe.LOGDEBUG)
 
         except Exception as e:
             self.backup_dlg.close()
@@ -576,7 +576,7 @@ class system:
 
     def do_restore(self, listItem=None):
         try:
-            self.oe.dbg_log('system::do_restore', 'enter_function', 0)
+            self.oe.dbg_log('system::do_restore', 'enter_function', self.oe.LOGDEBUG)
             copy_success = 0
             xbmcDialog = xbmcgui.Dialog()
             restore_file_path = xbmcDialog.browse( 1,
@@ -622,31 +622,31 @@ class system:
                         self.oe.xbmcm.waitForAbort(1)
                         xbmc.executebuiltin('Reboot')
                 else:
-                    self.oe.dbg_log('system::do_restore', 'User Abort!', 0)
+                    self.oe.dbg_log('system::do_restore', 'User Abort!', self.oe.LOGDEBUG)
                     self.oe.execute('rm -rf %s' % self.RESTORE_DIR)
-            self.oe.dbg_log('system::do_restore', 'exit_function', 0)
+            self.oe.dbg_log('system::do_restore', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.dbg_log('system::do_restore', 'ERROR: (' + repr(e) + ')')
 
     def do_send_system_logs(self, listItem=None):
         try:
-            self.oe.dbg_log('system::do_send_system_logs', 'enter_function', 0)
+            self.oe.dbg_log('system::do_send_system_logs', 'enter_function', self.oe.LOGDEBUG)
             self.do_send_logs('/usr/bin/pastekodi')
-            self.oe.dbg_log('system::do_send_system_logs', 'exit_function', 0)
+            self.oe.dbg_log('system::do_send_system_logs', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.dbg_log('system::do_do_send_system_logs', 'ERROR: (' + repr(e) + ')')
 
     def do_send_crash_logs(self, listItem=None):
         try:
-            self.oe.dbg_log('system::do_send_crash_logs', 'enter_function', 0)
+            self.oe.dbg_log('system::do_send_crash_logs', 'enter_function', self.oe.LOGDEBUG)
             self.do_send_logs('/usr/bin/pastecrash')
-            self.oe.dbg_log('system::do_send_crash_logs', 'exit_function', 0)
+            self.oe.dbg_log('system::do_send_crash_logs', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.dbg_log('system::do_do_send_crash_logs', 'ERROR: (' + repr(e) + ')')
 
     def do_send_logs(self, log_cmd):
         try:
-            self.oe.dbg_log('system::do_send_logs', 'enter_function', 0)
+            self.oe.dbg_log('system::do_send_logs', 'enter_function', self.oe.LOGDEBUG)
 
             paste_dlg = xbmcgui.DialogProgress()
             paste_dlg.create('Pasting log files', 'Pasting...')
@@ -658,12 +658,12 @@ class system:
                 done_dlg = xbmcgui.Dialog()
                 link = result.find('http')
                 if link != -1:
-                    self.oe.dbg_log('system::do_send_logs', result[link:], 2)
+                    self.oe.dbg_log('system::do_send_logs', result[link:], self.oe.LOGWARNING)
                     done_dlg.ok('Paste complete', 'Log files pasted to %s' % result[link:])
                 else:
                     done_dlg.ok('Failed paste', 'Failed to paste log files, try again')
 
-            self.oe.dbg_log('system::do_send_logs', 'exit_function', 0)
+            self.oe.dbg_log('system::do_send_logs', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.dbg_log('system::do_do_send_logs', 'ERROR: (' + repr(e) + ')')
 
@@ -712,7 +712,7 @@ class system:
 
     def init_pinlock(self, listItem=None):
         try:
-            self.oe.dbg_log('system::init_pinlock', 'enter_function', 0)
+            self.oe.dbg_log('system::init_pinlock', 'enter_function', self.oe.LOGDEBUG)
             if not listItem == None:
                 self.set_value(listItem)
 
@@ -724,13 +724,13 @@ class system:
             if self.oe.PIN.isEnabled() and self.oe.PIN.isSet() == False:
                 self.set_pinlock()
 
-            self.oe.dbg_log('system::init_pinlock', 'exit_function', 0)
+            self.oe.dbg_log('system::init_pinlock', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('system::init_pinlock', 'ERROR: (%s)' % repr(e), 4)
+            self.oe.dbg_log('system::init_pinlock', 'ERROR: (%s)' % repr(e), self.oe.LOGERROR)
 
     def set_pinlock(self, listItem=None):
         try:
-            self.oe.dbg_log('system::set_pinlock', 'enter_function', 0)
+            self.oe.dbg_log('system::set_pinlock', 'enter_function', self.oe.LOGDEBUG)
             newpin = xbmcDialog.input(self.oe._(32226), type=xbmcgui.INPUT_NUMERIC)
             if len(newpin) == 4 :
                newpinConfirm = xbmcDialog.input(self.oe._(32227), type=xbmcgui.INPUT_NUMERIC)
@@ -744,24 +744,24 @@ class system:
             if self.oe.PIN.isSet() == False:
                 self.struct['pinlock']['settings']['pinlock_enable']['value'] = '0'
                 self.oe.PIN.disable()
-            self.oe.dbg_log('system::set_pinlock', 'exit_function', 0)
+            self.oe.dbg_log('system::set_pinlock', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('system::set_pinlock', 'ERROR: (%s)' % repr(e), 4)
+            self.oe.dbg_log('system::set_pinlock', 'ERROR: (%s)' % repr(e), self.oe.LOGERROR)
 
     def do_wizard(self):
         try:
-            self.oe.dbg_log('system::do_wizard', 'enter_function', 0)
+            self.oe.dbg_log('system::do_wizard', 'enter_function', self.oe.LOGDEBUG)
             self.oe.winOeMain.set_wizard_title(self.oe._(32003))
             self.oe.winOeMain.set_wizard_text(self.oe._(32304))
             self.oe.winOeMain.set_wizard_button_title(self.oe._(32308))
             self.oe.winOeMain.set_wizard_button_1(self.struct['ident']['settings']['hostname']['value'], self, 'wizard_set_hostname')
-            self.oe.dbg_log('system::do_wizard', 'exit_function', 0)
+            self.oe.dbg_log('system::do_wizard', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.dbg_log('system::do_wizard', 'ERROR: (' + repr(e) + ')')
 
     def wizard_set_hostname(self):
         try:
-            self.oe.dbg_log('system::wizard_set_hostname', 'enter_function', 0)
+            self.oe.dbg_log('system::wizard_set_hostname', 'enter_function', self.oe.LOGDEBUG)
             currentHostname = self.struct['ident']['settings']['hostname']['value']
             xbmcKeyboard = xbmc.Keyboard(currentHostname)
             result_is_valid = False
@@ -780,6 +780,6 @@ class system:
                 self.set_hostname()
                 self.oe.winOeMain.getControl(1401).setLabel(self.struct['ident']['settings']['hostname']['value'])
                 self.oe.write_setting('system', 'hostname', self.struct['ident']['settings']['hostname']['value'])
-            self.oe.dbg_log('system::wizard_set_hostname', 'exit_function', 0)
+            self.oe.dbg_log('system::wizard_set_hostname', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.dbg_log('system::wizard_set_hostname', 'ERROR: (' + repr(e) + ')')

--- a/src/resources/lib/modules/updates.py
+++ b/src/resources/lib/modules/updates.py
@@ -36,7 +36,7 @@ class updates:
 
     def __init__(self, oeMain):
         try:
-            oeMain.dbg_log('updates::__init__', 'enter_function', 0)
+            oeMain.dbg_log('updates::__init__', 'enter_function', oeMain.LOGDEBUG)
             self.oe = oeMain
             self.struct = {
                 'update': {
@@ -171,40 +171,40 @@ class updates:
             self.nox_keyboard_layouts = False
             self.last_update_check = 0
             self.arrVariants = {}
-            self.oe.dbg_log('updates::__init__', 'exit_function', 0)
+            self.oe.dbg_log('updates::__init__', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.dbg_log('updates::__init__', 'ERROR: (' + repr(e) + ')')
 
     def start_service(self):
         try:
-            self.oe.dbg_log('updates::start_service', 'enter_function', 0)
+            self.oe.dbg_log('updates::start_service', 'enter_function', self.oe.LOGDEBUG)
             self.is_service = True
             self.load_values()
             self.set_auto_update()
             del self.is_service
-            self.oe.dbg_log('updates::start_service', 'exit_function', 0)
+            self.oe.dbg_log('updates::start_service', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.dbg_log('updates::start_service', 'ERROR: (' + repr(e) + ')')
 
     def stop_service(self):
         try:
-            self.oe.dbg_log('updates::stop_service', 'enter_function', 0)
+            self.oe.dbg_log('updates::stop_service', 'enter_function', self.oe.LOGDEBUG)
             if hasattr(self, 'update_thread'):
                 self.update_thread.stop()
-            self.oe.dbg_log('updates::stop_service', 'exit_function', 0)
+            self.oe.dbg_log('updates::stop_service', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.dbg_log('updates::stop_service', 'ERROR: (' + repr(e) + ')')
 
     def do_init(self):
         try:
-            self.oe.dbg_log('updates::do_init', 'enter_function', 0)
-            self.oe.dbg_log('updates::do_init', 'exit_function', 0)
+            self.oe.dbg_log('updates::do_init', 'enter_function', self.oe.LOGDEBUG)
+            self.oe.dbg_log('updates::do_init', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.dbg_log('updates::do_init', 'ERROR: (' + repr(e) + ')')
 
     def exit(self):
-        self.oe.dbg_log('updates::exit', 'enter_function', 0)
-        self.oe.dbg_log('updates::exit', 'exit_function', 0)
+        self.oe.dbg_log('updates::exit', 'enter_function', self.oe.LOGDEBUG)
+        self.oe.dbg_log('updates::exit', 'exit_function', self.oe.LOGDEBUG)
         pass
 
     # Identify connected GPU card (card0, card1 etc.)
@@ -227,10 +227,10 @@ class updates:
         gpu_driver = ""
 
         gpu_card = self.get_gpu_card()
-        self.oe.dbg_log('updates::get_hardware_flags_x86_64', 'Using card: %s' % gpu_card, 0)
+        self.oe.dbg_log('updates::get_hardware_flags_x86_64', 'Using card: %s' % gpu_card, self.oe.LOGDEBUG)
 
         gpu_path = self.oe.execute('/usr/bin/udevadm info --name=/dev/dri/%s --query path 2>/dev/null' % gpu_card, get_result=1).replace('\n','')
-        self.oe.dbg_log('updates::get_hardware_flags_x86_64', 'gpu path: %s' % gpu_path, 0)
+        self.oe.dbg_log('updates::get_hardware_flags_x86_64', 'gpu path: %s' % gpu_path, self.oe.LOGDEBUG)
 
         if gpu_path:
             drv_path = os.path.dirname(os.path.dirname(gpu_path))
@@ -239,7 +239,7 @@ class updates:
             if props:
                 for key, value in [x.strip().split('=') for x in props.strip().split('\n')]:
                     gpu_props[key] = value
-            self.oe.dbg_log('updates::get_gpu_type', 'gpu props: %s' % gpu_props, 0)
+            self.oe.dbg_log('updates::get_gpu_type', 'gpu props: %s' % gpu_props, self.oe.LOGDEBUG)
             gpu_driver = gpu_props.get("DRIVER", "")
 
         if not gpu_driver:
@@ -248,13 +248,13 @@ class updates:
         if gpu_driver == 'nvidia' and os.path.realpath('/var/lib/nvidia_drv.so').endswith('nvidia-legacy_drv.so'):
             gpu_driver = 'nvidia-legacy'
 
-        self.oe.dbg_log('updates::get_hardware_flags_x86_64', 'gpu driver: %s' % gpu_driver, 0)
+        self.oe.dbg_log('updates::get_hardware_flags_x86_64', 'gpu driver: %s' % gpu_driver, self.oe.LOGDEBUG)
 
         return gpu_driver if gpu_driver else "unknown"
 
     def get_hardware_flags_rpi(self):
         revision = self.oe.execute('grep "^Revision" /proc/cpuinfo | awk \'{ print $3 }\'',get_result=1).replace('\n','')
-        self.oe.dbg_log('updates::get_hardware_flags_rpi', 'Revision code: %s' % revision, 0)
+        self.oe.dbg_log('updates::get_hardware_flags_rpi', 'Revision code: %s' % revision, self.oe.LOGDEBUG)
 
         return '{:08x}'.format(int(revision, 16))
 
@@ -264,7 +264,7 @@ class updates:
         else:
             dtname = "unknown"
 
-        self.oe.dbg_log('system::get_hardware_flags_dtname', 'ARM board: %s' % dtname, 0)
+        self.oe.dbg_log('system::get_hardware_flags_dtname', 'ARM board: %s' % dtname, self.oe.LOGDEBUG)
 
         return dtname
 
@@ -276,16 +276,16 @@ class updates:
         elif self.oe.PROJECT in ['Allwinner', 'Amlogic', 'NXP', 'Qualcomm', 'Rockchip', 'Samsung' ]:
             return self.get_hardware_flags_dtname()
         else:
-            self.oe.dbg_log('updates::get_hardware_flags', 'Project is %s, no hardware flag available' % self.oe.PROJECT, 0)
+            self.oe.dbg_log('updates::get_hardware_flags', 'Project is %s, no hardware flag available' % self.oe.PROJECT, self.oe.LOGDEBUG)
             return ""
 
     def load_values(self):
         try:
-            self.oe.dbg_log('updates::load_values', 'enter_function', 0)
+            self.oe.dbg_log('updates::load_values', 'enter_function', self.oe.LOGDEBUG)
 
             # Hardware flags
             self.hardware_flags = self.get_hardware_flags()
-            self.oe.dbg_log('system::load_values', 'loaded hardware_flag %s' % self.hardware_flags, 0)
+            self.oe.dbg_log('system::load_values', 'loaded hardware_flag %s' % self.hardware_flags, self.oe.LOGDEBUG)
 
             # AutoUpdate
 
@@ -338,31 +338,31 @@ class updates:
             else:
                 self.struct['rpieeprom']['hidden'] = 'true'
 
-            self.oe.dbg_log('updates::load_values', 'exit_function', 0)
+            self.oe.dbg_log('updates::load_values', 'exit_function', self.oe.LOGDEBUG)
 
         except Exception as e:
             self.oe.dbg_log('updates::load_values', 'ERROR: (' + repr(e) + ')')
 
     def load_menu(self, focusItem):
         try:
-            self.oe.dbg_log('updates::load_menu', 'enter_function', 0)
+            self.oe.dbg_log('updates::load_menu', 'enter_function', self.oe.LOGDEBUG)
             self.oe.winOeMain.build_menu(self.struct)
-            self.oe.dbg_log('updates::load_menu', 'exit_function', 0)
+            self.oe.dbg_log('updates::load_menu', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.dbg_log('updates::load_menu', 'ERROR: (' + repr(e) + ')')
 
     def set_value(self, listItem):
         try:
-            self.oe.dbg_log('updates::set_value', 'enter_function', 0)
+            self.oe.dbg_log('updates::set_value', 'enter_function', self.oe.LOGDEBUG)
             self.struct[listItem.getProperty('category')]['settings'][listItem.getProperty('entry')]['value'] = listItem.getProperty('value')
             self.oe.write_setting('updates', listItem.getProperty('entry'), str(listItem.getProperty('value')))
-            self.oe.dbg_log('updates::set_value', 'exit_function', 0)
+            self.oe.dbg_log('updates::set_value', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.dbg_log('updates::set_value', 'ERROR: (' + repr(e) + ')')
 
     def set_auto_update(self, listItem=None):
         try:
-            self.oe.dbg_log('updates::set_auto_update', 'enter_function', 0)
+            self.oe.dbg_log('updates::set_auto_update', 'enter_function', self.oe.LOGDEBUG)
             if not listItem == None:
                 self.set_value(listItem)
             if not hasattr(self, 'update_disabled'):
@@ -371,24 +371,24 @@ class updates:
                     self.update_thread.start()
                 else:
                     self.update_thread.wait_evt.set()
-                self.oe.dbg_log('updates::set_auto_update', str(self.struct['update']['settings']['AutoUpdate']['value']), 1)
-            self.oe.dbg_log('updates::set_auto_update', 'exit_function', 0)
+                self.oe.dbg_log('updates::set_auto_update', str(self.struct['update']['settings']['AutoUpdate']['value']), self.oe.LOGINFO)
+            self.oe.dbg_log('updates::set_auto_update', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.dbg_log('updates::set_auto_update', 'ERROR: (' + repr(e) + ')')
 
     def set_channel(self, listItem=None):
         try:
-            self.oe.dbg_log('updates::set_channel', 'enter_function', 0)
+            self.oe.dbg_log('updates::set_channel', 'enter_function', self.oe.LOGDEBUG)
             if not listItem == None:
                 self.set_value(listItem)
             self.struct['update']['settings']['Build']['values'] = self.get_available_builds()
-            self.oe.dbg_log('updates::set_channel', 'exit_function', 0)
+            self.oe.dbg_log('updates::set_channel', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.dbg_log('updates::set_channel', 'ERROR: (' + repr(e) + ')')
 
     def set_custom_channel(self, listItem=None):
         try:
-            self.oe.dbg_log('updates::set_custom_channel', 'enter_function', 0)
+            self.oe.dbg_log('updates::set_custom_channel', 'enter_function', self.oe.LOGDEBUG)
             if not listItem == None:
                 self.set_value(listItem)
             self.update_json = self.build_json()
@@ -397,7 +397,7 @@ class updates:
                 if not self.struct['update']['settings']['Channel']['value'] in self.struct['update']['settings']['Channel']['values']:
                     self.struct['update']['settings']['Channel']['value'] = None
             self.struct['update']['settings']['Build']['values'] = self.get_available_builds()
-            self.oe.dbg_log('updates::set_custom_channel', 'exit_function', 0)
+            self.oe.dbg_log('updates::set_custom_channel', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.dbg_log('updates::set_custom_channel', 'ERROR: (' + repr(e) + ')')
 
@@ -417,20 +417,20 @@ class updates:
 
     def get_channels(self):
         try:
-            self.oe.dbg_log('updates::get_channels', 'enter_function', 0)
+            self.oe.dbg_log('updates::get_channels', 'enter_function', self.oe.LOGDEBUG)
             channels = []
-            self.oe.dbg_log('updates::get_channels', str(self.update_json), 0)
+            self.oe.dbg_log('updates::get_channels', str(self.update_json), self.oe.LOGDEBUG)
             if not self.update_json is None:
                 for channel in self.update_json:
                     channels.append(channel)
-            self.oe.dbg_log('updates::get_channels', 'exit_function', 0)
+            self.oe.dbg_log('updates::get_channels', 'exit_function', self.oe.LOGDEBUG)
             return sorted(list(set(channels)), key=cmp_to_key(self.custom_sort_train))
         except Exception as e:
             self.oe.dbg_log('updates::get_channels', 'ERROR: (' + repr(e) + ')')
 
     def do_manual_update(self, listItem=None):
         try:
-            self.oe.dbg_log('updates::do_manual_update', 'enter_function', 0)
+            self.oe.dbg_log('updates::do_manual_update', 'enter_function', self.oe.LOGDEBUG)
             self.struct['update']['settings']['Build']['value'] = ''
             update_json = self.build_json(notify_error=True)
             if update_json is None:
@@ -460,13 +460,13 @@ class updates:
                         self.update_in_progress = True
                         self.do_autoupdate()
                 self.struct['update']['settings']['Build']['value'] = ''
-            self.oe.dbg_log('updates::do_manual_update', 'exit_function', 0)
+            self.oe.dbg_log('updates::do_manual_update', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.dbg_log('updates::do_manual_update', 'ERROR: (' + repr(e) + ')')
 
     def get_json(self, url=None):
         try:
-            self.oe.dbg_log('updates::get_json', 'enter_function', 0)
+            self.oe.dbg_log('updates::get_json', 'enter_function', self.oe.LOGDEBUG)
             if url is None:
                 url = self.UPDATE_DOWNLOAD_URL % ('releases', 'releases.json')
             if url.split('/')[-1] != 'releases.json':
@@ -476,14 +476,14 @@ class updates:
                 update_json = json.loads(data)
             else:
                 update_json = None
-            self.oe.dbg_log('updates::get_json', 'exit_function', 0)
+            self.oe.dbg_log('updates::get_json', 'exit_function', self.oe.LOGDEBUG)
             return update_json
         except Exception as e:
             self.oe.dbg_log('updates::get_json', 'ERROR: (' + repr(e) + ')')
 
     def build_json(self, notify_error=False):
         try:
-            self.oe.dbg_log('updates::build_json', 'enter_function', 0)
+            self.oe.dbg_log('updates::build_json', 'enter_function', self.oe.LOGDEBUG)
             update_json = self.get_json()
             if self.struct['update']['settings']['ShowCustomChannels']['value'] == '1':
                 custom_urls = []
@@ -500,14 +500,14 @@ class updates:
                             answer = ok_window.ok(self.oe._(32191), 'Custom URL is not valid, or currently inaccessible.\n\n%s' % custom_url)
                             if not answer:
                                 return
-            self.oe.dbg_log('updates::build_json', 'exit_function', 0)
+            self.oe.dbg_log('updates::build_json', 'exit_function', self.oe.LOGDEBUG)
             return update_json
         except Exception as e:
             self.oe.dbg_log('updates::build_json', 'ERROR: (' + repr(e) + ')')
 
     def get_available_builds(self, shortname=None):
         try:
-            self.oe.dbg_log('updates::get_available_builds', 'enter_function', 0)
+            self.oe.dbg_log('updates::get_available_builds', 'enter_function', self.oe.LOGDEBUG)
             channel = self.struct['update']['settings']['Channel']['value']
             update_files = []
             build = None
@@ -523,7 +523,7 @@ class updates:
                                     build = self.update_json[channel]['project'][self.oe.ARCHITECTURE]['releases'][i]['file']['name']
                                     if shortname in build:
                                         break
-            self.oe.dbg_log('updates::get_available_builds', 'exit_function', 0)
+            self.oe.dbg_log('updates::get_available_builds', 'exit_function', self.oe.LOGDEBUG)
             if build is None:
                 return update_files
             else:
@@ -533,9 +533,9 @@ class updates:
 
     def check_updates_v2(self, force=False):
         try:
-            self.oe.dbg_log('updates::check_updates_v2', 'enter_function', 0)
+            self.oe.dbg_log('updates::check_updates_v2', 'enter_function', self.oe.LOGDEBUG)
             if hasattr(self, 'update_in_progress'):
-                self.oe.dbg_log('updates::check_updates_v2', 'Update in progress (exit)', 0)
+                self.oe.dbg_log('updates::check_updates_v2', 'Update in progress (exit)', self.oe.LOGDEBUG)
                 return
             if self.struct['update']['settings']['SubmitStats']['value'] == '1':
                 systemid = self.oe.SYSTEMID
@@ -556,9 +556,9 @@ class updates:
             if self.oe.BUILDER_NAME:
                url += '&b=%s' % self.oe.url_quote(self.oe.BUILDER_NAME)
 
-            self.oe.dbg_log('updates::check_updates_v2', 'URL: %s' % url, 0)
+            self.oe.dbg_log('updates::check_updates_v2', 'URL: %s' % url, self.oe.LOGDEBUG)
             update_json = self.oe.load_url(url)
-            self.oe.dbg_log('updates::check_updates_v2', 'RESULT: %s' % repr(update_json), 0)
+            self.oe.dbg_log('updates::check_updates_v2', 'RESULT: %s' % repr(update_json), self.oe.LOGDEBUG)
             if update_json != '':
                 update_json = json.loads(update_json)
                 self.last_update_check = time.time()
@@ -569,13 +569,13 @@ class updates:
                     if self.struct['update']['settings']['AutoUpdate']['value'] == 'auto' and force == False:
                         self.update_in_progress = True
                         self.do_autoupdate(None, True)
-            self.oe.dbg_log('updates::check_updates_v2', 'exit_function', 0)
+            self.oe.dbg_log('updates::check_updates_v2', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.dbg_log('updates::check_updates_v2', 'ERROR: (' + repr(e) + ')')
 
     def do_autoupdate(self, listItem=None, silent=False):
         try:
-            self.oe.dbg_log('updates::do_autoupdate', 'enter_function', 0)
+            self.oe.dbg_log('updates::do_autoupdate', 'enter_function', self.oe.LOGDEBUG)
             if hasattr(self, 'update_file'):
                 if not os.path.exists(self.LOCAL_UPDATE_DIR):
                     os.makedirs(self.LOCAL_UPDATE_DIR)
@@ -593,13 +593,13 @@ class updates:
                 else:
                     delattr(self, 'update_in_progress')
 
-            self.oe.dbg_log('updates::do_autoupdate', 'exit_function', 0)
+            self.oe.dbg_log('updates::do_autoupdate', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.dbg_log('updates::do_autoupdate', 'ERROR: (' + repr(e) + ')')
 
     def get_rpi_flashing_state(self):
         try:
-            self.oe.dbg_log('updates::get_rpi_flashing_state', 'enter_function', 0)
+            self.oe.dbg_log('updates::get_rpi_flashing_state', 'enter_function', self.oe.LOGDEBUG)
 
             jdata = {
                         'EXITCODE': 'EXIT_FAILED',
@@ -619,8 +619,8 @@ class updates:
                     state['incompatible'] = False
                     jdata = json.load(machine_out)
 
-            self.oe.dbg_log('updates::get_rpi_flashing_state', 'console output: %s' % console_output, 0)
-            self.oe.dbg_log('updates::get_rpi_flashing_state', 'json values: %s' % jdata, 0)
+            self.oe.dbg_log('updates::get_rpi_flashing_state', 'console output: %s' % console_output, self.oe.LOGDEBUG)
+            self.oe.dbg_log('updates::get_rpi_flashing_state', 'json values: %s' % jdata, self.oe.LOGDEBUG)
 
             if jdata['BOOTLOADER_CURRENT'] != 0:
                 state['bootloader']['current'] = datetime.datetime.utcfromtimestamp(jdata['BOOTLOADER_CURRENT']).strftime('%Y-%m-%d')
@@ -645,8 +645,8 @@ class updates:
                 else:
                     state['vl805']['state'] = self.oe._(32029) % state['vl805']['current']
 
-            self.oe.dbg_log('updates::get_rpi_flashing_state', 'state: %s' % state, 0)
-            self.oe.dbg_log('updates::get_rpi_flashing_state', 'exit_function', 0)
+            self.oe.dbg_log('updates::get_rpi_flashing_state', 'state: %s' % state, self.oe.LOGDEBUG)
+            self.oe.dbg_log('updates::get_rpi_flashing_state', 'exit_function', self.oe.LOGDEBUG)
             return state
         except Exception as e:
             self.oe.dbg_log('updates::get_rpi_flashing_state', 'ERROR: (' + repr(e) + ')')
@@ -654,23 +654,23 @@ class updates:
 
     def get_rpi_eeprom(self, device):
         try:
-            self.oe.dbg_log('updates::get_rpi_eeprom', 'enter_function', 0)
+            self.oe.dbg_log('updates::get_rpi_eeprom', 'enter_function', self.oe.LOGDEBUG)
             values = []
             if os.path.exists(self.RPI_FLASHING_TRIGGER):
                 with open(self.RPI_FLASHING_TRIGGER, 'r') as trigger:
                     values = trigger.read().split('\n')
-            self.oe.dbg_log('updates::get_rpi_eeprom', 'values: %s' % values, 0)
-            self.oe.dbg_log('updates::get_rpi_eeprom', 'exit_function', 0)
+            self.oe.dbg_log('updates::get_rpi_eeprom', 'values: %s' % values, self.oe.LOGDEBUG)
+            self.oe.dbg_log('updates::get_rpi_eeprom', 'exit_function', self.oe.LOGDEBUG)
             return 'true' if ('%s="yes"' % device) in values else 'false'
         except Exception as e:
             self.oe.dbg_log('updates::get_rpi_eeprom', 'ERROR: (' + repr(e) + ')')
 
     def set_rpi_eeprom(self):
         try:
-            self.oe.dbg_log('updates::set_rpi_eeprom', 'enter_function', 0)
+            self.oe.dbg_log('updates::set_rpi_eeprom', 'enter_function', self.oe.LOGDEBUG)
             bootloader = (self.struct['rpieeprom']['settings']['bootloader']['value'] == 'true')
             vl805 = (self.struct['rpieeprom']['settings']['vl805']['value'] == 'true')
-            self.oe.dbg_log('updates::set_rpi_eeprom', 'states: [%s], [%s]' % (bootloader, vl805), 0)
+            self.oe.dbg_log('updates::set_rpi_eeprom', 'states: [%s], [%s]' % (bootloader, vl805), self.oe.LOGDEBUG)
             if bootloader or vl805:
                 values = []
                 values.append('BOOTLOADER="%s"' % ('yes' if bootloader else 'no'))
@@ -681,33 +681,33 @@ class updates:
                 if os.path.exists(self.RPI_FLASHING_TRIGGER):
                     os.remove(self.RPI_FLASHING_TRIGGER)
 
-            self.oe.dbg_log('updates::set_rpi_eeprom', 'exit_function', 0)
+            self.oe.dbg_log('updates::set_rpi_eeprom', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.dbg_log('updates::set_rpi_eeprom', 'ERROR: (' + repr(e) + ')')
 
     def set_rpi_bootloader(self, listItem):
         try:
-            self.oe.dbg_log('updates::set_rpi_bootloader', 'enter_function', 0)
+            self.oe.dbg_log('updates::set_rpi_bootloader', 'enter_function', self.oe.LOGDEBUG)
             value = 'false'
             if listItem.getProperty('value') == 'true':
                 if xbmcgui.Dialog().yesno('Update RPi Bootloader', '%s\n\n%s' % (self.oe._(32023), self.oe._(32326))):
                     value = 'true'
             self.struct[listItem.getProperty('category')]['settings'][listItem.getProperty('entry')]['value'] = value
             self.set_rpi_eeprom()
-            self.oe.dbg_log('updates::set_rpi_bootloader', 'exit_function', 0)
+            self.oe.dbg_log('updates::set_rpi_bootloader', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.dbg_log('updates::set_rpi_bootloader', 'ERROR: (' + repr(e) + ')')
 
     def set_rpi_vl805(self, listItem):
         try:
-            self.oe.dbg_log('updates::set_rpi_vl805', 'enter_function', 0)
+            self.oe.dbg_log('updates::set_rpi_vl805', 'enter_function', self.oe.LOGDEBUG)
             value = 'false'
             if listItem.getProperty('value') == 'true':
                 if xbmcgui.Dialog().yesno('Update RPi USB3 Firmware', '%s\n\n%s' % (self.oe._(32023), self.oe._(32326))):
                     value = 'true'
             self.struct[listItem.getProperty('category')]['settings'][listItem.getProperty('entry')]['value'] = value
             self.set_rpi_eeprom()
-            self.oe.dbg_log('updates::set_rpi_vl805', 'exit_function', 0)
+            self.oe.dbg_log('updates::set_rpi_vl805', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.dbg_log('updates::set_rpi_vl805', 'ERROR: (' + repr(e) + ')')
 
@@ -715,28 +715,28 @@ class updateThread(threading.Thread):
 
     def __init__(self, oeMain):
         try:
-            oeMain.dbg_log('updates::updateThread::__init__', 'enter_function', 0)
+            oeMain.dbg_log('updates::updateThread::__init__', 'enter_function', oeMain.LOGDEBUG)
             self.oe = oeMain
             self.stopped = False
             self.wait_evt = threading.Event()
             threading.Thread.__init__(self)
-            self.oe.dbg_log('updates::updateThread', 'Started', 1)
-            self.oe.dbg_log('updates::updateThread::__init__', 'exit_function', 0)
+            self.oe.dbg_log('updates::updateThread', 'Started', self.oe.LOGINFO)
+            self.oe.dbg_log('updates::updateThread::__init__', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.dbg_log('updates::updateThread::__init__', 'ERROR: (' + repr(e) + ')')
 
     def stop(self):
         try:
-            self.oe.dbg_log('updates::updateThread::stop()', 'enter_function', 0)
+            self.oe.dbg_log('updates::updateThread::stop()', 'enter_function', self.oe.LOGDEBUG)
             self.stopped = True
             self.wait_evt.set()
-            self.oe.dbg_log('updates::updateThread::stop()', 'exit_function', 0)
+            self.oe.dbg_log('updates::updateThread::stop()', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.dbg_log('updates::updateThread::stop()', 'ERROR: (' + repr(e) + ')')
 
     def run(self):
         try:
-            self.oe.dbg_log('updates::updateThread::run', 'enter_function', 0)
+            self.oe.dbg_log('updates::updateThread::run', 'enter_function', self.oe.LOGDEBUG)
             while self.stopped == False:
                 if not xbmc.Player().isPlaying():
                     self.oe.dictModules['updates'].check_updates_v2()
@@ -746,7 +746,7 @@ class updateThread(threading.Thread):
                     self.oe.notify(self.oe._(32363), self.oe._(32364))
                     self.wait_evt.wait(3600)
                 self.wait_evt.clear()
-            self.oe.dbg_log('updates::updateThread', 'Stopped', 1)
-            self.oe.dbg_log('updates::updateThread::run', 'exit_function', 0)
+            self.oe.dbg_log('updates::updateThread', 'Stopped', self.oe.LOGINFO)
+            self.oe.dbg_log('updates::updateThread::run', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.dbg_log('updates::updateThread::run', 'ERROR: (' + repr(e) + ')')

--- a/src/resources/lib/modules/xdbus.py
+++ b/src/resources/lib/modules/xdbus.py
@@ -17,29 +17,29 @@ class xdbus:
 
     def __init__(self, oeMain):
         try:
-            oeMain.dbg_log('xdbus::__init__', 'enter_function', 0)
+            oeMain.dbg_log('xdbus::__init__', 'enter_function', oeMain.LOGDEBUG)
             self.oe = oeMain
             self.dbusSystemBus = self.oe.dbusSystemBus
-            self.oe.dbg_log('xdbus::__init__', 'exit_function', 0)
+            self.oe.dbg_log('xdbus::__init__', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('xdbus::__init__', 'ERROR: (' + repr(e) + ')', 4)
+            self.oe.dbg_log('xdbus::__init__', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
     def start_service(self):
         try:
-            self.oe.dbg_log('xdbus::start_service', 'enter_function', 0)
+            self.oe.dbg_log('xdbus::start_service', 'enter_function', self.oe.LOGDEBUG)
             self.dbusMonitor = dbusMonitor(self.oe)
             self.dbusMonitor.start()
-            self.oe.dbg_log('xdbus::start_service', 'exit_function', 0)
+            self.oe.dbg_log('xdbus::start_service', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('xdbus::start_service', 'ERROR: (' + repr(e) + ')', 4)
+            self.oe.dbg_log('xdbus::start_service', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
     def stop_service(self):
         try:
-            self.oe.dbg_log('xdbus::stop_service', 'enter_function', 0)
+            self.oe.dbg_log('xdbus::stop_service', 'enter_function', self.oe.LOGDEBUG)
             if hasattr(self, 'dbusMonitor'):
                 self.dbusMonitor.stop()
                 del self.dbusMonitor
-            self.oe.dbg_log('xdbus::stop_service', 'exit_function', 0)
+            self.oe.dbg_log('xdbus::stop_service', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.dbg_log('xdbus::stop_service', 'ERROR: (' + repr(e) + ')')
 
@@ -48,10 +48,10 @@ class xdbus:
 
     def restart(self):
         try:
-            self.oe.dbg_log('xdbus::restart', 'enter_function', 0)
+            self.oe.dbg_log('xdbus::restart', 'enter_function', self.oe.LOGDEBUG)
             self.stop_service()
             self.start_service()
-            self.oe.dbg_log('xdbus::restart', 'exit_function', 0)
+            self.oe.dbg_log('xdbus::restart', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.dbg_log('xdbus::restart', 'ERROR: (' + repr(e) + ')')
 
@@ -60,7 +60,7 @@ class dbusMonitor(threading.Thread):
 
     def __init__(self, oeMain):
         try:
-            oeMain.dbg_log('xdbus::dbusMonitor::__init__', 'enter_function', 0)
+            oeMain.dbg_log('xdbus::dbusMonitor::__init__', 'enter_function', oeMain.LOGDEBUG)
             self.monitors = []
             self.oe = oeMain
             self.dbusSystemBus = oeMain.dbusSystemBus
@@ -68,13 +68,13 @@ class dbusMonitor(threading.Thread):
             gobject.threads_init()
             dbus.mainloop.glib.threads_init()
             threading.Thread.__init__(self)
-            self.oe.dbg_log('xdbus::dbusMonitor::__init__', 'exit_function', 0)
+            self.oe.dbg_log('xdbus::dbusMonitor::__init__', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('xdbus::dbusMonitor::__init__', 'ERROR: (' + repr(e) + ')', 4)
+            self.oe.dbg_log('xdbus::dbusMonitor::__init__', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
     def run(self):
         try:
-            self.oe.dbg_log('xdbus::dbusMonitor::run', 'enter_function', 0)
+            self.oe.dbg_log('xdbus::dbusMonitor::run', 'enter_function', self.oe.LOGDEBUG)
             for strModule in sorted(self.oe.dictModules, key=lambda x: list(self.oe.dictModules[x].menu.keys())):
                 module = self.oe.dictModules[strModule]
                 if hasattr(module, 'monitor') and module.ENABLED:
@@ -82,22 +82,22 @@ class dbusMonitor(threading.Thread):
                     monitor.add_signal_receivers()
                     self.monitors.append(monitor)
             try:
-                self.oe.dbg_log('xdbus Monitor started.', '', 1)
+                self.oe.dbg_log('xdbus Monitor started.', '', self.oe.LOGINFO)
                 self.mainLoop.run()
-                self.oe.dbg_log('xdbus Monitor stopped.', '', 1)
+                self.oe.dbg_log('xdbus Monitor stopped.', '', self.oe.LOGINFO)
             except:
                 pass
-            self.oe.dbg_log('xdbus::dbusMonitor::run', 'exit_function', 0)
+            self.oe.dbg_log('xdbus::dbusMonitor::run', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('xdbus::dbusMonitor::run', 'ERROR: (' + repr(e) + ')', 4)
+            self.oe.dbg_log('xdbus::dbusMonitor::run', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
 
     def stop(self):
         try:
-            self.oe.dbg_log('xdbus::dbusMonitor::stop_service', 'enter_function', 0)
+            self.oe.dbg_log('xdbus::dbusMonitor::stop_service', 'enter_function', self.oe.LOGDEBUG)
             self.mainLoop.quit()
             for monitor in self.monitors:
                 monitor.remove_signal_receivers()
                 monitor = None
-            self.oe.dbg_log('xdbus::dbusMonitor::stop_service', 'exit_function', 0)
+            self.oe.dbg_log('xdbus::dbusMonitor::stop_service', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.dbg_log('xdbus::dbusMonitor::stop_service', 'ERROR: (' + repr(e) + ')')

--- a/src/resources/lib/oeWindows.py
+++ b/src/resources/lib/oeWindows.py
@@ -76,7 +76,7 @@ class mainWindow(xbmcgui.WindowXMLDialog):
             self.oe.winOeMain = self
             for strModule in sorted(self.oe.dictModules, key=lambda x: list(self.oe.dictModules[x].menu.keys())):
                 module = self.oe.dictModules[strModule]
-                self.oe.dbg_log('init module', strModule, 0)
+                self.oe.dbg_log('init module', strModule, self.oe.LOGDEBUG)
                 if module.ENABLED:
                     if hasattr(module, 'do_init'):
                         Thread(target=module.do_init(), args=()).start()
@@ -172,7 +172,7 @@ class mainWindow(xbmcgui.WindowXMLDialog):
 
     def showButton(self, number, name, module, action, onup=None, onleft=None):
         try:
-            self.oe.dbg_log('oeWindows::showButton', 'enter_function', 0)
+            self.oe.dbg_log('oeWindows::showButton', 'enter_function', self.oe.LOGDEBUG)
             button = self.getControl(self.buttons[number]['id'])
             self.buttons[number]['modul'] = module
             self.buttons[number]['action'] = action
@@ -182,7 +182,7 @@ class mainWindow(xbmcgui.WindowXMLDialog):
             if onleft != None:
                 button.controlLeft(self.getControl(onleft))
             button.setVisible(True)
-            self.oe.dbg_log('oeWindows::showButton', 'exit_function', 0)
+            self.oe.dbg_log('oeWindows::showButton', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.dbg_log('oeWindows.mainWindow::showButton(' + str(number) + ', ' + str(action) + ')', 'ERROR: (' + repr(e) + ')')
 
@@ -229,7 +229,7 @@ class mainWindow(xbmcgui.WindowXMLDialog):
                 self.close()
 
     def onClick(self, controlID):
-        self.oe.dbg_log('oeWindows::onClick', 'enter_function', 0)
+        self.oe.dbg_log('oeWindows::onClick', 'enter_function', self.oe.LOGDEBUG)
         try:
             for btn in self.buttons:
                 if controlID == self.buttons[btn]['id']:
@@ -335,7 +335,7 @@ class mainWindow(xbmcgui.WindowXMLDialog):
                 self.onFocus(self.guiMenList)
                 self.setFocusId(controlID)
                 self.getControl(controlID).selectItem(selectedPosition)
-            self.oe.dbg_log('oeWindows::onClick', 'exit_function', 0)
+            self.oe.dbg_log('oeWindows::onClick', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.dbg_log('oeWindows.mainWindow::onClick(' + str(controlID) + ')', 'ERROR: (' + repr(e) + ')')
 
@@ -499,7 +499,7 @@ class wizard(xbmcgui.WindowXMLDialog):
         global lang_str
         global lang_new
         try:
-            self.oe.dbg_log('oeWindows::wizard_set_language', 'enter_function', 0)
+            self.oe.dbg_log('oeWindows::wizard_set_language', 'enter_function', self.oe.LOGDEBUG)
             langCodes = {"Bulgarian":"resource.language.bg_bg","Czech":"resource.language.cs_cz","German":"resource.language.de_de","English":"resource.language.en_gb","Spanish":"resource.language.es_es","Basque":"resource.language.eu_es","Finnish":"resource.language.fi_fi","French":"resource.language.fr_fr","Hebrew":"resource.language.he_il","Hungarian":"resource.language.hu_hu","Italian":"resource.language.it_it","Lithuanian":"resource.language.lt_lt","Latvian":"resource.language.lv_lv","Norwegian":"resource.language.nb_no","Dutch":"resource.language.nl_nl","Polish":"resource.language.pl_pl","Portuguese (Brazil)":"resource.language.pt_br","Portuguese":"resource.language.pt_pt","Romanian":"resource.language.ro_ro","Russian":"resource.language.ru_ru","Slovak":"resource.language.sk_sk","Swedish":"resource.language.sv_se","Turkish":"resource.language.tr_tr","Ukrainian":"resource.language.uk_ua"}
             languagesList = sorted(list(langCodes.keys()))
             cur_lang = xbmc.getLanguage()
@@ -525,7 +525,7 @@ class wizard(xbmcgui.WindowXMLDialog):
                 self.oe.winOeMain.set_wizard_button_1(langKey, self, 'wizard_set_language')
                 self.showButton(1, 32303)
                 self.setFocusId(self.buttons[1]['id'])
-            self.oe.dbg_log('oeWindows::wizard_set_language', 'exit_function', 0)
+            self.oe.dbg_log('oeWindows::wizard_set_language', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.dbg_log('oeWindows::wizard_set_language', 'ERROR: (' + repr(e) + ')')
 
@@ -629,7 +629,7 @@ class wizard(xbmcgui.WindowXMLDialog):
         global strModule
         global prevModule
         try:
-            self.oe.dbg_log('wizard::onClick(' + str(controlID) + ')', 'enter_function', 0)
+            self.oe.dbg_log('wizard::onClick(' + str(controlID) + ')', 'enter_function', self.oe.LOGDEBUG)
             for btn in self.buttons:
                 if controlID == self.buttons[btn]['id'] and self.buttons[btn]['id'] > 2:
                     if hasattr(self.buttons[btn]['modul'], self.buttons[btn]['action']):
@@ -653,7 +653,7 @@ class wizard(xbmcgui.WindowXMLDialog):
                     self.wizards.remove(prevModule)
                     self.oe.remove_node(prevModule)
                     self.onClick(1500)
-                self.oe.dbg_log('wizard::onClick(' + str(controlID) + ')', 'exit_function', 0)
+                self.oe.dbg_log('wizard::onClick(' + str(controlID) + ')', 'exit_function', self.oe.LOGDEBUG)
 
             if controlID == 1500:
                 self.getControl(1390).setLabel('1')
@@ -701,7 +701,7 @@ class wizard(xbmcgui.WindowXMLDialog):
                     self.visible = False
                     self.close()
                     xbmc.executebuiltin(lang_str)
-            self.oe.dbg_log('wizard::onClick(' + str(controlID) + ')', 'exit_function', 0)
+            self.oe.dbg_log('wizard::onClick(' + str(controlID) + ')', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.dbg_log('oeWindows.wizard::onClick()', 'ERROR: (' + repr(e) + ')')
 

--- a/src/service.py
+++ b/src/service.py
@@ -17,7 +17,7 @@ class service_thread(threading.Thread):
 
     def __init__(self, oeMain):
         try:
-            oeMain.dbg_log('_service_::__init__', 'enter_function', 0)
+            oeMain.dbg_log('_service_::__init__', 'enter_function', oeMain.LOGDEBUG)
             self.oe = oeMain
             self.wait_evt = threading.Event()
             self.socket_file = '/var/run/service.libreelec.settings.sock'
@@ -30,33 +30,33 @@ class service_thread(threading.Thread):
             self.stopped = False
             threading.Thread.__init__(self)
             self.daemon = True
-            self.oe.dbg_log('_service_::__init__', 'exit_function', 0)
+            self.oe.dbg_log('_service_::__init__', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.dbg_log('_service_::__init__', 'ERROR: (' + repr(e) + ')')
 
     def stop(self):
         try:
-            self.oe.dbg_log('_service_::stop', 'enter_function', 0)
+            self.oe.dbg_log('_service_::stop', 'enter_function', self.oe.LOGDEBUG)
             self.stopped = True
             sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
             sock.connect(self.socket_file)
             sock.send(bytes('exit', 'utf-8'))
             sock.close()
             self.sock.close()
-            self.oe.dbg_log('_service_::stop', 'exit_function', 0)
+            self.oe.dbg_log('_service_::stop', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.dbg_log('_service_::stop', 'ERROR: (' + repr(e) + ')')
 
     def run(self):
         try:
-            self.oe.dbg_log('_service_::run', 'enter_function', 0)
+            self.oe.dbg_log('_service_::run', 'enter_function', self.oe.LOGDEBUG)
             if self.oe.read_setting('libreelec', 'wizard_completed') == None:
                 threading.Thread(target=self.oe.openWizard).start()
             while self.stopped == False:
-                self.oe.dbg_log('_service_::run', 'WAITING:', 1)
+                self.oe.dbg_log('_service_::run', 'WAITING:', self.oe.LOGINFO)
                 conn, addr = self.sock.accept()
                 message = (conn.recv(1024)).decode('utf-8')
-                self.oe.dbg_log('_service_::run', 'MESSAGE:' + message, 1)
+                self.oe.dbg_log('_service_::run', 'MESSAGE:' + message, self.oe.LOGINFO)
                 conn.close()
                 if message == 'openConfigurationWindow':
                     if not hasattr(self.oe, 'winOeMain'):
@@ -66,7 +66,7 @@ class service_thread(threading.Thread):
                             threading.Thread(target=self.oe.openConfigurationWindow).start()
                 if message == 'exit':
                     self.stopped = True
-            self.oe.dbg_log('_service_::run', 'exit_function', 0)
+            self.oe.dbg_log('_service_::run', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.dbg_log('_service_::run', 'ERROR: (' + repr(e) + ')')
 
@@ -77,16 +77,16 @@ class cxbmcm(xbmc.Monitor):
         xbmc.Monitor.__init__(self)
 
     def onScreensaverActivated(self):
-        oe.__oe__.dbg_log('c_xbmcm::onScreensaverActivated', 'enter_function', 0)
+        oe.__oe__.dbg_log('c_xbmcm::onScreensaverActivated', 'enter_function', oe.__oe__.LOGDEBUG)
         if oe.__oe__.read_setting('bluetooth', 'standby'):
             threading.Thread(target=oe.__oe__.standby_devices).start()
-        oe.__oe__.dbg_log('c_xbmcm::onScreensaverActivated', 'exit_function', 0)
+        oe.__oe__.dbg_log('c_xbmcm::onScreensaverActivated', 'exit_function', oe.__oe__.LOGDEBUG)
 
     def onDPMSActivated(self):
-        oe.__oe__.dbg_log('c_xbmcm::onDPMSActivated', 'enter_function', 0)
+        oe.__oe__.dbg_log('c_xbmcm::onDPMSActivated', 'enter_function', oe.__oe__.LOGDEBUG)
         if oe.__oe__.read_setting('bluetooth', 'standby'):
             threading.Thread(target=oe.__oe__.standby_devices).start()
-        oe.__oe__.dbg_log('c_xbmcm::onDPMSActivated', 'exit_function', 0)
+        oe.__oe__.dbg_log('c_xbmcm::onDPMSActivated', 'exit_function', oe.__oe__.LOGDEBUG)
 
     def onAbortRequested(self):
         pass
@@ -118,7 +118,7 @@ while not xbmcm.abortRequested():
         continue
 
     if xbmc.getGlobalIdleTime() / 60 >= timeout:
-        oe.__oe__.dbg_log('service', 'idle timeout reached', 0)
+        oe.__oe__.dbg_log('service', 'idle timeout reached', oe.__oe__.LOGDEBUG)
         oe.__oe__.standby_devices()
 
 if hasattr(oe, 'winOeMain') and hasattr(oe.winOeMain, 'visible'):


### PR DESCRIPTION
With Kodi PR [Remove LOGNOTICE and LOGSEVERE from python addons and kodi](https://github.com/xbmc/xbmc/pull/18346) the log level numbers will change. Fix setting addon by using symbolic log levels.

Most work was done by:
```
find src -name "*.py" -print0|xargs -0 sed -i 's/\([^ ]*\.\)\?\(dbg_log(.*, \)0)/\1\2\1LOGDEBUG)/'
find src -name "*.py" -print0|xargs -0 sed -i 's/\([^ ]*\.\)\?\(dbg_log(.*, \)1)/\1\2\1LOGINFO)/'
find src -name "*.py" -print0|xargs -0 sed -i 's/\([^ ]*\.\)\?\(dbg_log(.*, \)2)/\1\2\1LOGWARNING)/'
find src -name "*.py" -print0|xargs -0 sed -i 's/\([^ ]*\.\)\?\(dbg_log(.*, \)4)/\1\2\1LOGERROR)/'
# find and print multi line dbg_log()
find src -name "*.py" -print0|xargs -0 grep -ne 'dbg_log(.*[^)]$'
```

This PR needs #160 to be committed first.