### PR TITLE
system.py: backup: use gnutar format again

### DIFF
--- a/resources/lib/modules/system.py
+++ b/resources/lib/modules/system.py
@@ -452,7 +452,7 @@ class system(modules.Module):
                 if not os.path.exists(self.BACKUP_DESTINATION):
                     os.makedirs(self.BACKUP_DESTINATION)
                 self.backup_file = f'{oe.timestamp()}.tar'
-                tar = tarfile.open(bckDir + self.backup_file, 'w')
+                tar = tarfile.open(bckDir + self.backup_file, 'w', format=tarfile.GNU_FORMAT)
                 for directory in self.BACKUP_DIRS:
                     self.tar_add_folder(tar, directory)
                 tar.close()


### PR DESCRIPTION
Busybox tar fail to restore all timestamps of a POSIX 1003.1-2001/pax format tar file created by python3 "tarfile". See https://forum.libreelec.tv/thread/23744-le-9-95-1-backups-are-restored-with-mtime-jan-1-1970-for-some-files-with-testcas/

The previously used gnutar format is working fine. Just force it.

The default tar format of tarfile changed with python 3.8 from gnutar to posix.  

I'm not sure whom to blame. Tarfile generated files can be successfully extracted with GNU tar and GNU tar generated files can be successfully extracted with Busybox tar.