### PR TITLE
auto update: use unicode strings for notify()

### DIFF
--- a/src/resources/lib/modules/updates.py
+++ b/src/resources/lib/modules/updates.py
@@ -584,7 +584,7 @@ class updates:
                 if not downloaded is None:
                     self.update_file = self.update_file.split('/')[-1]
                     if self.struct['update']['settings']['UpdateNotify']['value'] == '1':
-                        self.oe.notify(self.oe._(32363), self.oe._(32366))
+                        self.oe.notify(self.oe._(32363).encode('utf-8'), self.oe._(32366).encode('utf-8'))
                     shutil.move(self.oe.TEMP + 'update_file', self.LOCAL_UPDATE_DIR + self.update_file)
                     subprocess.call('sync', shell=True, stdin=None, stdout=None, stderr=None)
                     if silent == False:


### PR DESCRIPTION
Error reported in the [forum](https://forum.libreelec.tv/thread/22609-libreelec-update/?postID=144324#post144324). Auto update is not working in LibreELEC 9.2.

Beside #164 there is a crash in the notify function when using i.e. Hungarian language because of missing unicode strings.

There is no fix needed in master due to the different string handling in Python 3.