### PR TITLE
Wizard: call xbmc.executebuiltin('UpdateAddonRepos') early

### DIFF
--- a/resources/lib/oeWindows.py
+++ b/resources/lib/oeWindows.py
@@ -663,6 +663,9 @@ class wizard(xbmcgui.WindowXMLDialog):
                 self.set_wizard_list_title('')
                 self.set_wizard_button_title('')
 
+                if strModule == 'connman':
+                    xbmc.executebuiltin('UpdateAddonRepos')
+
                 for module in sorted(oe.dictModules, key=lambda x: list(oe.dictModules[x].menu.keys())):
                     strModule = module
                     if hasattr(oe.dictModules[strModule], 'do_wizard') and oe.dictModules[strModule].ENABLED:
@@ -685,7 +688,6 @@ class wizard(xbmcgui.WindowXMLDialog):
                             self.is_last_wizard = False
                             break
                 if self.is_last_wizard == True:
-                    xbmc.executebuiltin('UpdateAddonRepos')
                     if lang_new and xbmc.getCondVisibility(f'System.HasAddon({lang_new})') == False:
                         xbmc.executebuiltin(f'InstallAddon({lang_new})')
                     oe.xbmcm.waitForAbort(0.5)


### PR DESCRIPTION
Calling xbmc.executebuiltin('UpdateAddonRepos') just trigger the repo update. The following xbmc.executebuiltin(f'InstallAddon({lang_new})') still fails to install the language addon.

We can trigger the repo update after the network is configured. The update is performed in the background while the user continue to use the wizard.