### PR TITLE
log.py: avoid log spam, only debug log to kodi if $DEBUG is set

### DIFF
--- a/resources/lib/log.py
+++ b/resources/lib/log.py
@@ -3,6 +3,7 @@
 import pprint
 import sys
 import traceback
+import os
 
 DEBUG = 0
 INFO = 1
@@ -17,7 +18,10 @@ _HEADER = 'SETTINGS: '
 
 try:
     import xbmc
+    _NO_DEBUG_ENV = os.environ.get('DEBUG', 'no') == 'no'
     def _log(message, level=_DEFAULT):
+        if level == DEBUG and _NO_DEBUG_ENV:
+            return
         xbmc.log(message, level)
 except ModuleNotFoundError:
     def _log(message, level=_DEFAULT):


### PR DESCRIPTION
Reimplmentation of LE 9.2 (and older) feature

Usually settings addon debug log messages are not required. When needed enable them with `DEBUG=on` in /storage/.config/kodi.conf.