### PR TITLE
service.py: cosmetic changes

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -7,7 +7,7 @@
    	<import addon="xbmc.python" version="3.0.0"/>
   </requires>
   <extension point="xbmc.python.script" library="default.py"></extension>
-  <extension point="xbmc.service"       library="service.py" start="startup"></extension>
+  <extension point="xbmc.service"       library="service.py"></extension>
   <extension point="xbmc.addon.metadata">
     <summary lang="af">@DISTRONAME@ Konfigurasie</summary>
     <summary lang="bg">Настройки на @DISTRONAME@</summary>

--- a/src/resources/lib/config.py
+++ b/src/resources/lib/config.py
@@ -10,6 +10,8 @@ import xbmc
 import xbmcaddon
 import xbmcgui
 
+BUS = ravel.system_bus()
+
 ADDON = xbmcaddon.Addon()
 ADDON_ICON = ADDON.getAddonInfo('icon')
 ADDON_NAME = ADDON.getAddonInfo('name')
@@ -17,9 +19,7 @@ ADDON_NAME = ADDON.getAddonInfo('name')
 LOG_HEADER = f'{ADDON_NAME}:'
 LOG_LEVEL = xbmc.LOGDEBUG
 
-BUS = ravel.system_bus()
 _LOOP = asyncio.get_event_loop()
-
 BUS.attach_asyncio(_LOOP)
 threading.Thread(target=_LOOP.run_forever, daemon=True).start()
 
@@ -46,6 +46,7 @@ def log_function(function):
             xbmc.log(f'{header}#{repr(e)}', xbmc.LOGERROR)
             xbmc.log(traceback.format_exc(), xbmc.LOGERROR)
     return wrapper
+
 
 @log_function
 def notification(message, heading=ADDON_NAME, icon=ADDON_ICON):


### PR DESCRIPTION
This simplifies the code of service.py
The existing logic is preserved
service.py only refers to itself
In other words, the modules being migrated to ravel are not affected by this pull request
However, some of the ideas used in this pull request and in #189 may be reused to simplify migration to ravel
Most importantly, service.py becomes legible and maintainable