### PR TITLE
oe: catch (and log) reported sporadic getpreferredencoding() error

### DIFF
--- a/resources/lib/oe.py
+++ b/resources/lib/oe.py
@@ -65,9 +65,12 @@ CANCEL = (
 ########################## initialize module ##################################
 ## set default encoding
 
-encoding = locale.getpreferredencoding(do_setlocale=True)
-imp.reload(sys)
-# sys.setdefaultencoding(encoding)
+try:
+    encoding = locale.getpreferredencoding(do_setlocale=True)
+    imp.reload(sys)
+    # sys.setdefaultencoding(encoding)
+except Exception as e:
+    xbmc.log(f'## LibreELEC Addon ## oe:encoding: ERROR: ({repr(e)})', LOGERROR)
 
 ## load oeSettings modules
 


### PR DESCRIPTION
I cannot reproduce the error but there have been some error reports, i.e.:

https://forum.libreelec.tv/thread/23655-le-10-libreelec-configuration-error-and-not-powering-down/
https://forum.libreelec.tv/thread/23904-libreelec-9-95-2-settings-error-on-startup/

No functional change, just catch possible errors, log and continue addon.
