### PR TITLE
Check if setting is None before join

### DIFF
--- a/resources/lib/oeWindows.py
+++ b/resources/lib/oeWindows.py
@@ -141,7 +141,7 @@ class mainWindow(xbmcgui.WindowXMLDialog):
                                 dictProperties['InfoText'] = oe._(setting['InfoText'])
                             if 'validate' in setting:
                                 dictProperties['validate'] = setting['validate']
-                            if 'values' in setting:
+                            if 'values' in setting and setting['values'] is not None:
                                 dictProperties['values'] = '|'.join(setting['values'])
                             if isinstance(setting['name'], str):
                                 name = setting['name']


### PR DESCRIPTION
Due to a malformed releases.json, the 'Updates' menu entry in settings addon disappeared. 

In this case, `setting['values']` was None and the following error was returned: `TypeError: can only join an iterable`.

If relases.json is malformed, the settings addon should be robust on errors and not hide menu entries.