### PR TITLE
use dtflag helper for arm board stats

### DIFF
--- a/src/resources/lib/modules/updates.py
+++ b/src/resources/lib/modules/updates.py
@@ -252,29 +252,21 @@ class updates:
 
         return gpu_driver if gpu_driver else "unknown"
 
-    def get_hardware_flags_rpi(self):
-        revision = self.oe.execute('grep "^Revision" /proc/cpuinfo | awk \'{ print $3 }\'',get_result=1).replace('\n','')
-        self.oe.dbg_log('updates::get_hardware_flags_rpi', 'Revision code: %s' % revision, self.oe.LOGDEBUG)
-
-        return '{:08x}'.format(int(revision, 16))
-
-    def get_hardware_flags_dtname(self):
-        if os.path.exists('/usr/bin/dtname'):
-            dtname = self.oe.execute('/usr/bin/dtname', get_result=1).rstrip('\x00')
+    def get_hardware_flags_dtflag(self):
+        if os.path.exists('/usr/bin/dtflag'):
+            dtflag = self.oe.execute('/usr/bin/dtflag', get_result=1).rstrip('\x00\n')
         else:
-            dtname = "unknown"
+            dtflag = "unknown"
 
-        self.oe.dbg_log('system::get_hardware_flags_dtname', 'ARM board: %s' % dtname, self.oe.LOGDEBUG)
+        self.oe.dbg_log('system::get_hardware_flags_dtflag', 'ARM board: %s' % dtflag, self.oe.LOGDEBUG)
 
-        return dtname
+        return dtflag
 
     def get_hardware_flags(self):
         if self.oe.PROJECT == "Generic":
             return self.get_hardware_flags_x86_64()
-        elif self.oe.PROJECT == "RPi":
-            return self.get_hardware_flags_rpi()
-        elif self.oe.PROJECT in ['Allwinner', 'Amlogic', 'NXP', 'Qualcomm', 'Rockchip', 'Samsung' ]:
-            return self.get_hardware_flags_dtname()
+        elif self.oe.PROJECT in ['Allwinner', 'Amlogic', 'NXP', 'Qualcomm', 'Rockchip', 'RPi', 'Samsung' ]:
+            return self.get_hardware_flags_dtflag()
         else:
             self.oe.dbg_log('updates::get_hardware_flags', 'Project is %s, no hardware flag available' % self.oe.PROJECT, self.oe.LOGDEBUG)
             return ""


### PR DESCRIPTION
This depends on https://github.com/LibreELEC/LibreELEC.tv/pull/4662 for the helper script. It will help normalise the board stats on our Pi userbase which are currently reported as SoC revision codes (more detailed, but not human friendly).