### PR TITLE
Fix backup creation

### DIFF
--- a/resources/language/resource.language.ast_es/strings.po
+++ b/resources/language/resource.language.ast_es/strings.po
@@ -1170,3 +1170,7 @@ msgstr ""
 msgctxt "#32400"
 msgid "Idle Timeout"
 msgstr ""
+
+msgctxt "#32401"
+msgid "Syncing Disks..."
+msgstr ""

--- a/resources/language/resource.language.bg_bg/strings.po
+++ b/resources/language/resource.language.bg_bg/strings.po
@@ -1170,3 +1170,7 @@ msgstr "Публичен режим"
 msgctxt "#32400"
 msgid "Idle Timeout"
 msgstr ""
+
+msgctxt "#32401"
+msgid "Syncing Disks..."
+msgstr ""

--- a/resources/language/resource.language.cs_cz/strings.po
+++ b/resources/language/resource.language.cs_cz/strings.po
@@ -1170,3 +1170,7 @@ msgstr "Veřejný"
 msgctxt "#32400"
 msgid "Idle Timeout"
 msgstr "Časový limit nečinnosti"
+
+msgctxt "#32401"
+msgid "Syncing Disks..."
+msgstr ""

--- a/resources/language/resource.language.de_de/strings.po
+++ b/resources/language/resource.language.de_de/strings.po
@@ -1170,3 +1170,7 @@ msgstr "Öffentlich"
 msgctxt "#32400"
 msgid "Idle Timeout"
 msgstr "Leerlauf-Timeout"
+
+msgctxt "#32401"
+msgid "Syncing Disks..."
+msgstr ""

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -1047,3 +1047,7 @@ msgstr ""
 msgctxt "#32400"
 msgid "Idle Timeout"
 msgstr ""
+
+msgctxt "#32401"
+msgid "Syncing Disks..."
+msgstr ""

--- a/resources/language/resource.language.es_es/strings.po
+++ b/resources/language/resource.language.es_es/strings.po
@@ -1173,4 +1173,4 @@ msgstr "Tiempo de inactividad"
 
 msgctxt "#32401"
 msgid "Syncing Disks..."
-msgstr ""
+msgstr "Escribiendo a Discos..."

--- a/resources/language/resource.language.es_es/strings.po
+++ b/resources/language/resource.language.es_es/strings.po
@@ -1170,3 +1170,7 @@ msgstr "Público"
 msgctxt "#32400"
 msgid "Idle Timeout"
 msgstr "Tiempo de inactividad"
+
+msgctxt "#32401"
+msgid "Syncing Disks..."
+msgstr ""

--- a/resources/language/resource.language.eu_es/strings.po
+++ b/resources/language/resource.language.eu_es/strings.po
@@ -1170,3 +1170,7 @@ msgstr "Publikoa"
 msgctxt "#32400"
 msgid "Idle Timeout"
 msgstr ""
+
+msgctxt "#32401"
+msgid "Syncing Disks..."
+msgstr ""

--- a/resources/language/resource.language.fi_fi/strings.po
+++ b/resources/language/resource.language.fi_fi/strings.po
@@ -1170,3 +1170,7 @@ msgstr "Julkinen"
 msgctxt "#32400"
 msgid "Idle Timeout"
 msgstr ""
+
+msgctxt "#32401"
+msgid "Syncing Disks..."
+msgstr ""

--- a/resources/language/resource.language.fr_ca/strings.po
+++ b/resources/language/resource.language.fr_ca/strings.po
@@ -1170,3 +1170,7 @@ msgstr "Public"
 msgctxt "#32400"
 msgid "Idle Timeout"
 msgstr ""
+
+msgctxt "#32401"
+msgid "Syncing Disks..."
+msgstr ""

--- a/resources/language/resource.language.fr_fr/strings.po
+++ b/resources/language/resource.language.fr_fr/strings.po
@@ -1170,3 +1170,7 @@ msgstr "Public"
 msgctxt "#32400"
 msgid "Idle Timeout"
 msgstr "Délai d'inactivité"
+
+msgctxt "#32401"
+msgid "Syncing Disks..."
+msgstr ""

--- a/resources/language/resource.language.he_il/strings.po
+++ b/resources/language/resource.language.he_il/strings.po
@@ -1170,3 +1170,7 @@ msgstr ""
 msgctxt "#32400"
 msgid "Idle Timeout"
 msgstr ""
+
+msgctxt "#32401"
+msgid "Syncing Disks..."
+msgstr ""

--- a/resources/language/resource.language.hu_hu/strings.po
+++ b/resources/language/resource.language.hu_hu/strings.po
@@ -1170,3 +1170,7 @@ msgstr "Nyilvános"
 msgctxt "#32400"
 msgid "Idle Timeout"
 msgstr "Tétlenségi Időtúllépés"
+
+msgctxt "#32401"
+msgid "Syncing Disks..."
+msgstr ""

--- a/resources/language/resource.language.it_it/strings.po
+++ b/resources/language/resource.language.it_it/strings.po
@@ -1170,3 +1170,7 @@ msgstr "Pubblico"
 msgctxt "#32400"
 msgid "Idle Timeout"
 msgstr ""
+
+msgctxt "#32401"
+msgid "Syncing Disks..."
+msgstr ""

--- a/resources/language/resource.language.ja_jp/strings.po
+++ b/resources/language/resource.language.ja_jp/strings.po
@@ -1170,3 +1170,7 @@ msgstr "パブリック"
 msgctxt "#32400"
 msgid "Idle Timeout"
 msgstr ""
+
+msgctxt "#32401"
+msgid "Syncing Disks..."
+msgstr ""

--- a/resources/language/resource.language.ko_kr/strings.po
+++ b/resources/language/resource.language.ko_kr/strings.po
@@ -1170,3 +1170,7 @@ msgstr "공용"
 msgctxt "#32400"
 msgid "Idle Timeout"
 msgstr "가동되지 않은 시간"
+
+msgctxt "#32401"
+msgid "Syncing Disks..."
+msgstr ""

--- a/resources/language/resource.language.lt_lt/strings.po
+++ b/resources/language/resource.language.lt_lt/strings.po
@@ -1170,3 +1170,7 @@ msgstr "Viešas"
 msgctxt "#32400"
 msgid "Idle Timeout"
 msgstr ""
+
+msgctxt "#32401"
+msgid "Syncing Disks..."
+msgstr ""

--- a/resources/language/resource.language.lv_lv/strings.po
+++ b/resources/language/resource.language.lv_lv/strings.po
@@ -1170,3 +1170,7 @@ msgstr "Publisks"
 msgctxt "#32400"
 msgid "Idle Timeout"
 msgstr ""
+
+msgctxt "#32401"
+msgid "Syncing Disks..."
+msgstr ""

--- a/resources/language/resource.language.nb_no/strings.po
+++ b/resources/language/resource.language.nb_no/strings.po
@@ -1170,3 +1170,7 @@ msgstr "Allment"
 msgctxt "#32400"
 msgid "Idle Timeout"
 msgstr ""
+
+msgctxt "#32401"
+msgid "Syncing Disks..."
+msgstr ""

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -1170,3 +1170,7 @@ msgstr "Publiek"
 msgctxt "#32400"
 msgid "Idle Timeout"
 msgstr "Idle Timeout"
+
+msgctxt "#32401"
+msgid "Syncing Disks..."
+msgstr ""

--- a/resources/language/resource.language.pl_pl/strings.po
+++ b/resources/language/resource.language.pl_pl/strings.po
@@ -1170,3 +1170,7 @@ msgstr "Publiczny"
 msgctxt "#32400"
 msgid "Idle Timeout"
 msgstr ""
+
+msgctxt "#32401"
+msgid "Syncing Disks..."
+msgstr ""

--- a/resources/language/resource.language.pt_br/strings.po
+++ b/resources/language/resource.language.pt_br/strings.po
@@ -1170,3 +1170,7 @@ msgstr "Público"
 msgctxt "#32400"
 msgid "Idle Timeout"
 msgstr ""
+
+msgctxt "#32401"
+msgid "Syncing Disks..."
+msgstr ""

--- a/resources/language/resource.language.pt_pt/strings.po
+++ b/resources/language/resource.language.pt_pt/strings.po
@@ -1170,3 +1170,7 @@ msgstr ""
 msgctxt "#32400"
 msgid "Idle Timeout"
 msgstr ""
+
+msgctxt "#32401"
+msgid "Syncing Disks..."
+msgstr ""

--- a/resources/language/resource.language.ro_ro/strings.po
+++ b/resources/language/resource.language.ro_ro/strings.po
@@ -1170,3 +1170,7 @@ msgstr "Public"
 msgctxt "#32400"
 msgid "Idle Timeout"
 msgstr ""
+
+msgctxt "#32401"
+msgid "Syncing Disks..."
+msgstr ""

--- a/resources/language/resource.language.ru_ru/strings.po
+++ b/resources/language/resource.language.ru_ru/strings.po
@@ -1170,3 +1170,7 @@ msgstr "Общественные"
 msgctxt "#32400"
 msgid "Idle Timeout"
 msgstr "Таймаут неактивности"
+
+msgctxt "#32401"
+msgid "Syncing Disks..."
+msgstr ""

--- a/resources/language/resource.language.sk_sk/strings.po
+++ b/resources/language/resource.language.sk_sk/strings.po
@@ -1170,3 +1170,7 @@ msgstr "Verejné"
 msgctxt "#32400"
 msgid "Idle Timeout"
 msgstr ""
+
+msgctxt "#32401"
+msgid "Syncing Disks..."
+msgstr ""

--- a/resources/language/resource.language.sv_se/strings.po
+++ b/resources/language/resource.language.sv_se/strings.po
@@ -1170,3 +1170,7 @@ msgstr "Public"
 msgctxt "#32400"
 msgid "Idle Timeout"
 msgstr "Timeout"
+
+msgctxt "#32401"
+msgid "Syncing Disks..."
+msgstr ""

--- a/resources/language/resource.language.tr_tr/strings.po
+++ b/resources/language/resource.language.tr_tr/strings.po
@@ -1170,3 +1170,7 @@ msgstr "Genel"
 msgctxt "#32400"
 msgid "Idle Timeout"
 msgstr ""
+
+msgctxt "#32401"
+msgid "Syncing Disks..."
+msgstr ""

--- a/resources/language/resource.language.uk_ua/strings.po
+++ b/resources/language/resource.language.uk_ua/strings.po
@@ -1170,3 +1170,7 @@ msgstr ""
 msgctxt "#32400"
 msgid "Idle Timeout"
 msgstr ""
+
+msgctxt "#32401"
+msgid "Syncing Disks..."
+msgstr ""

--- a/resources/language/resource.language.zh_cn/strings.po
+++ b/resources/language/resource.language.zh_cn/strings.po
@@ -1170,3 +1170,7 @@ msgstr "公共"
 msgctxt "#32400"
 msgid "Idle Timeout"
 msgstr ""
+
+msgctxt "#32401"
+msgid "Syncing Disks..."
+msgstr ""

--- a/resources/language/resource.language.zh_tw/strings.po
+++ b/resources/language/resource.language.zh_tw/strings.po
@@ -1170,3 +1170,7 @@ msgstr ""
 msgctxt "#32400"
 msgid "Idle Timeout"
 msgstr ""
+
+msgctxt "#32401"
+msgid "Syncing Disks..."
+msgstr ""

--- a/resources/lib/modules/system.py
+++ b/resources/lib/modules/system.py
@@ -44,6 +44,10 @@ class system(modules.Module):
         super().__init__()
         self.keyboard_layouts = False
         self.nox_keyboard_layouts = False
+        self.backup_dlg = None
+        self.backup_file = None
+        self.total_backup_size = 0
+        self.done_backup_size = 0
         self.arrVariants = {}
         self.struct = {
             'ident': {
@@ -446,15 +450,14 @@ class system(modules.Module):
                 self.backup_dlg.create('LibreELEC', oe._(32375))
                 if not os.path.exists(self.BACKUP_DESTINATION):
                     os.makedirs(self.BACKUP_DESTINATION)
-                self.backup_file = oe.timestamp() + '.tar'
+                self.backup_file = f'{oe.timestamp()}.tar'
                 tar = tarfile.open(bckDir + self.backup_file, 'w')
                 for directory in self.BACKUP_DIRS:
                     self.tar_add_folder(tar, directory)
                 tar.close()
-                self.backup_dlg.close()
-                del self.backup_dlg
         finally:
             self.backup_dlg.close()
+            self.backup_dlg = None
 
     @log.log_function()
     def do_restore(self, listItem=None):
@@ -548,8 +551,9 @@ class system(modules.Module):
                     if hasattr(self, 'backup_dlg'):
                         progress = round(1.0 * self.done_backup_size / self.total_backup_size * 100)
                         self.backup_dlg.update(int(progress), f'{folder}\n{item}')
-        finally:
+        except:
             self.backup_dlg.close()
+            raise
 
     @log.log_function()
     def get_folder_size(self, folder):

--- a/resources/lib/modules/system.py
+++ b/resources/lib/modules/system.py
@@ -455,6 +455,8 @@ class system(modules.Module):
                 for directory in self.BACKUP_DIRS:
                     self.tar_add_folder(tar, directory)
                 tar.close()
+                self.backup_dlg.update(100, oe._(32401))
+                os.sync()
         finally:
             self.backup_dlg.close()
             self.backup_dlg = None

--- a/resources/lib/oe.py
+++ b/resources/lib/oe.py
@@ -798,8 +798,7 @@ def load_modules():
 
 
 def timestamp():
-    now = time.time()
-    localtime = time.localtime(now)
+    localtime = time.localtime()
     return time.strftime('%Y%m%d%H%M%S', localtime)
 
 


### PR DESCRIPTION
This resolves 

ERROR <general>: SETTINGS: system.do_backup # AttributeError("'system' object has no attribute 'backup_dlg'")

when creating a backup.

My understanding is that certain variables are being used between functions, but functions are treating them as local to their function.

While not in the error, self.backup_file, self.total_backup_size, and self.done_backup_size are all used to report progress in the dialog box, and between functions, so init those too.

oe.timestamp() is a cleanup of a function used in the backup process. time.localtime() uses time.time() as the input time when another input isn't provided, so the `now` variable is useless.

Please test further. My generated backup is <30MB so I don't see much of the dialog box before it is finished. Since this is being tested, please look at #163 which is also about backups.