### PR TITLE
f-strings conversion

### DIFF
--- a/src/default.py
+++ b/src/default.py
@@ -10,7 +10,7 @@ import xbmcaddon
 __scriptid__ = 'service.libreelec.settings'
 __addon__ = xbmcaddon.Addon(id=__scriptid__)
 __cwd__ = __addon__.getAddonInfo('path')
-__media__ = '%s/resources/skins/Default/media' % __cwd__
+__media__ = f'{__cwd__}/resources/skins/Default/media'
 _ = __addon__.getLocalizedString
 
 try:
@@ -19,4 +19,4 @@ try:
     sock.send(bytes('openConfigurationWindow', 'utf-8'))
     sock.close()
 except Exception as e:
-    xbmc.executebuiltin('Notification("LibreELEC", "%s", 5000, "%s/icon.png")' % (_(32390), __media__))
+    xbmc.executebuiltin(f'Notification("LibreELEC", "{_(32390)}", 5000, "{__media__}/icon.png"')

--- a/src/defaults.py
+++ b/src/defaults.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2009-2013 Stephan Raue (stephan@openelec.tv)
 # Copyright (C) 2013 Lutz Fiebach (lufie@openelec.tv)
+# Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 import os
 
@@ -18,7 +19,7 @@ USER_CONFIG = os.environ.get('USER_CONFIG', '/storage/.config')
 
 connman = {
     'CONNMAN_DAEMON': '/usr/sbin/connmand',
-    'WAIT_CONF_FILE': '%s/libreelec/network_wait' % CONFIG_CACHE,
+    'WAIT_CONF_FILE': f'{CONFIG_CACHE}/libreelec/network_wait',
     'ENABLED': lambda : (True if os.path.exists(connman['CONNMAN_DAEMON']) and not os.path.exists('/dev/.kernel_ipconfig') else False),
     }
 connman['ENABLED'] = connman['ENABLED']()
@@ -62,10 +63,10 @@ system = {
     'ENABLED': True,
     'KERNEL_CMD': '/proc/cmdline',
     'SET_CLOCK_CMD': '/sbin/hwclock --systohc --utc',
-    'XBMC_RESET_FILE': '%s/reset_xbmc' % CONFIG_CACHE,
-    'LIBREELEC_RESET_FILE': '%s/reset_oe' % CONFIG_CACHE,
+    'XBMC_RESET_FILE': f'{CONFIG_CACHE}/reset_xbmc',
+    'LIBREELEC_RESET_FILE': f'{CONFIG_CACHE}/reset_oe',
     'KEYBOARD_INFO': '/usr/share/X11/xkb/rules/base.xml',
-    'UDEV_KEYBOARD_INFO': '%s/xkb/layout' % CONFIG_CACHE,
+    'UDEV_KEYBOARD_INFO': f'{CONFIG_CACHE}/xkb/layout',
     'NOX_KEYBOARD_INFO': '/usr/lib/keymaps',
     'BACKUP_DIRS': [
         XBMC_USER_HOME,

--- a/src/oe.py
+++ b/src/oe.py
@@ -34,7 +34,7 @@ __scriptid__ = 'service.libreelec.settings'
 __addon__ = xbmcaddon.Addon(id=__scriptid__)
 __cwd__ = __addon__.getAddonInfo('path')
 __oe__ = sys.modules[globals()['__name__']]
-__media__ = '%s/resources/skins/Default/media' % __cwd__
+__media__ = f'{__cwd__}/resources/skins/Default/media'
 xbmcDialog = xbmcgui.Dialog()
 
 xbmcm = xbmc.Monitor()
@@ -87,7 +87,7 @@ imp.reload(sys)
 ## load oeSettings modules
 
 import oeWindows
-xbmc.log('## LibreELEC Addon ## ' + str(__addon__.getAddonInfo('version')))
+xbmc.log(f"## LibreELEC Addon ## {str(__addon__.getAddonInfo('version'))}")
 
 class PINStorage:
     def __init__(self, module='system', prefix='pinlock', maxAttempts=4, delay=300):
@@ -113,11 +113,11 @@ class PINStorage:
             self.disable()
 
     def read(self, item):
-        value = read_setting(self.module, '%s_%s' % (self.prefix, item))
+        value = read_setting(self.module, f'{self.prefix}_{item}')
         return None if value == '' else value
 
     def write(self, item, value):
-        return write_setting(self.module, '%s_%s' % (self.prefix, item), str(value) if value else '')
+        return write_setting(self.module, f'{self.prefix}_{item}', str(value) if value else '')
 
     def isEnabled(self):
         return self.enabled == '1'
@@ -232,15 +232,15 @@ class ProgressDialog:
 
     def open(self, heading='LibreELEC', line1='', line2='', line3=''):
         self.dialog = xbmcgui.DialogProgress()
-        self.dialog.create(heading, '%s\n%s\n%s' % (line1, line2, line3))
+        self.dialog.create(heading, f'{line1}\n{line2}\n{line3}')
         self.reset()
 
     def update(self, chunk):
         if self.dialog and self.needsUpdate(chunk):
-            line1 = '%s: %s' % (self.label1, self.source.rsplit('/', 1)[1])
-            line2 = '%s: %s KB/s' % (self.label2, f'{self.speed:,}')
-            line3 = '%s: %d m %d s' % (self.label3, self.minutes, self.seconds)
-            self.dialog.update(self.percent, '%s\n%s\n%s' % (line1, line2, line3))
+            line1 = f'{self.label1}: {self.source.rsplit("/", 1)[1]}'
+            line2 = f'{self.label2}: {self.speed:,} KB/s'
+            line3 = f'{self.label3}: {self.minutes} m {self.seconds} s'
+            self.dialog.update(self.percent, f'{line1}\n{line2}\n{line3}')
             self.last_update = time.time()
 
     def close(self):
@@ -305,7 +305,7 @@ def _(code):
 def dbg_log(source, text, level=4):
     if level == 0 and os.environ.get('DEBUG', 'no') == 'no':
         return
-    xbmc.log('## LibreELEC Addon ## ' + source + ' ## ' + text, level)
+    xbmc.log(f"## LibreELEC Addon ## {source} ## {text}", level)
     if level == 4:
         tracedata = traceback.format_exc()
         if tracedata != "NoneType: None\n":
@@ -314,16 +314,11 @@ def dbg_log(source, text, level=4):
 def notify(title, message, icon='icon'):
     try:
         dbg_log('oe::notify', 'enter_function', LOGDEBUG)
-        msg = 'Notification("%s", "%s", 5000, "%s/%s.png")' % (
-            title,
-            message[0:64],
-            __media__,
-            icon,
-            )
+        msg = f'Notification("{title}", "{message[0:64]}", 5000, "{__media__}/{icon}.png")'
         xbmc.executebuiltin(msg)
         dbg_log('oe::notify', 'exit_function', LOGDEBUG)
     except Exception as e:
-        dbg_log('oe::notify', 'ERROR: (' + repr(e) + ')')
+        dbg_log('oe::notify', f'ERROR: ({repr(e)})')
 
 
 def execute(command_line, get_result=0):
@@ -342,48 +337,48 @@ def execute(command_line, get_result=0):
             return result
         dbg_log('oe::execute', 'exit_function', LOGDEBUG)
     except Exception as e:
-        dbg_log('oe::execute', 'ERROR: (' + repr(e) + ')')
+        dbg_log('oe::execute', f'ERROR: ({repr(e)})')
 
 
 def enable_service(service):
     try:
-        if os.path.exists('%s/services/%s' % (CONFIG_CACHE, service)):
+        if os.path.exists(f'{CONFIG_CACHE}/services/{service}'):
             pass
-        if os.path.exists('%s/services/%s.disabled' % (CONFIG_CACHE, service)):
+        if os.path.exists(f'{CONFIG_CACHE}/services/{service}.disabled'):
             pass
-        service_file = '%s/services/%s' % (CONFIG_CACHE, service)
+        service_file = f'{CONFIG_CACHE}/services/{service}'
     except Exception as e:
-        dbg_log('oe::enable_service', 'ERROR: (' + repr(e) + ')')
+        dbg_log('oe::enable_service', f'ERROR: ({repr(e)})')
 
 
 def set_service_option(service, option, value):
     try:
         lines = []
         changed = False
-        conf_file_name = '%s/services/%s.conf' % (CONFIG_CACHE, service)
+        conf_file_name = f'{CONFIG_CACHE}/services/{service}.conf'
         if os.path.isfile(conf_file_name):
             with open(conf_file_name, 'r') as conf_file:
                 for line in conf_file:
                     if option in line:
-                        line = '%s=%s' % (option, value)
+                        line = f'{option}={value}'
                         changed = True
                     lines.append(line.strip())
         if changed == False:
-            lines.append('%s=%s' % (option, value))
+            lines.append(f'{option}={value}')
         with open(conf_file_name, 'w') as conf_file:
             conf_file.write('\n'.join(lines) + '\n')
     except Exception as e:
-        dbg_log('oe::set_service_option', 'ERROR: (' + repr(e) + ')')
+        dbg_log('oe::set_service_option', f'ERROR: ({repr(e)})')
 
 
 def get_service_option(service, option, default=None):
     try:
         lines = []
         conf_file_name = ''
-        if os.path.exists('%s/services/%s.conf' % (CONFIG_CACHE, service)):
-            conf_file_name = '%s/services/%s.conf' % (CONFIG_CACHE, service)
-        if os.path.exists('%s/services/%s.disabled' % (CONFIG_CACHE, service)):
-            conf_file_name = '%s/services/%s.disabled' % (CONFIG_CACHE, service)
+        if os.path.exists(f'{CONFIG_CACHE}/services/{service}.conf'):
+            conf_file_name = f'{CONFIG_CACHE}/services/{service}.conf'
+        if os.path.exists(f'{CONFIG_CACHE}/services/{service}.disabled'):
+            conf_file_name = f'{CONFIG_CACHE}/services/{service}.disabled'
         if os.path.exists(conf_file_name):
             with open(conf_file_name, 'r') as conf_file:
                 for line in conf_file:
@@ -392,17 +387,17 @@ def get_service_option(service, option, default=None):
                             default = line.strip().split('=')[-1]
         return default
     except Exception as e:
-        dbg_log('oe::get_service_option', 'ERROR: (' + repr(e) + ')')
+        dbg_log('oe::get_service_option', f'ERROR: ({repr(e)})')
 
 
 def get_service_state(service):
     try:
-        if os.path.exists('%s/services/%s.conf' % (CONFIG_CACHE, service)):
+        if os.path.exists(f'{CONFIG_CACHE}/services/{service}.conf'):
             return '1'
         else:
             return '0'
     except Exception as e:
-        dbg_log('oe::get_service_state', 'ERROR: (' + repr(e) + ')')
+        dbg_log('oe::get_service_state', f'ERROR: ({repr(e)})')
 
 
 def set_service(service, options, state):
@@ -421,31 +416,31 @@ def set_service(service, options, state):
             # Is Service alwys enabled ?
 
             if get_service_state(service) == '1':
-                cfn = '%s/services/%s.conf' % (CONFIG_CACHE, service)
+                cfn = f'{CONFIG_CACHE}/services/{service}.conf'
                 cfo = cfn
             else:
-                cfn = '%s/services/%s.conf' % (CONFIG_CACHE, service)
-                cfo = '%s/services/%s.disabled' % (CONFIG_CACHE, service)
+                cfn = f'{CONFIG_CACHE}/services/{service}.conf'
+                cfo = f'{CONFIG_CACHE}/services/{service}.disabled'
             if os.path.exists(cfo) and not cfo == cfn:
                 os.remove(cfo)
             with open(cfn, 'w') as cf:
                 for option in options:
-                    cf.write('%s=%s\n' % (option, options[option]))
+                    cf.write(f'{option}={options[option]}\n')
         else:
 
         # Service Disabled
 
-            cfo = '%s/services/%s.conf' % (CONFIG_CACHE, service)
-            cfn = '%s/services/%s.disabled' % (CONFIG_CACHE, service)
+            cfo = f'{CONFIG_CACHE}/services/{service}.conf'
+            cfn = f'{CONFIG_CACHE}/services/{service}.disabled'
             if os.path.exists(cfo):
                 os.rename(cfo, cfn)
         if not __oe__.is_service:
             if service in defaults._services:
                 for svc in defaults._services[service]:
-                    execute('systemctl restart %s' % svc)
+                    execute(f'systemctl restart {svc}')
         dbg_log('oe::set_service', 'exit_function', LOGDEBUG)
     except Exception as e:
-        dbg_log('oe::set_service', 'ERROR: (' + repr(e) + ')')
+        dbg_log('oe::set_service', f'ERROR: ({repr(e)})')
 
 
 def load_file(filename):
@@ -458,7 +453,7 @@ def load_file(filename):
             content = ''
         return content.strip()
     except Exception as e:
-        dbg_log('oe::load_file(' + filename + ')', 'ERROR: (' + repr(e) + ')')
+        dbg_log(f'oe::load_file({filename})', f'ERROR: ({repr(e)})')
 
 def url_quote(var):
     return urllib.parse.quote(var, safe="")
@@ -470,7 +465,7 @@ def load_url(url):
         content = response.read()
         return content.decode('utf-8').strip()
     except Exception as e:
-        dbg_log('oe::load_url(' + url + ')', 'ERROR: (' + repr(e) + ')')
+        dbg_log(f'oe::load_url({url})', f'ERROR: ({repr(e)})')
 
 
 def download_file(source, destination, silent=False):
@@ -497,7 +492,7 @@ def download_file(source, destination, silent=False):
                 progress.update(part)
             else:
                 if progress.getPercent() - last_percent > 5 or not part:
-                    dbg_log('oe::download_file(%s)' % destination, '%d%% with %d KB/s' % (progress.getPercent(), progress.getSpeed()))
+                    dbg_log(f'oe::download_file({destination})', f'{progress.getPercent()}%% with {progress.getSpeed()} KB/s')
                     last_percent = progress.getPercent()
 
             if part:
@@ -516,12 +511,12 @@ def download_file(source, destination, silent=False):
         return destination
 
     except Exception as e:
-        dbg_log('oe::download_file(' + source + ', ' + destination + ')', 'ERROR: (' + repr(e) + ')')
+        dbg_log(f'oe::download_file({source},{destination})', f'ERROR: ({repr(e)})')
 
 
 def copy_file(source, destination, silent=False):
     try:
-        dbg_log('oe::copy_file', 'SOURCE: %s, DEST: %s' % (source, destination), LOGINFO)
+        dbg_log('oe::copy_file', f'SOURCE: {source}, DEST: {destination}', LOGINFO)
 
         source_file = open(source, 'rb')
         destination_file = open(destination, 'wb')
@@ -544,7 +539,7 @@ def copy_file(source, destination, silent=False):
                 progress.update(part)
             else:
                 if progress.getPercent() - last_percent > 5 or not part:
-                    dbg_log('oe::copy_file(%s)' % destination, '%d%% with %d KB/s' % (progress.getPercent(), progress.getSpeed()))
+                    dbg_log(f'oe::copy_file({destination})', f'{progress.getPercent()}%% with {progress.getSpeed()} KB/s')
                     last_percent = progress.getPercent()
 
             if part:
@@ -563,7 +558,7 @@ def copy_file(source, destination, silent=False):
         return destination
 
     except Exception as e:
-        dbg_log('oe::copy_file(' + source + ', ' + destination + ')', 'ERROR: (' + repr(e) + ')')
+        dbg_log(f'oe::copy_file({source},{destination})', f'ERROR: ({repr(e)})')
 
 
 def is_busy():
@@ -579,9 +574,9 @@ def set_busy(state):
                 __busy__ = __busy__ + 1
             else:
                 __busy__ = __busy__ - 1
-            dbg_log('oe::set_busy', '__busy__ = ' + str(__busy__), LOGDEBUG)
+            dbg_log('oe::set_busy', f'__busy__ = {str(__busy__)}', LOGDEBUG)
     except Exception as e:
-        dbg_log('oe::set_busy', 'ERROR: (' + repr(e) + ')', LOGERROR)
+        dbg_log('oe::set_busy', f'ERROR: ({repr(e)})', LOGERROR)
 
 
 def start_service():
@@ -594,7 +589,7 @@ def start_service():
                 module.start_service()
         __oe__.is_service = False
     except Exception as e:
-        dbg_log('oe::start_service', 'ERROR: (' + repr(e) + ')')
+        dbg_log('oe::start_service', f'ERROR: ({repr(e)})')
 
 
 def stop_service():
@@ -606,7 +601,7 @@ def stop_service():
                 module.stop_service()
         xbmc.log('## LibreELEC Addon ## STOP SERVICE DONE !')
     except Exception as e:
-        dbg_log('oe::stop_service', 'ERROR: (' + repr(e) + ')')
+        dbg_log('oe::stop_service', f'ERROR: ({repr(e)})')
 
 
 def openWizard():
@@ -616,7 +611,7 @@ def openWizard():
         winOeMain.doModal()
         winOeMain = oeWindows.mainWindow('service-LibreELEC-Settings-mainWindow.xml', __cwd__, 'Default', oeMain=__oe__)  # None
     except Exception as e:
-        dbg_log('oe::openWizard', 'ERROR: (' + repr(e) + ')')
+        dbg_log('oe::openWizard', f'ERROR: ({repr(e)})')
 
 
 def openConfigurationWindow():
@@ -647,7 +642,7 @@ def openConfigurationWindow():
                 PIN.fail()
 
                 if PIN.attemptsRemaining() > 0:
-                    xbmcDialog.ok(_(32234), '%d %s' % (PIN.attemptsRemaining(), _(32235)))
+                    xbmcDialog.ok(_(32234), f'{PIN.attemptsRemaining()} {_(32235)}')
 
             if not match and PIN.attemptsRemaining() <= 0:
               xbmcDialog.ok(_(32234), _(32236))
@@ -662,7 +657,7 @@ def openConfigurationWindow():
             del winOeMain
 
     except Exception as e:
-        dbg_log('oe::openConfigurationWindow', 'ERROR: (' + repr(e) + ')')
+        dbg_log('oe::openConfigurationWindow', f'ERROR: ({repr(e)})')
 
 def standby_devices():
     global dictModules
@@ -670,7 +665,7 @@ def standby_devices():
         if 'bluetooth' in dictModules:
             dictModules['bluetooth'].standby_devices()
     except Exception as e:
-        dbg_log('oe::standby_devices', 'ERROR: (' + repr(e) + ')')
+        dbg_log('oe::standby_devices', f'ERROR: ({repr(e)})')
 
 def load_config():
     try:
@@ -698,7 +693,7 @@ def load_config():
         conf_lock = False
         return xml_conf
     except Exception as e:
-        dbg_log('oe::load_config', 'ERROR: (' + repr(e) + ')')
+        dbg_log('oe::load_config', f'ERROR: ({repr(e)})')
 
 
 def save_config(xml_conf):
@@ -712,7 +707,7 @@ def save_config(xml_conf):
         config_file.close()
         conf_lock = False
     except Exception as e:
-        dbg_log('oe::save_config', 'ERROR: (' + repr(e) + ')')
+        dbg_log('oe::save_config', f'ERROR: ({repr(e)})')
 
 
 def read_module(module):
@@ -723,7 +718,7 @@ def read_module(module):
             for xml_modul in xml_setting.getElementsByTagName(module):
                 return xml_modul
     except Exception as e:
-        dbg_log('oe::read_module', 'ERROR: (' + repr(e) + ')')
+        dbg_log('oe::read_module', f'ERROR: ({repr(e)})')
 
 
 def read_node(node_name):
@@ -744,7 +739,7 @@ def read_node(node_name):
                         value[xml_main_node.nodeName][xml_sub_node.nodeName][xml_value.nodeName] = ''
         return value
     except Exception as e:
-        dbg_log('oe::read_node', 'ERROR: (' + repr(e) + ')')
+        dbg_log('oe::read_node', f'ERROR: ({repr(e)})')
 
 
 def remove_node(node_name):
@@ -755,7 +750,7 @@ def remove_node(node_name):
             xml_main_node.parentNode.removeChild(xml_main_node)
         save_config(xml_conf)
     except Exception as e:
-        dbg_log('oe::remove_node', 'ERROR: (' + repr(e) + ')')
+        dbg_log('oe::remove_node', f'ERROR: ({repr(e)})')
 
 
 def read_setting(module, setting, default=None):
@@ -770,7 +765,7 @@ def read_setting(module, setting, default=None):
                         value = xml_modul_setting.firstChild.nodeValue
         return value
     except Exception as e:
-        dbg_log('oe::read_setting', 'ERROR: (' + repr(e) + ')')
+        dbg_log('oe::read_setting', f'ERROR: ({repr(e)})')
 
 
 def write_setting(module, setting, value, main_node='settings'):
@@ -805,7 +800,7 @@ def write_setting(module, setting, value, main_node='settings'):
             xml_setting.appendChild(xml_value)
         save_config(xml_conf)
     except Exception as e:
-        dbg_log('oe::write_setting', 'ERROR: (' + repr(e) + ')')
+        dbg_log('oe::write_setting', f'ERROR: ({repr(e)})')
 
 
 def load_modules():
@@ -818,7 +813,7 @@ def load_modules():
             dictModules[strModule] = None
         dict_names = {}
         dictModules = {}
-        for file_name in sorted(os.listdir(__cwd__ + '/resources/lib/modules')):
+        for file_name in sorted(os.listdir(f'{__cwd__}/resources/lib/modules')):
             if not file_name.startswith('__') and (file_name.endswith('.py') or file_name.endswith('.pyc')):
                 (name, ext) = file_name.split('.')
                 dict_names[name] = None
@@ -830,9 +825,9 @@ def load_modules():
                         for key in getattr(defaults, module_name):
                             setattr(dictModules[module_name], key, getattr(defaults, module_name)[key])
             except Exception as e:
-                dbg_log('oe::MAIN(loadingModules)(strModule)', 'ERROR: (' + repr(e) + ')')
+                dbg_log('oe::MAIN(loadingModules)(strModule)', f'ERROR: ({repr(e)})')
     except Exception as e:
-        dbg_log('oe::MAIN(loadingModules)', 'ERROR: (' + repr(e) + ')')
+        dbg_log('oe::MAIN(loadingModules)', f'ERROR: ({repr(e)})')
 
 
 def timestamp():
@@ -852,7 +847,7 @@ def split_dialog_text(text):
 
 def reboot_counter(seconds=10, title=' '):
     reboot_dlg = xbmcgui.DialogProgress()
-    reboot_dlg.create('LibreELEC %s' % title, ' ')
+    reboot_dlg.create(f'LibreELEC {title}', ' ')
     reboot_dlg.update(0)
     wait_time = seconds
     while seconds >= 0 and not (reboot_dlg.iscanceled() or xbmcm.abortRequested()):
@@ -883,31 +878,27 @@ def exit():
 # fix for xml printout
 
 def fixed_writexml(self, writer, indent='', addindent='', newl=''):
-    writer.write(indent + '<' + self.tagName)
+    writer.write(f'{indent}<{self.tagName}')
     attrs = self._get_attributes()
     a_names = list(attrs.keys())
     a_names.sort()
     for a_name in a_names:
-        writer.write(' %s="' % a_name)
+        writer.write(f' {a_name}="')
         minidom._write_data(writer, attrs[a_name].value)
         writer.write('"')
     if self.childNodes:
         if len(self.childNodes) == 1 and self.childNodes[0].nodeType == minidom.Node.TEXT_NODE:
             writer.write('>')
             self.childNodes[0].writexml(writer, '', '', '')
-            writer.write('</%s>%s' % (self.tagName, newl))
+            writer.write(f'</{self.tagName}>{newl}')
             return
-        writer.write('>%s' % newl)
+        writer.write(f'>{newl}')
         for node in self.childNodes:
             if node.nodeType is not minidom.Node.TEXT_NODE:
                 node.writexml(writer, indent + addindent, addindent, newl)
-        writer.write('%s</%s>%s' % (
-            indent,
-            self.tagName,
-            newl,
-            ))
+        writer.write(f'{indent}</{self.tagName}>{newl}')
     else:
-        writer.write('/>%s' % newl)
+        writer.write(f'/>{newl}')
 
 
 def parse_os_release():
@@ -979,7 +970,7 @@ DOWNLOAD_DIR = '/storage/downloads'
 XBMC_USER_HOME = os.environ.get('XBMC_USER_HOME', '/storage/.kodi')
 CONFIG_CACHE = os.environ.get('CONFIG_CACHE', '/storage/.cache')
 USER_CONFIG = os.environ.get('USER_CONFIG', '/storage/.config')
-TEMP = '%s/temp/' % XBMC_USER_HOME
+TEMP = f'{XBMC_USER_HOME}/temp/'
 winOeMain = oeWindows.mainWindow('service-LibreELEC-Settings-mainWindow.xml', __cwd__, 'Default', oeMain=__oe__)
 if os.path.exists('/etc/machine-id'):
     SYSTEMID = load_file('/etc/machine-id')
@@ -996,11 +987,11 @@ BOOT_STATUS = load_file('/storage/.config/boot.status')
 ############################################################################################
 
 try:
-    configFile = '%s/userdata/addon_data/service.libreelec.settings/oe_settings.xml' % XBMC_USER_HOME
-    if not os.path.exists('%s/userdata/addon_data/service.libreelec.settings' % XBMC_USER_HOME):
-        if os.path.exists('%s/userdata/addon_data/service.openelec.settings' % XBMC_USER_HOME):
-            shutil.copytree(('%s/userdata/addon_data/service.openelec.settings' % XBMC_USER_HOME),
-                    ('%s/userdata/addon_data/service.libreelec.settings' % XBMC_USER_HOME))
+    configFile = f'{XBMC_USER_HOME}/userdata/addon_data/service.libreelec.settings/oe_settings.xml'
+    if not os.path.exists(f'{XBMC_USER_HOME}/userdata/addon_data/service.libreelec.settings'):
+        if os.path.exists(f'{XBMC_USER_HOME}/userdata/addon_data/service.openelec.settings'):
+            shutil.copytree((f'{XBMC_USER_HOME}/userdata/addon_data/service.openelec.settings'),
+                    (f'{XBMC_USER_HOME}/userdata/addon_data/service.libreelec.settings'))
             with open(configFile,'r+') as f:
                 xml = f.read()
                 xml = xml.replace("<openelec>","<libreelec>")
@@ -1009,9 +1000,9 @@ try:
                 f.write(xml)
                 f.truncate()
         else:
-            os.makedirs('%s/userdata/addon_data/service.libreelec.settings' % XBMC_USER_HOME)
-    if not os.path.exists('%s/services' % CONFIG_CACHE):
-        os.makedirs('%s/services' % CONFIG_CACHE)
+            os.makedirs(f'{XBMC_USER_HOME}/userdata/addon_data/service.libreelec.settings')
+    if not os.path.exists(f'{CONFIG_CACHE}/services'):
+        os.makedirs(f'{CONFIG_CACHE}/services')
 except:
     pass
 

--- a/src/resources/lib/modules/about.py
+++ b/src/resources/lib/modules/about.py
@@ -20,7 +20,7 @@ class about:
             self.controls = {}
             self.oe.dbg_log('about::__init__', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('about::__init__', 'ERROR: (' + repr(e) + ')')
+            self.oe.dbg_log('about::__init__', f'ERROR: ({repr(e)})')
 
     def menu_loader(self, menuItem):
         try:
@@ -29,7 +29,7 @@ class about:
                 self.init_controls()
             self.oe.dbg_log('about::menu_loader', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('about::menu_loader', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
+            self.oe.dbg_log('about::menu_loader', f'ERROR: ({repr(e)})', self.oe.LOGERROR)
 
     def exit_addon(self):
         try:
@@ -37,14 +37,14 @@ class about:
             self.oe.winOeMain.close()
             self.oe.dbg_log('about::exit_addon', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('about::exit_addon', 'ERROR: (' + repr(e) + ')')
+            self.oe.dbg_log('about::exit_addon', f'ERROR: ({repr(e)})')
 
     def init_controls(self):
         try:
             self.oe.dbg_log('about::init_controls', 'enter_function', self.oe.LOGDEBUG)
             self.oe.dbg_log('about::init_controls', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('about::init_controls', 'ERROR: (' + repr(e) + ')')
+            self.oe.dbg_log('about::init_controls', f'ERROR: ({repr(e)})')
 
     def exit(self):
         try:
@@ -57,7 +57,7 @@ class about:
             self.controls = {}
             self.oe.dbg_log('about::exit', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('about::exit', 'ERROR: (' + repr(e) + ')')
+            self.oe.dbg_log('about::exit', f'ERROR: ({repr(e)})')
 
     def do_wizard(self):
         try:
@@ -66,4 +66,4 @@ class about:
             self.oe.winOeMain.set_wizard_text(self.oe._(32318))
             self.oe.dbg_log('about::do_wizard', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('about::do_wizard', 'ERROR: (' + repr(e) + ')')
+            self.oe.dbg_log('about::do_wizard', f'ERROR: ({repr(e)})')

--- a/src/resources/lib/modules/bluetooth.py
+++ b/src/resources/lib/modules/bluetooth.py
@@ -868,7 +868,7 @@ class bluetooth:
                     if interface['Status'] == 'active':
                         self.parent.download_start = time.time()
                         self.parent.download = xbmcgui.DialogProgress()
-                        self.parent.download.create('Bluetooth Filetransfer', '%s: %s' % (self.oe._(32181), self.parent.download_file))
+                        self.parent.download.create('Bluetooth Filetransfer', f'{self.oe._(32181)}: {self.parent.download_file}')
                     else:
                         if hasattr(self.parent, 'download'):
                             self.parent.download.close()
@@ -880,9 +880,9 @@ class bluetooth:
                             xbmcDialog = xbmcgui.Dialog()
                             answer = xbmcDialog.yesno('Bluetooth Filetransfer', self.oe._(32383))
                             if answer == 1:
-                                fil = '%s/%s' % (self.oe.DOWNLOAD_DIR, self.parent.download_file)
+                                fil = f'{self.oe.DOWNLOAD_DIR}/{self.parent.download_file}'
                                 if 'image' in self.parent.download_type:
-                                    xbmc.executebuiltin('showpicture(%s)' % fil)
+                                    xbmc.executebuiltin(f'showpicture({fil})')
                                 else:
                                     xbmc.Player().play(fil)
                             del self.parent.download_type
@@ -892,7 +892,7 @@ class bluetooth:
                         transferred = int(interface['Transferred'] / 1024)
                         speed = transferred / (time.time() - self.parent.download_start)
                         percent = int(round(100 / self.parent.download_size * (interface['Transferred'] / 1024), 0))
-                        message = '%s: %s\n%s: %d KB/s' % (self.oe._(32181), self.parent.download_file, self.oe._(32382), speed)
+                        message = f'{self.oe._(32181)}: {self.parent.download_file}\n{self.oe._(32382)}: {speed} KB/s'
                         self.parent.download.update(percent, message)
                     if self.parent.download.iscanceled():
                         obj = self.oe.dbusSystemBus.get_object('org.bluez.obex', self.parent.download_path)
@@ -935,7 +935,7 @@ class bluetoothAgent(dbus.service.Object):
             self.oe.dbg_log('bluetooth::btAgent::AuthorizeService::uuid=', repr(uuid), self.oe.LOGDEBUG)
             self.oe.input_request = True
             xbmcDialog = xbmcgui.Dialog()
-            answer = xbmcDialog.yesno('Bluetooth', 'Authorize service %s?' % uuid)
+            answer = xbmcDialog.yesno('Bluetooth', f'Authorize service {uuid}?')
             self.oe.dbg_log('bluetooth::btAgent::AuthorizeService::answer=', repr(answer), self.oe.LOGDEBUG)
             self.busy()
             self.oe.dbg_log('bluetooth::btAgent::AuthorizeService', 'exit_function', self.oe.LOGDEBUG)
@@ -1002,7 +1002,7 @@ class bluetoothAgent(dbus.service.Object):
                 self.parent.close_pinkey_window()
             self.parent.open_pinkey_window(runtime=30)
             self.parent.pinkey_window.device = device
-            self.parent.pinkey_window.set_label1('PIN code: %s' % (pincode))
+            self.parent.pinkey_window.set_label1(f'PIN code: {pincode}')
             self.oe.dbg_log('bluetooth::btAgent::DisplayPinCode', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.dbg_log('bluetooth::btAgent::DisplayPinCode', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
@@ -1015,7 +1015,7 @@ class bluetoothAgent(dbus.service.Object):
             self.oe.dbg_log('bluetooth::btAgent::RequestConfirmation::passkey=', repr(passkey), self.oe.LOGDEBUG)
             self.oe.input_request = True
             xbmcDialog = xbmcgui.Dialog()
-            answer = xbmcDialog.yesno('Bluetooth', 'Confirm passkey %06u' % passkey)
+            answer = xbmcDialog.yesno('Bluetooth', f'Confirm passkey {passkey}')
             self.oe.dbg_log('bluetooth::btAgent::RequestConfirmation::answer=', repr(answer), self.oe.LOGDEBUG)
             self.busy()
             self.oe.dbg_log('bluetooth::btAgent::RequestConfirmation', 'exit_function', self.oe.LOGDEBUG)
@@ -1081,7 +1081,7 @@ class obexAgent(dbus.service.Object):
             properties = transfer.GetAll('org.bluez.obex.Transfer1')
             self.oe.input_request = True
             xbmcDialog = xbmcgui.Dialog()
-            answer = xbmcDialog.yesno('Bluetooth', "%s\n\n%s" % (self.oe._(32381), properties['Name']))
+            answer = xbmcDialog.yesno('Bluetooth', f"{self.oe._(32381)}\n\n{properties['Name']}")
             self.oe.dbg_log('bluetooth::obexAgent::AuthorizePush::answer=', repr(answer), self.oe.LOGDEBUG)
             self.busy()
             if answer != 1:

--- a/src/resources/lib/modules/services.py
+++ b/src/resources/lib/modules/services.py
@@ -282,7 +282,7 @@ class services:
             self.oe = oeMain
             oeMain.dbg_log('services::__init__', 'exit_function', oeMain.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('services::__init__', 'ERROR: (%s)' % repr(e))
+            self.oe.dbg_log('services::__init__', f'ERROR: ({rep(e)})')
 
     def start_service(self):
         try:
@@ -295,7 +295,7 @@ class services:
             self.init_bluetooth(service=1)
             self.oe.dbg_log('services::start_service', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('services::start_service', 'ERROR: (%s)' % repr(e))
+            self.oe.dbg_log('services::start_service', f'ERROR: ({repr(e)})')
 
     def stop_service(self):
         try:
@@ -310,7 +310,7 @@ class services:
             self.load_values()
             self.oe.dbg_log('services::do_init', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('services::do_init', 'ERROR: (%s)' % repr(e))
+            self.oe.dbg_log('services::do_init', f'ERROR: ({repr(e)})')
 
     def set_value(self, listItem):
         try:
@@ -326,7 +326,7 @@ class services:
             self.oe.winOeMain.build_menu(self.struct)
             self.oe.dbg_log('services::load_menu', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('services::load_menu', 'ERROR: (%s)' % repr(e))
+            self.oe.dbg_log('services::load_menu', f'ERROR: ({repr(e)})')
 
     def load_values(self):
         try:
@@ -407,7 +407,7 @@ class services:
 
             self.oe.dbg_log('services::load_values', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('services::load_values', 'ERROR: (%s)' % repr(e))
+            self.oe.dbg_log('services::load_values', f'ERROR: ({repr(e)})')
 
     def initialize_samba(self, **kwargs):
         try:
@@ -430,13 +430,13 @@ class services:
                     val_autoshare = 'true'
                 else:
                     val_autoshare = 'false'
-                options['SAMBA_WORKGROUP'] = '"%s"' % self.struct['samba']['settings']['samba_workgroup']['value']
-                options['SAMBA_SECURE'] = '"%s"' % val_secure
-                options['SAMBA_AUTOSHARE'] = '"%s"' % val_autoshare
-                options['SAMBA_MINPROTOCOL'] = '"%s"' % self.struct['samba']['settings']['samba_minprotocol']['value']
-                options['SAMBA_MAXPROTOCOL'] = '"%s"' % self.struct['samba']['settings']['samba_maxprotocol']['value']
-                options['SAMBA_USERNAME'] = '"%s"' % self.struct['samba']['settings']['samba_username']['value']
-                options['SAMBA_PASSWORD'] = '"%s"' % self.struct['samba']['settings']['samba_password']['value']
+                options['SAMBA_WORKGROUP'] = f"{self.struct['samba']['settings']['samba_workgroup']['value']}"
+                options['SAMBA_SECURE'] = f"{val_secure}"
+                options['SAMBA_AUTOSHARE'] = f"{val_autoshare}"
+                options['SAMBA_MINPROTOCOL'] = f"{self.struct['samba']['settings']['samba_minprotocol']['value']}"
+                options['SAMBA_MAXPROTOCOL'] = f"{self.struct['samba']['settings']['samba_maxprotocol']['value']}"
+                options['SAMBA_USERNAME'] = f"{self.struct['samba']['settings']['samba_username']['value']}"
+                options['SAMBA_PASSWORD'] = f"{self.struct['samba']['settings']['samba_password']['value']}"
             else:
                 state = 0
                 self.struct['samba']['settings']['samba_username']['hidden'] = True
@@ -446,7 +446,7 @@ class services:
             self.oe.dbg_log('services::initialize_samba', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.set_busy(0)
-            self.oe.dbg_log('services::initialize_samba', 'ERROR: (%s)' % repr(e), self.oe.LOGERROR)
+            self.oe.dbg_log('services::initialize_samba', f'ERROR: (%{repr(e)})', self.oe.LOGERROR)
 
     def initialize_ssh(self, **kwargs):
         try:
@@ -459,11 +459,11 @@ class services:
             if self.struct['ssh']['settings']['ssh_autostart']['value'] == '1':
                 if self.struct['ssh']['settings']['ssh_secure']['value'] == '1':
                     val = 'true'
-                    options['SSH_ARGS'] = '"%s"' % self.OPT_SSH_NOPASSWD
+                    options['SSH_ARGS'] = f"{self.OPT_SSH_NOPASSWD}"
                 else:
                     val = 'false'
                     options['SSH_ARGS'] = '""'
-                options['SSHD_DISABLE_PW_AUTH'] = '"%s"' % val
+                options['SSHD_DISABLE_PW_AUTH'] = f"{val}"
             else:
                 state = 0
             self.oe.set_service('sshd', options, state)
@@ -471,7 +471,7 @@ class services:
             self.oe.dbg_log('services::initialize_ssh', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.set_busy(0)
-            self.oe.dbg_log('services::initialize_ssh', 'ERROR: (%s)' % repr(e), self.oe.LOGERROR)
+            self.oe.dbg_log('services::initialize_ssh', f'ERROR: ({repr(e)})', self.oe.LOGERROR)
 
     def initialize_avahi(self, **kwargs):
         try:
@@ -488,7 +488,7 @@ class services:
             self.oe.dbg_log('services::initialize_avahi', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.set_busy(0)
-            self.oe.dbg_log('services::initialize_avahi', 'ERROR: (%s)' % repr(e), self.oe.LOGERROR)
+            self.oe.dbg_log('services::initialize_avahi', f'ERROR: ({repr(e)})', self.oe.LOGERROR)
 
     def initialize_cron(self, **kwargs):
         try:
@@ -505,7 +505,7 @@ class services:
             self.oe.dbg_log('services::initialize_cron', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.set_busy(0)
-            self.oe.dbg_log('services::initialize_cron', 'ERROR: (%s)' % repr(e), self.oe.LOGERROR)
+            self.oe.dbg_log('services::initialize_cron', f'ERROR: ({repr(e)})', self.oe.LOGERROR)
 
     def init_bluetooth(self, **kwargs):
         try:
@@ -540,7 +540,7 @@ class services:
             state = 1
             options = {}
             if self.struct['bluez']['settings']['obex_enabled']['value'] == '1':
-                options['OBEXD_ROOT'] = '"%s"' % self.struct['bluez']['settings']['obex_root']['value']
+                options['OBEXD_ROOT'] = f"{self.struct['bluez']['settings']['obex_root']['value']}"
             else:
                 state = 0
             self.oe.set_service('obexd', options, state)
@@ -568,7 +568,7 @@ class services:
             self.oe.dbg_log('services::exit', 'enter_function', self.oe.LOGDEBUG)
             self.oe.dbg_log('services::exit', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('services::exit', 'ERROR: (%s)' % repr(e), self.oe.LOGERROR)
+            self.oe.dbg_log('services::exit', f'ERROR: ({repr(e)})', self.oe.LOGERROR)
 
     def do_wizard(self):
         try:
@@ -587,7 +587,7 @@ class services:
             self.set_wizard_buttons()
             self.oe.dbg_log('services::do_wizard', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('services::do_wizard', 'ERROR: (%s)' % repr(e))
+            self.oe.dbg_log('services::do_wizard', f'ERROR: ({repr(e)})')
 
     def set_wizard_buttons(self):
         try:
@@ -603,7 +603,7 @@ class services:
                     self.oe.winOeMain.set_wizard_radiobutton_2(self.oe._(32200), self, 'wizard_set_samba')
             self.oe.dbg_log('services::set_wizard_buttons', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('services::set_wizard_buttons', 'ERROR: (%s)' % repr(e))
+            self.oe.dbg_log('services::set_wizard_buttons', f'ERROR: ({repr(e)})')
 
     def wizard_set_ssh(self):
         try:
@@ -627,7 +627,7 @@ class services:
             self.set_wizard_buttons()
             self.oe.dbg_log('services::wizard_set_ssh', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('services::wizard_set_ssh', 'ERROR: (%s)' % repr(e))
+            self.oe.dbg_log('services::wizard_set_ssh', f'ERROR: ({repr(e)})')
 
     def wizard_set_samba(self):
         try:
@@ -641,7 +641,7 @@ class services:
             self.set_wizard_buttons()
             self.oe.dbg_log('services::wizard_set_samba', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('services::wizard_set_samba', 'ERROR: (%s)' % repr(e))
+            self.oe.dbg_log('services::wizard_set_samba', f'ERROR: ({repr(e)})')
 
     def wizard_sshpasswd(self):
         SSHresult = False
@@ -667,9 +667,9 @@ class services:
                 else:
                     ssh = subprocess.Popen(["passwd"], shell=False, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, bufsize=0)
                     readout1 = ssh.stdout.readline()
-                    ssh.stdin.write('%s\n' % newpwd)
+                    ssh.stdin.write(f'{newpwd}\n')
                     readout2 = ssh.stdout.readline()
-                    ssh.stdin.write('%s\n' % newpwd)
+                    ssh.stdin.write(f'{newpwd}\n')
                     readout3 = ssh.stdout.readline()
                 if "Bad password" in readout3:
                     xbmcDialog.ok(self.oe._(32220), self.oe._(32221))

--- a/src/resources/lib/modules/system.py
+++ b/src/resources/lib/modules/system.py
@@ -208,7 +208,7 @@ class system:
             self.arrVariants = {}
             self.oe.dbg_log('system::__init__', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('system::__init__', 'ERROR: (' + repr(e) + ')')
+            self.oe.dbg_log('system::__init__', f'ERROR: ({repr(e)})')
 
     def start_service(self):
         try:
@@ -221,7 +221,7 @@ class system:
             del self.is_service
             self.oe.dbg_log('system::start_service', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('system::start_service', 'ERROR: (' + repr(e) + ')')
+            self.oe.dbg_log('system::start_service', f'ERROR: ({repr(e)})')
 
     def stop_service(self):
         try:
@@ -230,14 +230,14 @@ class system:
                 self.update_thread.stop()
             self.oe.dbg_log('system::stop_service', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('system::stop_service', 'ERROR: (' + repr(e) + ')')
+            self.oe.dbg_log('system::stop_service', f'ERROR: ({repr(e)})')
 
     def do_init(self):
         try:
             self.oe.dbg_log('system::do_init', 'enter_function', self.oe.LOGDEBUG)
             self.oe.dbg_log('system::do_init', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('system::do_init', 'ERROR: (' + repr(e) + ')')
+            self.oe.dbg_log('system::do_init', f'ERROR: ({repr(e)})')
 
     def exit(self):
         self.oe.dbg_log('system::exit', 'enter_function', self.oe.LOGDEBUG)
@@ -296,7 +296,7 @@ class system:
             self.struct['pinlock']['settings']['pinlock_enable']['value'] = '1' if self.oe.PIN.isEnabled() else '0'
 
         except Exception as e:
-            self.oe.dbg_log('system::load_values', 'ERROR: (' + repr(e) + ')')
+            self.oe.dbg_log('system::load_values', f'ERROR: ({repr(e)})')
 
     def load_menu(self, focusItem):
         try:
@@ -304,7 +304,7 @@ class system:
             self.oe.winOeMain.build_menu(self.struct)
             self.oe.dbg_log('system::load_menu', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('system::load_menu', 'ERROR: (' + repr(e) + ')')
+            self.oe.dbg_log('system::load_menu', f'ERROR: ({repr(e)})')
 
     def set_value(self, listItem):
         try:
@@ -313,7 +313,7 @@ class system:
             self.oe.write_setting('system', listItem.getProperty('entry'), str(listItem.getProperty('value')))
             self.oe.dbg_log('system::set_value', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('system::set_value', 'ERROR: (' + repr(e) + ')')
+            self.oe.dbg_log('system::set_value', f'ERROR: ({repr(e)})')
 
     def set_keyboard_layout(self, listItem=None):
         try:
@@ -337,11 +337,10 @@ class system:
                 if not os.path.exists(os.path.dirname(self.UDEV_KEYBOARD_INFO)):
                     os.makedirs(os.path.dirname(self.UDEV_KEYBOARD_INFO))
                 config_file = open(self.UDEV_KEYBOARD_INFO, 'w')
-                config_file.write('XKBMODEL="' + self.struct['keyboard']['settings']['KeyboardType']['value'] + '"\n')
-                config_file.write('XKBVARIANT="%s,%s"\n' % (self.struct['keyboard']['settings']['KeyboardVariant1']['value'],
-                                  self.struct['keyboard']['settings']['KeyboardVariant2']['value']))
-                config_file.write('XKBLAYOUT="' + self.struct['keyboard']['settings']['KeyboardLayout1']['value'] + ',' + self.struct['keyboard'
-                                  ]['settings']['KeyboardLayout2']['value'] + '"\n')
+                config_file.write(f"XKBMODEL=\"{self.struct['keyboard']['settings']['KeyboardType']['value']}\"\n")
+                config_file.write(f"XKBVARIANT=\"{self.struct['keyboard']['settings']['KeyboardVariant1']['value']}, \
+                                                 {self.struct['keyboard']['settings']['KeyboardVariant2']['value']}\"\n")
+                config_file.write(f"XKBLAYOUT=\"{self.struct['keyboard']['settings']['KeyboardLayout1']['value']}, {self.struct['keyboard']['settings']['KeyboardLayout2']['value']}\"\n")
                 config_file.write('XKBOPTIONS="grp:alt_shift_toggle"\n')
                 config_file.close()
                 parameters = [
@@ -357,12 +356,12 @@ class system:
             elif self.nox_keyboard_layouts == True:
                 self.oe.dbg_log('system::set_keyboard_layout', str(self.struct['keyboard']['settings']['KeyboardLayout1']['value']), self.oe.LOGINFO)
                 parameter = self.struct['keyboard']['settings']['KeyboardLayout1']['value']
-                command = 'loadkmap < `ls -1 %s/*/%s.bmap`' % (self.NOX_KEYBOARD_INFO, parameter)
+                command = f'loadkmap < `ls -1 {self.NOX_KEYBOARD_INFO}/*/{parameter}.bmap`'
                 self.oe.dbg_log('system::set_keyboard_layout', command, self.oe.LOGINFO)
                 self.oe.execute(command)
             self.oe.dbg_log('system::set_keyboard_layout', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('system::set_keyboard_layout', 'ERROR: (' + repr(e) + ')')
+            self.oe.dbg_log('system::set_keyboard_layout', f'ERROR: ({repr(e)})')
 
     def set_hostname(self, listItem=None):
         try:
@@ -376,17 +375,17 @@ class system:
                 hostname = open('/proc/sys/kernel/hostname', 'w')
                 hostname.write(self.struct['ident']['settings']['hostname']['value'])
                 hostname.close()
-                hostname = open('%s/hostname' % self.oe.CONFIG_CACHE, 'w')
+                hostname = open(f'{self.oe.CONFIG_CACHE}/hostname', 'w')
                 hostname.write(self.struct['ident']['settings']['hostname']['value'])
                 hostname.close()
                 hosts = open('/etc/hosts', 'w')
-                user_hosts_file = os.environ['HOME'] + '/.config/hosts.conf'
+                user_hosts_file = f"{os.environ['HOME']}/.config/hosts.conf"
                 if os.path.isfile(user_hosts_file):
                     user_hosts = open(user_hosts_file, 'r')
                     hosts.write(user_hosts.read())
                     user_hosts.close()
-                hosts.write('127.0.0.1\tlocalhost %s\n' % self.struct['ident']['settings']['hostname']['value'])
-                hosts.write('::1\tlocalhost ip6-localhost ip6-loopback %s\n' % self.struct['ident']['settings']['hostname']['value'])
+                hosts.write(f"127.0.0.1\tlocalhost {self.struct['ident']['settings']['hostname']['value']}\n")
+                hosts.write(f"::1\tlocalhost ip6-localhost ip6-loopback {self.struct['ident']['settings']['hostname']['value']}\n")
                 hosts.close()
             else:
                 self.oe.dbg_log('system::set_hostname', 'is empty', self.oe.LOGINFO)
@@ -394,7 +393,7 @@ class system:
             self.oe.dbg_log('system::set_hostname', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.set_busy(0)
-            self.oe.dbg_log('system::set_hostname', 'ERROR: (' + repr(e) + ')')
+            self.oe.dbg_log('system::set_hostname', f'ERROR: ({repr(e)})')
 
     def get_keyboard_layouts(self):
         try:
@@ -403,7 +402,7 @@ class system:
             arrVariants = {}
             arrTypes = []
             if os.path.exists(self.NOX_KEYBOARD_INFO):
-                for layout in glob.glob(self.NOX_KEYBOARD_INFO + '/*/*.bmap'):
+                for layout in glob.glob(f'{self.NOX_KEYBOARD_INFO}/*/*.bmap'):
                     if os.path.isfile(layout):
                         arrLayouts.append(layout.split('/')[-1].split('.')[0])
                 arrLayouts.sort()
@@ -461,16 +460,16 @@ class system:
                 arrVariants,
                 )
         except Exception as e:
-            self.oe.dbg_log('system::get_keyboard_layouts', 'ERROR: (' + repr(e) + ')')
+            self.oe.dbg_log('system::get_keyboard_layouts', f'ERROR: ({repr(e)})')
 
 
     def set_hw_clock(self):
         try:
             self.oe.dbg_log('system::set_hw_clock', 'enter_function', self.oe.LOGDEBUG)
-            self.oe.execute('%s 2>/dev/null' % self.SET_CLOCK_CMD)
+            self.oe.execute(f'{self.SET_CLOCK_CMD} 2>/dev/null')
             self.oe.dbg_log('system::set_hw_clock', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('system::set_hw_clock', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
+            self.oe.dbg_log('system::set_hw_clock', f'ERROR: ({repr(e)})', self.oe.LOGERROR)
 
     def reset_xbmc(self, listItem=None):
         try:
@@ -485,7 +484,7 @@ class system:
             self.oe.dbg_log('system::reset_xbmc', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.set_busy(0)
-            self.oe.dbg_log('system::reset_xbmc', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
+            self.oe.dbg_log('system::reset_xbmc', f'ERROR: ({repr(e)})', self.oe.LOGERROR)
 
     def reset_oe(self, listItem=None):
         try:
@@ -500,13 +499,13 @@ class system:
             self.oe.dbg_log('system::reset_oe', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.set_busy(0)
-            self.oe.dbg_log('system::reset_oe', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
+            self.oe.dbg_log('system::reset_oe', f'ERROR: ({repr(e)})', self.oe.LOGERROR)
 
     def ask_sure_reset(self, part):
         try:
             self.oe.dbg_log('system::ask_sure_reset', 'enter_function', self.oe.LOGDEBUG)
             xbmcDialog = xbmcgui.Dialog()
-            answer = xbmcDialog.yesno(part + ' Reset', '%s\n\n%s' % (self.oe._(32326), self.oe._(32328)))
+            answer = xbmcDialog.yesno(part + ' Reset', f'{self.oe._(32326)}\n\n{self.oe._(32328)}')
             if answer == 1:
                 if self.oe.reboot_counter(30, self.oe._(32323)) == 1:
                     return 1
@@ -515,7 +514,7 @@ class system:
             self.oe.dbg_log('system::ask_sure_reset', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
             self.oe.set_busy(0)
-            self.oe.dbg_log('system::ask_sure_reset', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
+            self.oe.dbg_log('system::ask_sure_reset', f'ERROR: ({repr(e)})', self.oe.LOGERROR)
 
     def do_backup(self, listItem=None):
         try:
@@ -548,7 +547,7 @@ class system:
                     if self.total_backup_size > free_space:
                         txt = self.oe.split_dialog_text(self.oe._(32379))
                         xbmcDialog = xbmcgui.Dialog()
-                        answer = xbmcDialog.ok('Backup', '%s\n%s\n%s' % (txt[0], txt[1], txt[2]))
+                        answer = xbmcDialog.ok('Backup', f'{txt[0]}\n{txt[1]}\n{txt[2]}')
                         return 0
                 except:
                     pass
@@ -568,7 +567,7 @@ class system:
 
         except Exception as e:
             self.backup_dlg.close()
-            self.oe.dbg_log('system::do_backup', 'ERROR: (' + repr(e) + ')')
+            self.oe.dbg_log('system::do_backup', f'ERROR: ({repr(e)})')
 
     def do_restore(self, listItem=None):
         try:
@@ -601,15 +600,15 @@ class system:
                 if self.oe.copy_file(restore_file_path, self.RESTORE_DIR + restore_file_name) != None:
                     copy_success = 1
                 else:
-                    self.oe.execute('rm -rf %s' % self.RESTORE_DIR)
+                    self.oe.execute(f'rm -rf {self.RESTORE_DIR}')
             else:
                 txt = self.oe.split_dialog_text(self.oe._(32379))
                 xbmcDialog = xbmcgui.Dialog()
-                answer = xbmcDialog.ok('Restore', '%s\n%s\n%s' % (txt[0], txt[1], txt[2]))
+                answer = xbmcDialog.ok('Restore', f'{txt[0]}\n{txt[1]}\n{txt[2]}')
             if copy_success == 1:
                 txt = self.oe.split_dialog_text(self.oe._(32380))
                 xbmcDialog = xbmcgui.Dialog()
-                answer = xbmcDialog.yesno('Restore', '%s\n%s\n%s' % (txt[0], txt[1], txt[2]))
+                answer = xbmcDialog.yesno('Restore', f'{txt[0]}\n{txt[1]}\n{txt[2]}')
                 if answer == 1:
                     if self.oe.reboot_counter(10, self.oe._(32371)) == 1:
                         self.oe.winOeMain.close()
@@ -617,10 +616,10 @@ class system:
                         xbmc.executebuiltin('Reboot')
                 else:
                     self.oe.dbg_log('system::do_restore', 'User Abort!', self.oe.LOGDEBUG)
-                    self.oe.execute('rm -rf %s' % self.RESTORE_DIR)
+                    self.oe.execute(f'rm -rf {self.RESTORE_DIR}')
             self.oe.dbg_log('system::do_restore', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('system::do_restore', 'ERROR: (' + repr(e) + ')')
+            self.oe.dbg_log('system::do_restore', f'ERROR: ({repr(e)})')
 
     def do_send_system_logs(self, listItem=None):
         try:
@@ -628,7 +627,7 @@ class system:
             self.do_send_logs('/usr/bin/pastekodi')
             self.oe.dbg_log('system::do_send_system_logs', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('system::do_do_send_system_logs', 'ERROR: (' + repr(e) + ')')
+            self.oe.dbg_log('system::do_do_send_system_logs', f'ERROR: ({repr(e)})')
 
     def do_send_crash_logs(self, listItem=None):
         try:
@@ -636,7 +635,7 @@ class system:
             self.do_send_logs('/usr/bin/pastecrash')
             self.oe.dbg_log('system::do_send_crash_logs', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('system::do_do_send_crash_logs', 'ERROR: (' + repr(e) + ')')
+            self.oe.dbg_log('system::do_do_send_crash_logs', f'ERROR: ({repr(e)})')
 
     def do_send_logs(self, log_cmd):
         try:
@@ -653,13 +652,13 @@ class system:
                 link = result.find('http')
                 if link != -1:
                     self.oe.dbg_log('system::do_send_logs', result[link:], self.oe.LOGWARNING)
-                    done_dlg.ok('Paste complete', 'Log files pasted to %s' % result[link:])
+                    done_dlg.ok('Paste complete', f'Log files pasted to {result[link:]}')
                 else:
                     done_dlg.ok('Failed paste', 'Failed to paste log files, try again')
 
             self.oe.dbg_log('system::do_send_logs', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('system::do_do_send_logs', 'ERROR: (' + repr(e) + ')')
+            self.oe.dbg_log('system::do_do_send_logs', f'ERROR: ({repr(e)})')
 
     def tar_add_folder(self, tar, folder):
         try:
@@ -687,10 +686,10 @@ class system:
                     tar.add(itempath)
                     if hasattr(self, 'backup_dlg'):
                         progress = round(1.0 * self.done_backup_size / self.total_backup_size * 100)
-                        self.backup_dlg.update(int(progress), '%s\n%s' % (folder, item))
+                        self.backup_dlg.update(int(progress), f'{folder}\n{item}')
         except Exception as e:
             self.backup_dlg.close()
-            self.oe.dbg_log('system::tar_add_folder', 'ERROR: (' + repr(e) + ')')
+            self.oe.dbg_log('system::tar_add_folder', f'ERROR: ({repr(e)})')
 
     def get_folder_size(self, folder):
         for item in os.listdir(folder):
@@ -720,7 +719,7 @@ class system:
 
             self.oe.dbg_log('system::init_pinlock', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('system::init_pinlock', 'ERROR: (%s)' % repr(e), self.oe.LOGERROR)
+            self.oe.dbg_log('system::init_pinlock', f'ERROR: ({repr(e)})', self.oe.LOGERROR)
 
     def set_pinlock(self, listItem=None):
         try:
@@ -732,7 +731,7 @@ class system:
                    xbmcDialog.ok(self.oe._(32228), self.oe._(32229))
                else:
                    self.oe.PIN.set(newpin)
-                   xbmcDialog.ok(self.oe._(32230), '%s\n\n%s' % (self.oe._(32231), newpin))
+                   xbmcDialog.ok(self.oe._(32230), f'{self.oe._(32231)}\n\n{newpin}')
             else:
                 xbmcDialog.ok(self.oe._(32232), self.oe._(32229))
             if self.oe.PIN.isSet() == False:
@@ -740,7 +739,7 @@ class system:
                 self.oe.PIN.disable()
             self.oe.dbg_log('system::set_pinlock', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('system::set_pinlock', 'ERROR: (%s)' % repr(e), self.oe.LOGERROR)
+            self.oe.dbg_log('system::set_pinlock', f'ERROR: ({repr(e)})', self.oe.LOGERROR)
 
     def do_wizard(self):
         try:
@@ -751,7 +750,7 @@ class system:
             self.oe.winOeMain.set_wizard_button_1(self.struct['ident']['settings']['hostname']['value'], self, 'wizard_set_hostname')
             self.oe.dbg_log('system::do_wizard', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('system::do_wizard', 'ERROR: (' + repr(e) + ')')
+            self.oe.dbg_log('system::do_wizard', f'ERROR: ({repr(e)})')
 
     def wizard_set_hostname(self):
         try:
@@ -776,4 +775,4 @@ class system:
                 self.oe.write_setting('system', 'hostname', self.struct['ident']['settings']['hostname']['value'])
             self.oe.dbg_log('system::wizard_set_hostname', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('system::wizard_set_hostname', 'ERROR: (' + repr(e) + ')')
+            self.oe.dbg_log('system::wizard_set_hostname', f'ERROR: ({repr(e)})')

--- a/src/resources/lib/modules/updates.py
+++ b/src/resources/lib/modules/updates.py
@@ -173,7 +173,7 @@ class updates:
             self.arrVariants = {}
             self.oe.dbg_log('updates::__init__', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('updates::__init__', 'ERROR: (' + repr(e) + ')')
+            self.oe.dbg_log('updates::__init__', f'ERROR: ({repr(e)})')
 
     def start_service(self):
         try:
@@ -184,7 +184,7 @@ class updates:
             del self.is_service
             self.oe.dbg_log('updates::start_service', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('updates::start_service', 'ERROR: (' + repr(e) + ')')
+            self.oe.dbg_log('updates::start_service', f'ERROR: ({repr(e)})')
 
     def stop_service(self):
         try:
@@ -193,14 +193,14 @@ class updates:
                 self.update_thread.stop()
             self.oe.dbg_log('updates::stop_service', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('updates::stop_service', 'ERROR: (' + repr(e) + ')')
+            self.oe.dbg_log('updates::stop_service', f'ERROR: ({repr(e)})')
 
     def do_init(self):
         try:
             self.oe.dbg_log('updates::do_init', 'enter_function', self.oe.LOGDEBUG)
             self.oe.dbg_log('updates::do_init', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('updates::do_init', 'ERROR: (' + repr(e) + ')')
+            self.oe.dbg_log('updates::do_init', f'ERROR: ({repr(e)})')
 
     def exit(self):
         self.oe.dbg_log('updates::exit', 'enter_function', self.oe.LOGDEBUG)
@@ -227,19 +227,19 @@ class updates:
         gpu_driver = ""
 
         gpu_card = self.get_gpu_card()
-        self.oe.dbg_log('updates::get_hardware_flags_x86_64', 'Using card: %s' % gpu_card, self.oe.LOGDEBUG)
+        self.oe.dbg_log('updates::get_hardware_flags_x86_64', f'Using card: {gpu_card}', self.oe.LOGDEBUG)
 
-        gpu_path = self.oe.execute('/usr/bin/udevadm info --name=/dev/dri/%s --query path 2>/dev/null' % gpu_card, get_result=1).replace('\n','')
-        self.oe.dbg_log('updates::get_hardware_flags_x86_64', 'gpu path: %s' % gpu_path, self.oe.LOGDEBUG)
+        gpu_path = self.oe.execute(f'/usr/bin/udevadm info --name=/dev/dri/{gpu_card} --query path 2>/dev/null', get_result=1).replace('\n','')
+        self.oe.dbg_log('updates::get_hardware_flags_x86_64', f'gpu path: {gpu_path}', self.oe.LOGDEBUG)
 
         if gpu_path:
             drv_path = os.path.dirname(os.path.dirname(gpu_path))
-            props = self.oe.execute('/usr/bin/udevadm info --path=%s --query=property 2>/dev/null' % drv_path, get_result=1)
+            props = self.oe.execute(f'/usr/bin/udevadm info --path={drv_path} --query=property 2>/dev/null', get_result=1)
 
             if props:
                 for key, value in [x.strip().split('=') for x in props.strip().split('\n')]:
                     gpu_props[key] = value
-            self.oe.dbg_log('updates::get_gpu_type', 'gpu props: %s' % gpu_props, self.oe.LOGDEBUG)
+            self.oe.dbg_log('updates::get_gpu_type', f'gpu props: {gpu_props}', self.oe.LOGDEBUG)
             gpu_driver = gpu_props.get("DRIVER", "")
 
         if not gpu_driver:
@@ -248,7 +248,7 @@ class updates:
         if gpu_driver == 'nvidia' and os.path.realpath('/var/lib/nvidia_drv.so').endswith('nvidia-legacy_drv.so'):
             gpu_driver = 'nvidia-legacy'
 
-        self.oe.dbg_log('updates::get_hardware_flags_x86_64', 'gpu driver: %s' % gpu_driver, self.oe.LOGDEBUG)
+        self.oe.dbg_log('updates::get_hardware_flags_x86_64', f'gpu driver: {gpu_driver}', self.oe.LOGDEBUG)
 
         return gpu_driver if gpu_driver else "unknown"
 
@@ -258,7 +258,7 @@ class updates:
         else:
             dtflag = "unknown"
 
-        self.oe.dbg_log('system::get_hardware_flags_dtflag', 'ARM board: %s' % dtflag, self.oe.LOGDEBUG)
+        self.oe.dbg_log('system::get_hardware_flags_dtflag', f'ARM board: {dtflag}', self.oe.LOGDEBUG)
 
         return dtflag
 
@@ -268,7 +268,7 @@ class updates:
         elif self.oe.PROJECT in ['Allwinner', 'Amlogic', 'NXP', 'Qualcomm', 'Rockchip', 'RPi', 'Samsung' ]:
             return self.get_hardware_flags_dtflag()
         else:
-            self.oe.dbg_log('updates::get_hardware_flags', 'Project is %s, no hardware flag available' % self.oe.PROJECT, self.oe.LOGDEBUG)
+            self.oe.dbg_log('updates::get_hardware_flags', f'Project is {self.oe.PROJECT}, no hardware flag available', self.oe.LOGDEBUG)
             return ""
 
     def load_values(self):
@@ -277,7 +277,7 @@ class updates:
 
             # Hardware flags
             self.hardware_flags = self.get_hardware_flags()
-            self.oe.dbg_log('system::load_values', 'loaded hardware_flag %s' % self.hardware_flags, self.oe.LOGDEBUG)
+            self.oe.dbg_log('system::load_values', f'loaded hardware_flag {self.hardware_flags}', self.oe.LOGDEBUG)
 
             # AutoUpdate
 
@@ -290,7 +290,7 @@ class updates:
             value = self.oe.read_setting('updates', 'UpdateNotify')
             if not value is None:
                 self.struct['update']['settings']['UpdateNotify']['value'] = value
-            if os.path.isfile('%s/SYSTEM' % self.LOCAL_UPDATE_DIR):
+            if os.path.isfile(f'{self.LOCAL_UPDATE_DIR}/SYSTEM'):
                 self.update_in_progress = True
 
             # Manual Update
@@ -324,16 +324,16 @@ class updates:
                     self.struct['rpieeprom']['hidden'] = 'true'
                 else:
                     self.struct['rpieeprom']['settings']['bootloader']['value'] = self.get_rpi_eeprom('BOOTLOADER')
-                    self.struct['rpieeprom']['settings']['bootloader']['name'] = '%s (%s)' % (self.oe._(32024), self.rpi_flashing_state['bootloader']['state'])
+                    self.struct['rpieeprom']['settings']['bootloader']['name'] = f"{self.oe._(32024)} ({self.rpi_flashing_state['bootloader']['state']})"
                     self.struct['rpieeprom']['settings']['vl805']['value'] = self.get_rpi_eeprom('VL805')
-                    self.struct['rpieeprom']['settings']['vl805']['name'] = '%s (%s)' % (self.oe._(32026), self.rpi_flashing_state['vl805']['state'])
+                    self.struct['rpieeprom']['settings']['vl805']['name'] = f"{self.oe._(32026)} ({self.rpi_flashing_state['vl805']['state']})"
             else:
                 self.struct['rpieeprom']['hidden'] = 'true'
 
             self.oe.dbg_log('updates::load_values', 'exit_function', self.oe.LOGDEBUG)
 
         except Exception as e:
-            self.oe.dbg_log('updates::load_values', 'ERROR: (' + repr(e) + ')')
+            self.oe.dbg_log('updates::load_values', f'ERROR: ({repr(e)})')
 
     def load_menu(self, focusItem):
         try:
@@ -341,7 +341,7 @@ class updates:
             self.oe.winOeMain.build_menu(self.struct)
             self.oe.dbg_log('updates::load_menu', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('updates::load_menu', 'ERROR: (' + repr(e) + ')')
+            self.oe.dbg_log('updates::load_menu', f'ERROR: ({repr(e)})')
 
     def set_value(self, listItem):
         try:
@@ -350,7 +350,7 @@ class updates:
             self.oe.write_setting('updates', listItem.getProperty('entry'), str(listItem.getProperty('value')))
             self.oe.dbg_log('updates::set_value', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('updates::set_value', 'ERROR: (' + repr(e) + ')')
+            self.oe.dbg_log('updates::set_value', f'ERROR: ({repr(e)})')
 
     def set_auto_update(self, listItem=None):
         try:
@@ -366,7 +366,7 @@ class updates:
                 self.oe.dbg_log('updates::set_auto_update', str(self.struct['update']['settings']['AutoUpdate']['value']), self.oe.LOGINFO)
             self.oe.dbg_log('updates::set_auto_update', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('updates::set_auto_update', 'ERROR: (' + repr(e) + ')')
+            self.oe.dbg_log('updates::set_auto_update', f'ERROR: ({repr(e)})')
 
     def set_channel(self, listItem=None):
         try:
@@ -376,7 +376,7 @@ class updates:
             self.struct['update']['settings']['Build']['values'] = self.get_available_builds()
             self.oe.dbg_log('updates::set_channel', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('updates::set_channel', 'ERROR: (' + repr(e) + ')')
+            self.oe.dbg_log('updates::set_channel', f'ERROR: ({repr(e)})')
 
     def set_custom_channel(self, listItem=None):
         try:
@@ -391,7 +391,7 @@ class updates:
             self.struct['update']['settings']['Build']['values'] = self.get_available_builds()
             self.oe.dbg_log('updates::set_custom_channel', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('updates::set_custom_channel', 'ERROR: (' + repr(e) + ')')
+            self.oe.dbg_log('updates::set_custom_channel', f'ERROR: ({repr(e)})')
 
     def custom_sort_train(self, a, b):
         a_items = a.split('-')
@@ -418,7 +418,7 @@ class updates:
             self.oe.dbg_log('updates::get_channels', 'exit_function', self.oe.LOGDEBUG)
             return sorted(list(set(channels)), key=cmp_to_key(self.custom_sort_train))
         except Exception as e:
-            self.oe.dbg_log('updates::get_channels', 'ERROR: (' + repr(e) + ')')
+            self.oe.dbg_log('updates::get_channels', f'ERROR: ({repr(e)})')
 
     def do_manual_update(self, listItem=None):
         try:
@@ -444,7 +444,7 @@ class updates:
                     version = self.oe.VERSION
                 if self.struct['update']['settings']['Build']['value'] != '':
                     self.update_file = self.update_json[self.struct['update']['settings']['Channel']['value']]['url'] + self.get_available_builds(self.struct['update']['settings']['Build']['value'])
-                    message = '%s: %s\n%s: %s\n%s' % (self.oe._(32188), version, self.oe._(32187), self.struct['update']['settings']['Build']['value'], self.oe._(32180))
+                    message = f"{self.oe._(32188)}: {version}\n{self.oe._(32187)}: {self.struct['update']['settings']['Build']['value']}\n{self.oe._(32180)}"
                     answer = xbmcDialog.yesno('LibreELEC Update', message)
                     xbmcDialog = None
                     del xbmcDialog
@@ -454,7 +454,7 @@ class updates:
                 self.struct['update']['settings']['Build']['value'] = ''
             self.oe.dbg_log('updates::do_manual_update', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('updates::do_manual_update', 'ERROR: (' + repr(e) + ')')
+            self.oe.dbg_log('updates::do_manual_update', f'ERROR: ({repr(e)})')
 
     def get_json(self, url=None):
         try:
@@ -471,7 +471,7 @@ class updates:
             self.oe.dbg_log('updates::get_json', 'exit_function', self.oe.LOGDEBUG)
             return update_json
         except Exception as e:
-            self.oe.dbg_log('updates::get_json', 'ERROR: (' + repr(e) + ')')
+            self.oe.dbg_log('updates::get_json', f'ERROR: ({repr(e)})')
 
     def build_json(self, notify_error=False):
         try:
@@ -489,13 +489,13 @@ class updates:
                                 update_json[channel] = custom_update_json[channel]
                         elif notify_error:
                             ok_window = xbmcgui.Dialog()
-                            answer = ok_window.ok(self.oe._(32191), 'Custom URL is not valid, or currently inaccessible.\n\n%s' % custom_url)
+                            answer = ok_window.ok(self.oe._(32191), f'Custom URL is not valid, or currently inaccessible.\n\n{custom_url}')
                             if not answer:
                                 return
             self.oe.dbg_log('updates::build_json', 'exit_function', self.oe.LOGDEBUG)
             return update_json
         except Exception as e:
-            self.oe.dbg_log('updates::build_json', 'ERROR: (' + repr(e) + ')')
+            self.oe.dbg_log('updates::build_json', f'ERROR: ({repr(e)})')
 
     def get_available_builds(self, shortname=None):
         try:
@@ -521,7 +521,7 @@ class updates:
             else:
                 return build
         except Exception as e:
-            self.oe.dbg_log('updates::get_available_builds', 'ERROR: (' + repr(e) + ')')
+            self.oe.dbg_log('updates::get_available_builds', f'ERROR: ({repr(e)})')
 
     def check_updates_v2(self, force=False):
         try:
@@ -537,20 +537,13 @@ class updates:
                 version = self.oe.BUILDER_VERSION
             else:
                 version = self.oe.VERSION
-            url = '%s?i=%s&d=%s&pa=%s&v=%s&f=%s' % (
-                self.UPDATE_REQUEST_URL,
-                self.oe.url_quote(systemid),
-                self.oe.url_quote(self.oe.DISTRIBUTION),
-                self.oe.url_quote(self.oe.ARCHITECTURE),
-                self.oe.url_quote(version),
-                self.oe.url_quote(self.hardware_flags),
-                )
+            url = f'{self.UPDATE_REQUEST_URL}?i={self.oe.url_quote(systemid)}&d={self.oe.url_quote(self.oe.DISTRIBUTION)}&pa={self.oe.url_quote(self.oe.ARCHITECTURE)}&v={self.oe.url_quote(version)}&f={self.oe.url_quote(self.hardware_flags)}'
             if self.oe.BUILDER_NAME:
-               url += '&b=%s' % self.oe.url_quote(self.oe.BUILDER_NAME)
+               url += f'&b={self.oe.url_quote(self.oe.BUILDER_NAME)}'
 
-            self.oe.dbg_log('updates::check_updates_v2', 'URL: %s' % url, self.oe.LOGDEBUG)
+            self.oe.dbg_log('updates::check_updates_v2', f'URL: {url}', self.oe.LOGDEBUG)
             update_json = self.oe.load_url(url)
-            self.oe.dbg_log('updates::check_updates_v2', 'RESULT: %s' % repr(update_json), self.oe.LOGDEBUG)
+            self.oe.dbg_log('updates::check_updates_v2', f'RESULT: {repr(update_json)}', self.oe.LOGDEBUG)
             if update_json != '':
                 update_json = json.loads(update_json)
                 self.last_update_check = time.time()
@@ -563,7 +556,7 @@ class updates:
                         self.do_autoupdate(None, True)
             self.oe.dbg_log('updates::check_updates_v2', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('updates::check_updates_v2', 'ERROR: (' + repr(e) + ')')
+            self.oe.dbg_log('updates::check_updates_v2', f'ERROR: ({repr(e)})')
 
     def do_autoupdate(self, listItem=None, silent=False):
         try:
@@ -587,7 +580,7 @@ class updates:
 
             self.oe.dbg_log('updates::do_autoupdate', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('updates::do_autoupdate', 'ERROR: (' + repr(e) + ')')
+            self.oe.dbg_log('updates::do_autoupdate', f'ERROR: ({repr(e)})')
 
     def get_rpi_flashing_state(self):
         try:
@@ -606,13 +599,13 @@ class updates:
                     }
 
             with tempfile.NamedTemporaryFile(mode='r', delete=True) as machine_out:
-                console_output = self.oe.execute('/usr/bin/.rpi-eeprom-update.real -j -m "%s"' % machine_out.name, get_result=1).split('\n')
+                console_output = self.oe.execute(f'/usr/bin/.rpi-eeprom-update.real -j -m "{machine_out.name}"', get_result=1).split('\n')
                 if os.path.getsize(machine_out.name) != 0:
                     state['incompatible'] = False
                     jdata = json.load(machine_out)
 
-            self.oe.dbg_log('updates::get_rpi_flashing_state', 'console output: %s' % console_output, self.oe.LOGDEBUG)
-            self.oe.dbg_log('updates::get_rpi_flashing_state', 'json values: %s' % jdata, self.oe.LOGDEBUG)
+            self.oe.dbg_log('updates::get_rpi_flashing_state', f'console output: {console_output}', self.oe.LOGDEBUG)
+            self.oe.dbg_log('updates::get_rpi_flashing_state', f'json values: {jdata}', self.oe.LOGDEBUG)
 
             if jdata['BOOTLOADER_CURRENT'] != 0:
                 state['bootloader']['current'] = datetime.datetime.utcfromtimestamp(jdata['BOOTLOADER_CURRENT']).strftime('%Y-%m-%d')
@@ -637,11 +630,11 @@ class updates:
                 else:
                     state['vl805']['state'] = self.oe._(32029) % state['vl805']['current']
 
-            self.oe.dbg_log('updates::get_rpi_flashing_state', 'state: %s' % state, self.oe.LOGDEBUG)
+            self.oe.dbg_log('updates::get_rpi_flashing_state', f'state: {state}', self.oe.LOGDEBUG)
             self.oe.dbg_log('updates::get_rpi_flashing_state', 'exit_function', self.oe.LOGDEBUG)
             return state
         except Exception as e:
-            self.oe.dbg_log('updates::get_rpi_flashing_state', 'ERROR: (' + repr(e) + ')')
+            self.oe.dbg_log('updates::get_rpi_flashing_state', f'ERROR: ({repr(e)})')
             return {'incompatible': True}
 
     def get_rpi_eeprom(self, device):
@@ -651,18 +644,18 @@ class updates:
             if os.path.exists(self.RPI_FLASHING_TRIGGER):
                 with open(self.RPI_FLASHING_TRIGGER, 'r') as trigger:
                     values = trigger.read().split('\n')
-            self.oe.dbg_log('updates::get_rpi_eeprom', 'values: %s' % values, self.oe.LOGDEBUG)
+            self.oe.dbg_log('updates::get_rpi_eeprom', f'values: {values}', self.oe.LOGDEBUG)
             self.oe.dbg_log('updates::get_rpi_eeprom', 'exit_function', self.oe.LOGDEBUG)
-            return 'true' if ('%s="yes"' % device) in values else 'false'
+            return 'true' if (f'{device}="yes"') in values else 'false'
         except Exception as e:
-            self.oe.dbg_log('updates::get_rpi_eeprom', 'ERROR: (' + repr(e) + ')')
+            self.oe.dbg_log('updates::get_rpi_eeprom', f'ERROR: ({repr(e)})')
 
     def set_rpi_eeprom(self):
         try:
             self.oe.dbg_log('updates::set_rpi_eeprom', 'enter_function', self.oe.LOGDEBUG)
             bootloader = (self.struct['rpieeprom']['settings']['bootloader']['value'] == 'true')
             vl805 = (self.struct['rpieeprom']['settings']['vl805']['value'] == 'true')
-            self.oe.dbg_log('updates::set_rpi_eeprom', 'states: [%s], [%s]' % (bootloader, vl805), self.oe.LOGDEBUG)
+            self.oe.dbg_log('updates::set_rpi_eeprom', f'states: [{bootloader}], [{vl805}]', self.oe.LOGDEBUG)
             if bootloader or vl805:
                 values = []
                 values.append('BOOTLOADER="%s"' % ('yes' if bootloader else 'no'))
@@ -675,33 +668,33 @@ class updates:
 
             self.oe.dbg_log('updates::set_rpi_eeprom', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('updates::set_rpi_eeprom', 'ERROR: (' + repr(e) + ')')
+            self.oe.dbg_log('updates::set_rpi_eeprom', f'ERROR: ({repr(e)})')
 
     def set_rpi_bootloader(self, listItem):
         try:
             self.oe.dbg_log('updates::set_rpi_bootloader', 'enter_function', self.oe.LOGDEBUG)
             value = 'false'
             if listItem.getProperty('value') == 'true':
-                if xbmcgui.Dialog().yesno('Update RPi Bootloader', '%s\n\n%s' % (self.oe._(32023), self.oe._(32326))):
+                if xbmcgui.Dialog().yesno('Update RPi Bootloader', f'{self.oe._(32023)}\n\n{self.oe._(32326)}'):
                     value = 'true'
             self.struct[listItem.getProperty('category')]['settings'][listItem.getProperty('entry')]['value'] = value
             self.set_rpi_eeprom()
             self.oe.dbg_log('updates::set_rpi_bootloader', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('updates::set_rpi_bootloader', 'ERROR: (' + repr(e) + ')')
+            self.oe.dbg_log('updates::set_rpi_bootloader', f'ERROR: ({repr(e)})')
 
     def set_rpi_vl805(self, listItem):
         try:
             self.oe.dbg_log('updates::set_rpi_vl805', 'enter_function', self.oe.LOGDEBUG)
             value = 'false'
             if listItem.getProperty('value') == 'true':
-                if xbmcgui.Dialog().yesno('Update RPi USB3 Firmware', '%s\n\n%s' % (self.oe._(32023), self.oe._(32326))):
+                if xbmcgui.Dialog().yesno('Update RPi USB3 Firmware', f'{self.oe._(32023)}\n\n{self.oe._(32326)}'):
                     value = 'true'
             self.struct[listItem.getProperty('category')]['settings'][listItem.getProperty('entry')]['value'] = value
             self.set_rpi_eeprom()
             self.oe.dbg_log('updates::set_rpi_vl805', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('updates::set_rpi_vl805', 'ERROR: (' + repr(e) + ')')
+            self.oe.dbg_log('updates::set_rpi_vl805', f'ERROR: ({repr(e)})')
 
 class updateThread(threading.Thread):
 
@@ -715,7 +708,7 @@ class updateThread(threading.Thread):
             self.oe.dbg_log('updates::updateThread', 'Started', self.oe.LOGINFO)
             self.oe.dbg_log('updates::updateThread::__init__', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('updates::updateThread::__init__', 'ERROR: (' + repr(e) + ')')
+            self.oe.dbg_log('updates::updateThread::__init__', f'ERROR: ({repr(e)})')
 
     def stop(self):
         try:
@@ -724,7 +717,7 @@ class updateThread(threading.Thread):
             self.wait_evt.set()
             self.oe.dbg_log('updates::updateThread::stop()', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('updates::updateThread::stop()', 'ERROR: (' + repr(e) + ')')
+            self.oe.dbg_log('updates::updateThread::stop()', f'ERROR: ({repr(e)})')
 
     def run(self):
         try:
@@ -741,4 +734,4 @@ class updateThread(threading.Thread):
             self.oe.dbg_log('updates::updateThread', 'Stopped', self.oe.LOGINFO)
             self.oe.dbg_log('updates::updateThread::run', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('updates::updateThread::run', 'ERROR: (' + repr(e) + ')')
+            self.oe.dbg_log('updates::updateThread::run', f'ERROR: ({repr(e)})')

--- a/src/resources/lib/modules/xdbus.py
+++ b/src/resources/lib/modules/xdbus.py
@@ -20,7 +20,7 @@ class xdbus:
             self.dbusSystemBus = self.oe.dbusSystemBus
             self.oe.dbg_log('xdbus::__init__', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('xdbus::__init__', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
+            self.oe.dbg_log('xdbus::__init__', f'ERROR: ({repr(e)})', self.oe.LOGERROR)
 
     def start_service(self):
         try:
@@ -29,7 +29,7 @@ class xdbus:
             self.dbusMonitor.start()
             self.oe.dbg_log('xdbus::start_service', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('xdbus::start_service', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
+            self.oe.dbg_log('xdbus::start_service', f'ERROR: ({repr(e)})', self.oe.LOGERROR)
 
     def stop_service(self):
         try:
@@ -39,7 +39,7 @@ class xdbus:
                 del self.dbusMonitor
             self.oe.dbg_log('xdbus::stop_service', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('xdbus::stop_service', 'ERROR: (' + repr(e) + ')')
+            self.oe.dbg_log('xdbus::stop_service', f'ERROR: ({repr(e)})')
 
     def exit(self):
         pass
@@ -51,7 +51,7 @@ class xdbus:
             self.start_service()
             self.oe.dbg_log('xdbus::restart', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('xdbus::restart', 'ERROR: (' + repr(e) + ')')
+            self.oe.dbg_log('xdbus::restart', f'ERROR: ({repr(e)})')
 
 
 class dbusMonitor(threading.Thread):
@@ -65,7 +65,7 @@ class dbusMonitor(threading.Thread):
             threading.Thread.__init__(self)
             self.oe.dbg_log('xdbus::dbusMonitor::__init__', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('xdbus::dbusMonitor::__init__', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
+            self.oe.dbg_log('xdbus::dbusMonitor::__init__', f'ERROR: ({repr(e)})', self.oe.LOGERROR)
 
     def run(self):
         try:
@@ -84,7 +84,7 @@ class dbusMonitor(threading.Thread):
                 pass
             self.oe.dbg_log('xdbus::dbusMonitor::run', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('xdbus::dbusMonitor::run', 'ERROR: (' + repr(e) + ')', self.oe.LOGERROR)
+            self.oe.dbg_log('xdbus::dbusMonitor::run', f'ERROR: ({repr(e)})', self.oe.LOGERROR)
 
     def stop(self):
         try:
@@ -95,4 +95,4 @@ class dbusMonitor(threading.Thread):
                 monitor = None
             self.oe.dbg_log('xdbus::dbusMonitor::stop_service', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('xdbus::dbusMonitor::stop_service', 'ERROR: (' + repr(e) + ')')
+            self.oe.dbg_log('xdbus::dbusMonitor::stop_service', f'ERROR: ({repr(e)})')

--- a/src/resources/lib/oeWindows.py
+++ b/src/resources/lib/oeWindows.py
@@ -95,7 +95,7 @@ class mainWindow(xbmcgui.WindowXMLDialog):
             self.oe.set_busy(0)
         except Exception as e:
             self.oe.set_busy(0)
-            self.oe.dbg_log('oeWindows.mainWindow::onInit', 'ERROR: (' + repr(e) + ')')
+            self.oe.dbg_log('oeWindows.mainWindow::onInit', f'ERROR: ({repr(e)})')
 
     def addMenuItem(self, strName, dictProperties):
         try:
@@ -104,7 +104,7 @@ class mainWindow(xbmcgui.WindowXMLDialog):
                 lstItem.setProperty(strProp, str(dictProperties[strProp]))
             self.getControl(self.guiMenList).addItem(lstItem)
         except Exception as e:
-            self.oe.dbg_log('oeWindows.mainWindow::addMenuItem(' + str(strName) + ')', 'ERROR: (' + repr(e) + ')')
+            self.oe.dbg_log(f'oeWindows.mainWindow::addMenuItem({str(strName)})', f'ERROR: ({repr(e)})')
 
     def addConfigItem(self, strName, dictProperties, strType):
         try:
@@ -114,7 +114,7 @@ class mainWindow(xbmcgui.WindowXMLDialog):
             self.getControl(int(strType)).addItem(lstItem)
             return lstItem
         except Exception as e:
-            self.oe.dbg_log('oeWindows.mainWindow::addConfigItem(' + strName + ')', 'ERROR: (' + repr(e) + ')')
+            self.oe.dbg_log(f'oeWindows.mainWindow::addConfigItem({strName})', f'ERROR: ({repr(e)})')
 
     def build_menu(self, struct, fltr=[], optional='0'):
         try:
@@ -168,7 +168,7 @@ class mainWindow(xbmcgui.WindowXMLDialog):
             for m_entry in m_menu:
                 self.addConfigItem(m_entry['name'], m_entry['properties'], m_entry['list'])
         except Exception as e:
-            self.oe.dbg_log('oeWindows.mainWindow::build_menu', 'ERROR: (' + repr(e) + ')')
+            self.oe.dbg_log('oeWindows.mainWindow::build_menu', f'ERROR: ({repr(e)})')
 
     def showButton(self, number, name, module, action, onup=None, onleft=None):
         try:
@@ -184,7 +184,7 @@ class mainWindow(xbmcgui.WindowXMLDialog):
             button.setVisible(True)
             self.oe.dbg_log('oeWindows::showButton', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('oeWindows.mainWindow::showButton(' + str(number) + ', ' + str(action) + ')', 'ERROR: (' + repr(e) + ')')
+            self.oe.dbg_log(f'oeWindows.mainWindow::showButton({str(number)}, {str(action)})', f'ERROR: ({repr(e)})')
 
     def onAction(self, action):
         try:
@@ -224,7 +224,7 @@ class mainWindow(xbmcgui.WindowXMLDialog):
             if focusId == self.guiMenList:
                 self.setFocusId(focusId)
         except Exception as e:
-            self.oe.dbg_log('oeWindows.mainWindow::onAction(' + str(action) + ')', 'ERROR: (' + repr(e) + ')')
+            self.oe.dbg_log(f'oeWindows.mainWindow::onAction({str(action)})', f'ERROR: ({repr(e)})')
             if actionId in self.oe.CANCEL:
                 self.close()
 
@@ -337,7 +337,7 @@ class mainWindow(xbmcgui.WindowXMLDialog):
                 self.getControl(controlID).selectItem(selectedPosition)
             self.oe.dbg_log('oeWindows::onClick', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('oeWindows.mainWindow::onClick(' + str(controlID) + ')', 'ERROR: (' + repr(e) + ')')
+            self.oe.dbg_log(f'oeWindows.mainWindow::onClick({str(controlID)})', f'ERROR: ({repr(e)})')
 
     def onUnload(self):
         pass
@@ -382,7 +382,7 @@ class mainWindow(xbmcgui.WindowXMLDialog):
                     self.getControl(int(selectedMenuItem.getProperty('listTyp'))).setAnimations([('conditional',
                             'effect=fade start=0 end=100 time=100 condition=true')])
         except Exception as e:
-            self.oe.dbg_log('oeWindows.mainWindow::onFocus(' + repr(controlID) + ')', 'ERROR: (' + repr(e) + ')')
+            self.oe.dbg_log(f'oeWindows.mainWindow::onFocus({repr(controlID)})', f'ERROR: ({repr(e)})')
 
     def emptyButtonLabels(self):
         for btn in self.buttons:
@@ -426,7 +426,7 @@ class wizard(xbmcgui.WindowXMLDialog):
         self.wizLstTitle = 1404
         self.wizWinTitle = 32300
         self.oe = kwargs['oeMain']
-        self.guisettings = '%s/userdata/guisettings.xml' % self.oe.XBMC_USER_HOME
+        self.guisettings = f'{self.oe.XBMC_USER_HOME}/userdata/guisettings.xml'
         self.buttons = {
             1: {
                 'id': 1500,
@@ -482,7 +482,7 @@ class wizard(xbmcgui.WindowXMLDialog):
             self.getControl(self.radiobuttons[2]['id']).setVisible(False)
             self.getControl(self.buttons[2]['id']).setVisible(False)
             if self.oe.BOOT_STATUS == "SAFE":
-              self.set_wizard_title("[COLOR red][B]%s[/B][/COLOR]" % self.oe._(32393))
+              self.set_wizard_title(f"[COLOR red][B]{self.oe._(32393)}[/B][/COLOR]")
               self.set_wizard_text(self.oe._(32394))
             else:
               self.set_wizard_title(self.oe._(32301))
@@ -493,7 +493,7 @@ class wizard(xbmcgui.WindowXMLDialog):
             self.showButton(1, 32303)
             self.setFocusId(self.buttons[1]['id'])
         except Exception as e:
-            self.oe.dbg_log('oeWindows.wizard::onInit()', 'ERROR: (' + repr(e) + ')')
+            self.oe.dbg_log('oeWindows.wizard::onInit()', f'ERROR: ({repr(e)})')
 
     def wizard_set_language(self):
         global lang_str
@@ -527,31 +527,31 @@ class wizard(xbmcgui.WindowXMLDialog):
                 self.setFocusId(self.buttons[1]['id'])
             self.oe.dbg_log('oeWindows::wizard_set_language', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('oeWindows::wizard_set_language', 'ERROR: (' + repr(e) + ')')
+            self.oe.dbg_log('oeWindows::wizard_set_language', f'ERROR: ({repr(e)})')
 
     def set_wizard_text(self, text):
         try:
             self.getControl(self.wizTextbox).setText(text)
         except Exception as e:
-            self.oe.dbg_log('oeWindows.wizard::set_wizard_text()', 'ERROR: (' + repr(e) + ')')
+            self.oe.dbg_log('oeWindows.wizard::set_wizard_text()', f'ERROR: ({repr(e)})')
 
     def set_wizard_title(self, title):
         try:
             self.getControl(self.wizTitle).setLabel(title)
         except Exception as e:
-            self.oe.dbg_log('oeWindows.wizard::set_wizard_title()', 'ERROR: (' + repr(e) + ')')
+            self.oe.dbg_log('oeWindows.wizard::set_wizard_title()', f'ERROR: ({repr(e)})')
 
     def set_wizard_button_title(self, title):
         try:
             self.getControl(self.wizBtnTitle).setLabel(title)
         except Exception as e:
-            self.oe.dbg_log('oeWindows.wizard::set_wizard_button_title()', 'ERROR: (' + repr(e) + ')')
+            self.oe.dbg_log('oeWindows.wizard::set_wizard_button_title()', f'ERROR: ({repr(e)})')
 
     def set_wizard_list_title(self, title):
         try:
             self.getControl(self.wizLstTitle).setLabel(title)
         except Exception as e:
-            self.oe.dbg_log('oeWindows.wizard::set_wizard_list_title()', 'ERROR: (' + repr(e) + ')')
+            self.oe.dbg_log('oeWindows.wizard::set_wizard_list_title()', f'ERROR: ({repr(e)})')
 
     def set_wizard_button_1(self, label, modul, action):
         try:
@@ -569,7 +569,7 @@ class wizard(xbmcgui.WindowXMLDialog):
             self.getControl(self.buttons[2]['id']).controlUp(self.getControl(self.buttons[3]['id']))
             self.getControl(self.buttons[2]['id']).controlRight(self.getControl(self.buttons[1]['id']))
         except Exception as e:
-            self.oe.dbg_log('oeWindows.wizard::set_wizard_button_1()', 'ERROR: (' + repr(e) + ')')
+            self.oe.dbg_log('oeWindows.wizard::set_wizard_button_1()', f'ERROR: ({repr(e)})')
 
     def set_wizard_button_2(self, label, modul, action):
         try:
@@ -602,7 +602,7 @@ class wizard(xbmcgui.WindowXMLDialog):
             self.getControl(self.buttons[2]['id']).controlRight(self.getControl(self.buttons[1]['id']))
             self.getControl(self.radiobuttons[1]['id']).setSelected(selected)
         except Exception as e:
-            self.oe.dbg_log('oeWindows.wizard::set_wizard_button_1()', 'ERROR: (' + repr(e) + ')')
+            self.oe.dbg_log('oeWindows.wizard::set_wizard_button_1()', f'ERROR: ({repr(e)})')
 
     def set_wizard_radiobutton_2(self, label, modul, action, selected=False):
         try:
@@ -620,7 +620,7 @@ class wizard(xbmcgui.WindowXMLDialog):
             self.getControl(self.radiobuttons[1]['id']).controlRight(self.getControl(self.radiobuttons[2]['id']))
             self.getControl(self.radiobuttons[2]['id']).setSelected(selected)
         except Exception as e:
-            self.oe.dbg_log('oeWindows.wizard::set_wizard_button_2()', 'ERROR: (' + repr(e) + ')')
+            self.oe.dbg_log('oeWindows.wizard::set_wizard_button_2()', f'ERROR: ({repr(e)})')
 
     def onAction(self, action):
         pass
@@ -629,7 +629,7 @@ class wizard(xbmcgui.WindowXMLDialog):
         global strModule
         global prevModule
         try:
-            self.oe.dbg_log('wizard::onClick(' + str(controlID) + ')', 'enter_function', self.oe.LOGDEBUG)
+            self.oe.dbg_log(f'wizard::onClick({str(controlID)})', 'enter_function', self.oe.LOGDEBUG)
             for btn in self.buttons:
                 if controlID == self.buttons[btn]['id'] and self.buttons[btn]['id'] > 2:
                     if hasattr(self.buttons[btn]['modul'], self.buttons[btn]['action']):
@@ -653,7 +653,7 @@ class wizard(xbmcgui.WindowXMLDialog):
                     self.wizards.remove(prevModule)
                     self.oe.remove_node(prevModule)
                     self.onClick(1500)
-                self.oe.dbg_log('wizard::onClick(' + str(controlID) + ')', 'exit_function', self.oe.LOGDEBUG)
+                self.oe.dbg_log(f'wizard::onClick({str(controlID)})', 'exit_function', self.oe.LOGDEBUG)
 
             if controlID == 1500:
                 self.getControl(1390).setLabel('1')
@@ -693,7 +693,7 @@ class wizard(xbmcgui.WindowXMLDialog):
                             break
                 if self.is_last_wizard == True:
                     xbmc.executebuiltin('UpdateAddonRepos')
-                    langAddon = "InstallAddon(" + lang_new + ")"
+                    langAddon = f"InstallAddon({lang_new})"
                     xbmc.executebuiltin(langAddon)
                     self.oe.xbmcm.waitForAbort(0.5)
                     xbmc.executebuiltin('SendClick(10100,11)')
@@ -701,9 +701,9 @@ class wizard(xbmcgui.WindowXMLDialog):
                     self.visible = False
                     self.close()
                     xbmc.executebuiltin(lang_str)
-            self.oe.dbg_log('wizard::onClick(' + str(controlID) + ')', 'exit_function', self.oe.LOGDEBUG)
+            self.oe.dbg_log(f'wizard::onClick({str(controlID)})', 'exit_function', self.oe.LOGDEBUG)
         except Exception as e:
-            self.oe.dbg_log('oeWindows.wizard::onClick()', 'ERROR: (' + repr(e) + ')')
+            self.oe.dbg_log('oeWindows.wizard::onClick()', f'ERROR: ({repr(e)})')
 
     def onFocus(self, controlID):
         pass
@@ -714,7 +714,7 @@ class wizard(xbmcgui.WindowXMLDialog):
             button.setLabel(self.oe._(name))
             button.setVisible(True)
         except Exception as e:
-            self.oe.dbg_log('oeWindows.wizard::showButton(' + str(number) + ')', 'ERROR: (' + repr(e) + ')')
+            self.oe.dbg_log(f'oeWindows.wizard::showButton({str(number)})', f'ERROR: ({repr(e)})')
 
     def addConfigItem(self, strName, dictProperties, strType):
         try:
@@ -724,4 +724,4 @@ class wizard(xbmcgui.WindowXMLDialog):
             self.getControl(int(strType)).addItem(lstItem)
             return lstItem
         except Exception as e:
-            self.oe.dbg_log('oeWindows.wizard::addConfigItem(' + strName + ')', 'ERROR: (' + repr(e) + ')')
+            self.oe.dbg_log(f'oeWindows.wizard::addConfigItem({strName})', f'ERROR: ({repr(e)})')

--- a/src/service.py
+++ b/src/service.py
@@ -39,7 +39,7 @@ class Service_Thread(threading.Thread):
             conn, addr = self.sock.accept()
             message = (conn.recv(1024)).decode('utf-8')
             conn.close()
-            oe.dbg_log('_service_::run', 'MESSAGE:' + message, oe.LOGINFO)
+            oe.dbg_log('_service_::run', f'MESSAGE:{message}', oe.LOGINFO)
             if message == 'openConfigurationWindow':
                 if not hasattr(oe, 'winOeMain'):
                     threading.Thread(target=oe.openConfigurationWindow).start()


### PR DESCRIPTION
Python has multiple ways to combine strings and variables:

`print("Some Var's value is: %s" % SOME_VAR)`
`print("Some Var's value is: " + SOME_VAR)`
`print("Some Var's value is: {}".format(SOME_VAR))`
`print(f"Some Var's value is: {SOME_VAR}")`
(and probably some others that I haven't used)

The addon uses a blend of the first two styles. The examples above are purposefully simple, but they can get complicated to maintain. This PR converts most usage to the 4th option, known as an f-string, which is easiest to read in my opinion. Functionally, they're identical so it comes down to what others prefer to use. Assuming others agree, f-strings have the added benefit of being the fastest method of formatting strings.

Draft because while this should be complete, and I've been using it since June/July, I'm certain there are elements of the addon I don't use.