### PR TITLE
oe: fix 'load_file' encoding for Python 3

### DIFF
--- a/resources/lib/oe.py
+++ b/resources/lib/oe.py
@@ -440,7 +440,7 @@ def set_service(service, options, state):
 def load_file(filename):
     try:
         if os.path.isfile(filename):
-            objFile = open(filename, 'r')
+            objFile = open(filename, 'r', encoding='utf-8')
             content = objFile.read()
             objFile.close()
         else:


### PR DESCRIPTION
Without encoding the read() will end up with **UnicodeDecodeError** when using Python 3.