### PR TITLE
Assorted minor changes

### DIFF
--- a/src/oe.py
+++ b/src/oe.py
@@ -8,6 +8,7 @@
 import xbmc
 import xbmcaddon
 import xbmcgui
+import xbmcvfs
 import os
 import re
 import locale
@@ -72,8 +73,8 @@ dbusSystemBus = dbus.SystemBus()
 ########################## initialize module ##################################
 ## append resource subfolders to path
 
-sys.path.append(xbmc.translatePath(os.path.join(__cwd__, 'resources', 'lib')))
-sys.path.append(xbmc.translatePath(os.path.join(__cwd__, 'resources', 'lib', 'modules')))
+sys.path.append(xbmcvfs.translatePath(os.path.join(__cwd__, 'resources', 'lib')))
+sys.path.append(xbmcvfs.translatePath(os.path.join(__cwd__, 'resources', 'lib', 'modules')))
 
 ## set default encoding
 

--- a/src/resources/lib/modules/system.py
+++ b/src/resources/lib/modules/system.py
@@ -589,11 +589,9 @@ class system:
 
             restore_file_name = restore_file_path.split('/')[-1]
 
-            if not os.path.exists(self.RESTORE_DIR):
-                os.makedirs(self.RESTORE_DIR)
-            else:
+            if os.path.exists(self.RESTORE_DIR):
                 self.oe.execute('rm -rf %s' % self.RESTORE_DIR)
-                os.makedirs(self.RESTORE_DIR)
+            os.makedirs(self.RESTORE_DIR)
             folder_stat = os.statvfs(self.RESTORE_DIR)
             file_size = os.path.getsize(restore_file_path)
             free_space = folder_stat.f_frsize * folder_stat.f_bavail

--- a/src/resources/lib/modules/system.py
+++ b/src/resources/lib/modules/system.py
@@ -477,9 +477,7 @@ class system:
             self.oe.dbg_log('system::reset_xbmc', 'enter_function', 0)
             if self.ask_sure_reset('Soft') == 1:
                 self.oe.set_busy(1)
-                reset_file = open(self.XBMC_RESET_FILE, 'w')
-                reset_file.write('reset')
-                reset_file.close()
+                open(self.XBMC_RESET_FILE, 'a').close()
                 self.oe.winOeMain.close()
                 self.oe.xbmcm.waitForAbort(1)
                 xbmc.executebuiltin('Reboot')
@@ -494,9 +492,7 @@ class system:
             self.oe.dbg_log('system::reset_oe', 'enter_function', 0)
             if self.ask_sure_reset('Hard') == 1:
                 self.oe.set_busy(1)
-                reset_file = open(self.LIBREELEC_RESET_FILE, 'w')
-                reset_file.write('reset')
-                reset_file.close()
+                open(self.LIBREELEC_RESET_FILE, 'a').close()
                 self.oe.winOeMain.close()
                 self.oe.xbmcm.waitForAbort(1)
                 xbmc.executebuiltin('Reboot')


### PR DESCRIPTION
Three minors from my build branch:

xbmc.translatePath -> xbmcvfs.translatePath is a K19 change; resolves a deprecation warning in the log

system reset file flags simply need to exist as files, not have anything written to them

The backup dir creation logic was doing:
If dir doesn't exist, create it, otherwise delete it and create it.
This is:
If it exists, delete it, then everyone creates it.