### PR TITLE
add dbus_systemd to handle systemctl calls

### DIFF
--- a/resources/lib/dbus_systemd.py
+++ b/resources/lib/dbus_systemd.py
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2020-present Team LibreELEC
+
+import dbus_utils
+
+BUS_NAME = 'org.freedesktop.systemd1'
+PATH_SYSTEMD = '/org/freedesktop/systemd1'
+INTERFACE_SYSTEMD_MANAGER = 'org.freedesktop.systemd1.Manager'
+
+def restart_unit(name, mode='replace'):
+    return dbus_utils.call_method(BUS_NAME, PATH_SYSTEMD, INTERFACE_SYSTEMD_MANAGER, 'RestartUnit', name, mode)
+
+def reboot():
+    return dbus_utils.call_method(BUS_NAME, PATH_SYSTEMD, INTERFACE_SYSTEMD_MANAGER, 'Reboot')

--- a/resources/lib/modules/system.py
+++ b/resources/lib/modules/system.py
@@ -16,6 +16,7 @@ import tarfile
 import oeWindows
 from xml.dom import minidom
 import subprocess
+import dbus_systemd
 
 xbmcDialog = xbmcgui.Dialog()
 
@@ -394,7 +395,7 @@ class system(modules.Module):
             open(self.XBMC_RESET_FILE, 'a').close()
             oe.winOeMain.close()
             oe.xbmcm.waitForAbort(1)
-            subprocess.call(['/usr/bin/systemctl', '--no-block', 'reboot'], close_fds=True)
+            dbus_systemd.reboot()
 
     @log.log_function()
     def reset_oe(self, listItem=None):
@@ -402,7 +403,7 @@ class system(modules.Module):
             open(self.LIBREELEC_RESET_FILE, 'a').close()
             oe.winOeMain.close()
             oe.xbmcm.waitForAbort(1)
-            subprocess.call(['/usr/bin/systemctl', '--no-block', 'reboot'], close_fds=True)
+            dbus_systemd.reboot()
 
     @log.log_function()
     def ask_sure_reset(self, part):
@@ -493,7 +494,7 @@ class system(modules.Module):
                     if oe.reboot_counter(10, oe._(32371)) == 1:
                         oe.winOeMain.close()
                         oe.xbmcm.waitForAbort(1)
-                        subprocess.call(['/usr/bin/systemctl', '--no-block', 'reboot'], close_fds=True)
+                        dbus_systemd.reboot()
                 else:
                     log.log('User Abort!')
                     oe.execute(f'rm -rf {self.RESTORE_DIR}')

--- a/resources/lib/modules/updates.py
+++ b/resources/lib/modules/updates.py
@@ -22,7 +22,7 @@ from xml.dom import minidom
 import datetime
 import tempfile
 from functools import cmp_to_key
-
+import dbus_systemd
 class updates(modules.Module):
 
     ENABLED = False
@@ -502,7 +502,7 @@ class updates(modules.Module):
                 if silent == False:
                     oe.winOeMain.close()
                     oe.xbmcm.waitForAbort(1)
-                    subprocess.call(['/usr/bin/systemctl', '--no-block', 'reboot'], close_fds=True)
+                    dbus_systemd.reboot()
             else:
                 delattr(self, 'update_in_progress')
 

--- a/resources/lib/oe.py
+++ b/resources/lib/oe.py
@@ -21,6 +21,7 @@ import subprocess
 import defaults
 import shutil
 import hashlib, binascii
+import dbus_systemd
 
 from xml.dom import minidom
 import imp
@@ -422,7 +423,7 @@ def set_service(service, options, state):
         if not __oe__.is_service:
             if service in defaults._services:
                 for svc in defaults._services[service]:
-                    execute(f'systemctl restart {svc}')
+                    dbus_systemd.restart_unit(svc)
         dbg_log('oe::set_service', 'exit_function', LOGDEBUG)
     except Exception as e:
         dbg_log('oe::set_service', f'ERROR: ({repr(e)})')


### PR DESCRIPTION
Pretty self explanatory. Maybe this can be expanded in the future to make use of more or the systemd dbus API.

Could probably use some more testing to make sure the rebooting works properly.