### PR TITLE
Work around deadlock when calling xbmc.executebuildin(Reboot)

### DIFF
--- a/resources/lib/modules/system.py
+++ b/resources/lib/modules/system.py
@@ -15,6 +15,7 @@ import xbmcgui
 import tarfile
 import oeWindows
 from xml.dom import minidom
+import subprocess
 
 xbmcDialog = xbmcgui.Dialog()
 
@@ -393,7 +394,7 @@ class system(modules.Module):
             open(self.XBMC_RESET_FILE, 'a').close()
             oe.winOeMain.close()
             oe.xbmcm.waitForAbort(1)
-            xbmc.executebuiltin('Reboot')
+            subprocess.call(['/usr/bin/systemctl', '--no-block', 'reboot'], close_fds=True)
 
     @log.log_function()
     def reset_oe(self, listItem=None):
@@ -401,7 +402,7 @@ class system(modules.Module):
             open(self.LIBREELEC_RESET_FILE, 'a').close()
             oe.winOeMain.close()
             oe.xbmcm.waitForAbort(1)
-            xbmc.executebuiltin('Reboot')
+            subprocess.call(['/usr/bin/systemctl', '--no-block', 'reboot'], close_fds=True)
 
     @log.log_function()
     def ask_sure_reset(self, part):
@@ -492,7 +493,7 @@ class system(modules.Module):
                     if oe.reboot_counter(10, oe._(32371)) == 1:
                         oe.winOeMain.close()
                         oe.xbmcm.waitForAbort(1)
-                        xbmc.executebuiltin('Reboot')
+                        subprocess.call(['/usr/bin/systemctl', '--no-block', 'reboot'], close_fds=True)
                 else:
                     log.log('User Abort!')
                     oe.execute(f'rm -rf {self.RESTORE_DIR}')

--- a/resources/lib/modules/updates.py
+++ b/resources/lib/modules/updates.py
@@ -502,7 +502,7 @@ class updates(modules.Module):
                 if silent == False:
                     oe.winOeMain.close()
                     oe.xbmcm.waitForAbort(1)
-                    xbmc.executebuiltin('Reboot')
+                    subprocess.call(['/usr/bin/systemctl', '--no-block', 'reboot'], close_fds=True)
             else:
                 delattr(self, 'update_in_progress')
 


### PR DESCRIPTION
Calling xbmc.executebuildin('Reboot') from Settings addon result in deadlock in libdbus python callback.

Use `/usr/bin/systemctl --no-block reboot` instead.

Backtrace: http://ix.io/2KYC  Debug log: http://ix.io/2KYD

For the tests a minimal not functional version of the bluetooth.py module was used to avoid the typical hang on exit because of using dbus-python (deleting bluetooth.py is possible too). 

Note: calling xbmc.executebuildin('Reboot') from an addon not using dbus i.e. [script.hello.world.reboot-matrix.zip](https://github.com/LibreELEC/service.libreelec.settings/files/5771938/script.hello.world.reboot-matrix.zip) is still possible.
