### PR TITLE
Bluetooth: finish moving to dbussy

### DIFF
--- a/resources/lib/dbus_bluez.py
+++ b/resources/lib/dbus_bluez.py
@@ -87,7 +87,7 @@ class Agent(dbus_utils.Agent):
     )
     def RequestPasskey(self, device):
         passkey = self.request_passkey(device)
-        reply[0] = (dbus.Signature('u'), passkey)
+        reply[0] = (dbussy.DBUS.Signature('u'), passkey)
 
     @ravel.method(
         in_signature='o',
@@ -97,11 +97,38 @@ class Agent(dbus_utils.Agent):
     )
     def RequestPinCode(self, device, reply):
         pincode = self.request_pincode(device)
-        reply[0] = (dbus.Signature('s'), pincode)
+        reply[0] = (dbussy.DBUS.Signature('s'), pincode)
 
     def reject(self, message):
-        raise dbus.DBusError(ERROR_REJECTED, message)
+        raise dbussy.DBusError(ERROR_REJECTED, message)
 
+class Listener(object):
+
+    def __init__(self):
+        dbus_utils.BUS.listen_objects_added(func=self._on_interfaces_added)
+        dbus_utils.BUS.listen_objects_removed(func=self._on_interfaces_removed)
+        dbus_utils.BUS.listen_propchanged(
+            interface=dbussy.DBUS.INTERFACE_PROPERTIES,
+            fallback=True,
+            func=self._on_properties_changed,
+            path='/')
+
+    @ravel.signal(name='InterfacesAdded', in_signature='oa{sa{sv}}', arg_keys=('path', 'interfaces'))
+    async def _on_interfaces_added(self, path, interfaces):
+        interfaces = dbus_utils.convert_from_dbussy(interfaces)
+        await self.on_interfaces_added(path, interfaces)
+
+    @ravel.signal(name='InterfacesRemoved', in_signature='oas', arg_keys=('path', 'interfaces'))
+    async def _on_interfaces_removed(self, path, interfaces):
+        interfaces = dbus_utils.convert_from_dbussy(interfaces)
+        await self.on_interfaces_removed(path, interfaces)
+
+    @ravel.signal(name='PropertiesChanged', in_signature='sa{sv}as', arg_keys=('interface', 'changed', 'invalidated'), path_keyword='path')
+    async def _on_properties_changed(self, interface, changed, invalidated, path):
+        interface = dbus_utils.convert_from_dbussy(interface)
+        changed = dbus_utils.convert_from_dbussy(changed)
+        invalidated = dbus_utils.convert_from_dbussy(invalidated)
+        await self.on_properties_changed(interface, changed, invalidated, path)
 
 def get_managed_objects():
     return dbus_utils.call_method(BUS_NAME, '/', dbussy.DBUSX.INTERFACE_OBJECT_MANAGER, 'GetManagedObjects')

--- a/resources/lib/dbus_bluez.py
+++ b/resources/lib/dbus_bluez.py
@@ -114,21 +114,21 @@ class Listener(object):
             path='/')
 
     @ravel.signal(name='InterfacesAdded', in_signature='oa{sa{sv}}', arg_keys=('path', 'interfaces'))
-    async def _on_interfaces_added(self, path, interfaces):
+    def _on_interfaces_added(self, path, interfaces):
         interfaces = dbus_utils.convert_from_dbussy(interfaces)
-        await self.on_interfaces_added(path, interfaces)
+        self.on_interfaces_added(path, interfaces)
 
     @ravel.signal(name='InterfacesRemoved', in_signature='oas', arg_keys=('path', 'interfaces'))
-    async def _on_interfaces_removed(self, path, interfaces):
+    def _on_interfaces_removed(self, path, interfaces):
         interfaces = dbus_utils.convert_from_dbussy(interfaces)
-        await self.on_interfaces_removed(path, interfaces)
+        self.on_interfaces_removed(path, interfaces)
 
     @ravel.signal(name='PropertiesChanged', in_signature='sa{sv}as', arg_keys=('interface', 'changed', 'invalidated'), path_keyword='path')
-    async def _on_properties_changed(self, interface, changed, invalidated, path):
+    def _on_properties_changed(self, interface, changed, invalidated, path):
         interface = dbus_utils.convert_from_dbussy(interface)
         changed = dbus_utils.convert_from_dbussy(changed)
         invalidated = dbus_utils.convert_from_dbussy(invalidated)
-        await self.on_properties_changed(interface, changed, invalidated, path)
+        self.on_properties_changed(interface, changed, invalidated, path)
 
 def get_managed_objects():
     return dbus_utils.call_method(BUS_NAME, '/', dbussy.DBUSX.INTERFACE_OBJECT_MANAGER, 'GetManagedObjects')

--- a/resources/lib/dbus_obex.py
+++ b/resources/lib/dbus_obex.py
@@ -6,9 +6,9 @@ BUS_NAME = 'org.bluez.obex'
 ERROR_REJECTED = 'org.bluez.Error.Rejected'
 INTERFACE_AGENT = 'org.bluez.obex.Agent1'
 INTERFACE_AGENT_MANAGER = 'org.bluez.obex.AgentManager1'
+INTERFACE_TRANSFER = 'org.bluez.obex.Transfer1'
 PATH_OBEX = '/org/bluez/obex'
 PATH_AGENT = '/kodi/agent/obex'
-
 
 @ravel.interface(ravel.INTERFACE.SERVER, name=INTERFACE_AGENT)
 class Agent(dbus_utils.Agent):
@@ -33,9 +33,9 @@ class Agent(dbus_utils.Agent):
         arg_keys=['path'],
         result_keyword='reply'
     )
-    def AuthorizePush(self, path):
-        name = self.authorize_push(path)
-        reply[0] = (dbus.Signature('s'), name)
+    def AuthorizePush(self, transfer):
+        name = self.authorize_push(transfer)
+        reply[0] = (dbussy.DBUS.Signature('s'), name)
 
     @ravel.method(
         in_signature='',
@@ -45,4 +45,25 @@ class Agent(dbus_utils.Agent):
         pass
 
     def reject(self, message):
-        raise dbus.DBusError(ERROR_REJECTED, message)
+        raise dbussy.DBusError(ERROR_REJECTED, message)
+
+class Listener(object):
+
+    def __init__(self):
+        pass
+        # dbussy doesn't currenltly support listening for non specific signals
+        # dbus_utils.BUS.listen_signal(
+        #     interface=INTERFACE_TRANSFER,
+        #     fallback=True,
+        #     func=self._on_transfer_changed,
+        #     path='/')
+
+    # @ravel.signal(name='PropertiesChanged', in_signature='sa{sv}as', arg_keys=('interface', 'changed', 'invalidated'), path_keyword='path', bus_keyword=BUS_NAME)
+    # async def _on_transfer_changed(self, interface, changed, invalidated, path):
+    #     interface = dbus_utils.convert_from_dbussy(interface)
+    #     changed = dbus_utils.convert_from_dbussy(changed)
+    #     invalidated = dbus_utils.convert_from_dbussy(invalidated)
+    #     await self.on_transfer_changed(interface, changed, invalidated, path)
+
+def transfer_get_all_properties(path):
+    return dbus_utils.call_method(BUS_NAME, path, dbussy.DBUS.INTERFACE_PROPERTIES, 'GetAll', INTERFACE_TRANSFER)

--- a/resources/lib/modules/bluetooth.py
+++ b/resources/lib/modules/bluetooth.py
@@ -90,6 +90,9 @@ class bluetooth(modules.Module):
 
     @log.log_function()
     def start_discovery(self):
+        if self.discovering:
+            return
+
         self.discovering = True
         dbus_bluez.adapter_start_discovery(self.dbusBluezAdapter)
 

--- a/resources/lib/modules/bluetooth.py
+++ b/resources/lib/modules/bluetooth.py
@@ -444,7 +444,7 @@ class Bluez_Listener(dbus_bluez.Listener):
         super().__init__()
 
     @log.log_function()
-    async def on_interfaces_added(self, path, interfaces):
+    def on_interfaces_added(self, path, interfaces):
         if dbus_bluez.INTERFACE_ADAPTER in interfaces:
             self.parent.dbusBluezAdapter = path
             self.parent.init_adapter()
@@ -455,14 +455,14 @@ class Bluez_Listener(dbus_bluez.Listener):
             self.parent.menu_connections()
 
     @log.log_function()
-    async def on_interfaces_removed(self, path, interfaces):
+    def on_interfaces_removed(self, path, interfaces):
         if dbus_bluez.INTERFACE_ADAPTER in interfaces:
             self.parent.dbusBluezAdapter = None
         if self.parent.visible and not hasattr(self.parent, 'discovery_thread'):
             self.parent.menu_connections()
 
     @log.log_function()
-    async def on_properties_changed(self, interface, changed, invalidated, path):
+    def on_properties_changed(self, interface, changed, invalidated, path):
         if self.parent.visible:
             properties = [
                 'Paired',


### PR DESCRIPTION
This finishes up the great work done by @thoradia. They changes they made really made this easy to do (I'm not sure why they didn't finish it?).

A few comments:
 - obex is updated (and should work) but there won't be any gui for the file transfer. dbussy doesn't currently have the ability to listen for signals on an interface without specifying a method name. For file transfers we want to be able to update the status during any change. I'll make an issue about this at the dbussy repo.
 - I had problems with the async method calls crashing kodi. I attribute this to the fact that we are asynchronously trying to update the menu items and subsequently crash if we try to update (or delete) and item that doesn't exist. I've changed these methods to be synchronous in d3d7a78 (I'm wondering if we should do this for connman also?)
 - Likely this is going to give us similar behavior to the old ways. There can still be a lot of fixes with regards to how the gui list updates and is navigated but that can be for another PR.

Please test before merging. I had issues on my NUC (even just using bluetoothctl) so I haven't fully tested this. I think I just need to charge my bluetooth devices and try again.