### PR TITLE
Handle invalid regex pattern in updates

### DIFF
--- a/resources/lib/modules/updates.py
+++ b/resources/lib/modules/updates.py
@@ -446,7 +446,11 @@ class updates(modules.Module):
                     if oe.ARCHITECTURE in self.update_json[channel]['project']:
                         for i in sorted(self.update_json[channel]['project'][oe.ARCHITECTURE]['releases'], key=int, reverse=True):
                             if shortname is None:
-                                update_files.append(regex.findall(self.update_json[channel]['project'][oe.ARCHITECTURE]['releases'][i]['file']['name'])[0].strip('.tar'))
+                                matches = regex.findall(self.update_json[channel]['project'][oe.ARCHITECTURE]['releases'][i]['file']['name'])
+                                if matches:
+                                    update_files.append(matches[0].strip('.tar'))
+                                else:
+                                    update_files.append(self.update_json[channel]['project'][oe.ARCHITECTURE]['releases'][i]['file']['name'].strip('.tar'))
                             else:
                                 build = self.update_json[channel]['project'][oe.ARCHITECTURE]['releases'][i]['file']['name']
                                 if shortname in build:


### PR DESCRIPTION
In the last LibreELEC nightly build, the name pattern changed from 
`LibreELEC-RPi4.arm-10.0-nightly-20210227-9c75e28.tar` to
`LibreELEC-RPi4.arm-10.0-devel-20210304145850-fa9da75.tar`

Since I use a custom update channel with a `prettyname_regex`, the regex broke and the "update" menu entry in LibreELEC settings addon completely disappeared.

This PR adds a check if regex matches and falls back to full name.

Note: I will runtime test this PR later, haven't tested yet. 