### PR TITLE
system.py: fix reading UTF-8 keyboard layouts in Python 3.8

### DIFF
--- a/src/resources/lib/modules/system.py
+++ b/src/resources/lib/modules/system.py
@@ -409,7 +409,7 @@ class system:
                 arrLayouts.sort()
                 arrTypes = None
             elif os.path.exists(self.KEYBOARD_INFO):
-                objXmlFile = open(self.KEYBOARD_INFO, 'r')
+                objXmlFile = open(self.KEYBOARD_INFO, 'r', encoding='utf-8')
                 strXmlText = objXmlFile.read()
                 objXmlFile.close()
                 xml_conf = minidom.parseString(strXmlText)


### PR DESCRIPTION
Fix not using UTF-8 error when loading keyboard info. A fatal error is generated after Python 3.8 update:

```
2020-09-16 10:29:46.260 T:661     FATAL <general>: ## LibreELEC Addon ## system::get_keyboard_layouts ## ERROR: (UnicodeDecodeError('ascii', b'<?xml ...
```

Log: https://github.com/LibreELEC/service.libreelec.settings/files/5233919/kodi.log
