### PR TITLE
oeWindows.py: only change language using wizard if language installed

### DIFF
--- a/resources/lib/oeWindows.py
+++ b/resources/lib/oeWindows.py
@@ -696,6 +696,10 @@ class wizard(xbmcgui.WindowXMLDialog):
                     self.visible = False
                     self.close()
                     if lang_new:
+                        for _ in range(20):
+                            if xbmc.getCondVisibility(f'System.HasAddon({lang_new})'):
+                                break
+                            oe.xbmcm.waitForAbort(0.5)
                         if xbmc.getCondVisibility(f'System.HasAddon({lang_new})') == True:
                             xbmc.executebuiltin(f'SetGUILanguage({str(lang_new)})')
                         else:

--- a/resources/lib/oeWindows.py
+++ b/resources/lib/oeWindows.py
@@ -696,7 +696,10 @@ class wizard(xbmcgui.WindowXMLDialog):
                     self.visible = False
                     self.close()
                     if lang_new:
-                        xbmc.executebuiltin(f'SetGUILanguage({str(lang_new)})')
+                        if xbmc.getCondVisibility(f'System.HasAddon({lang_new})') == True:
+                            xbmc.executebuiltin(f'SetGUILanguage({str(lang_new)})')
+                        else:
+                            oe.dbg_log(f'wizard::onClick({str(controlID)})', f"ERROR: Unable to switch language to: {lang_new}. Language addon is not installed.")
             oe.dbg_log(f'wizard::onClick({str(controlID)})', 'exit_function', oe.LOGDEBUG)
         except Exception as e:
             oe.dbg_log('oeWindows.wizard::onClick()', f'ERROR: ({repr(e)})')


### PR DESCRIPTION
When using LE's first run wizard, only attempt to switch the language if the language addon is installed. When it's not installed, write something useful to the log.

User experience in the failure case won't be great, but also won't cause errors. The wizard will change language, complete, and the interface will remain in English. Going to Settings -> Interface -> Regional afterwards will continue to change the language like normal.