### PR TITLE
More information around backup and restore

### DIFF
--- a/resources/language/resource.language.ast_es/strings.po
+++ b/resources/language/resource.language.ast_es/strings.po
@@ -1174,3 +1174,7 @@ msgstr ""
 msgctxt "#32401"
 msgid "Syncing Disks..."
 msgstr ""
+
+msgctxt "#32402"
+msgid "Backup is incomplete. An error occurred. See Kodi log for details."
+msgstr ""

--- a/resources/language/resource.language.bg_bg/strings.po
+++ b/resources/language/resource.language.bg_bg/strings.po
@@ -1174,3 +1174,7 @@ msgstr ""
 msgctxt "#32401"
 msgid "Syncing Disks..."
 msgstr ""
+
+msgctxt "#32402"
+msgid "Backup is incomplete. An error occurred. See Kodi log for details."
+msgstr ""

--- a/resources/language/resource.language.cs_cz/strings.po
+++ b/resources/language/resource.language.cs_cz/strings.po
@@ -1174,3 +1174,7 @@ msgstr "Časový limit nečinnosti"
 msgctxt "#32401"
 msgid "Syncing Disks..."
 msgstr ""
+
+msgctxt "#32402"
+msgid "Backup is incomplete. An error occurred. See Kodi log for details."
+msgstr ""

--- a/resources/language/resource.language.de_de/strings.po
+++ b/resources/language/resource.language.de_de/strings.po
@@ -1174,3 +1174,7 @@ msgstr "Leerlauf-Timeout"
 msgctxt "#32401"
 msgid "Syncing Disks..."
 msgstr ""
+
+msgctxt "#32402"
+msgid "Backup is incomplete. An error occurred. See Kodi log for details."
+msgstr ""

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -1051,3 +1051,7 @@ msgstr ""
 msgctxt "#32401"
 msgid "Syncing Disks..."
 msgstr ""
+
+msgctxt "#32402"
+msgid "Backup is incomplete. An error occurred. See Kodi log for details."
+msgstr ""

--- a/resources/language/resource.language.es_es/strings.po
+++ b/resources/language/resource.language.es_es/strings.po
@@ -1174,3 +1174,7 @@ msgstr "Tiempo de inactividad"
 msgctxt "#32401"
 msgid "Syncing Disks..."
 msgstr "Escribiendo a Discos..."
+
+msgctxt "#32402"
+msgid "Backup is incomplete. An error occurred. See Kodi log for details."
+msgstr ""

--- a/resources/language/resource.language.eu_es/strings.po
+++ b/resources/language/resource.language.eu_es/strings.po
@@ -1174,3 +1174,7 @@ msgstr ""
 msgctxt "#32401"
 msgid "Syncing Disks..."
 msgstr ""
+
+msgctxt "#32402"
+msgid "Backup is incomplete. An error occurred. See Kodi log for details."
+msgstr ""

--- a/resources/language/resource.language.fi_fi/strings.po
+++ b/resources/language/resource.language.fi_fi/strings.po
@@ -1174,3 +1174,7 @@ msgstr ""
 msgctxt "#32401"
 msgid "Syncing Disks..."
 msgstr ""
+
+msgctxt "#32402"
+msgid "Backup is incomplete. An error occurred. See Kodi log for details."
+msgstr ""

--- a/resources/language/resource.language.fr_ca/strings.po
+++ b/resources/language/resource.language.fr_ca/strings.po
@@ -1174,3 +1174,7 @@ msgstr ""
 msgctxt "#32401"
 msgid "Syncing Disks..."
 msgstr ""
+
+msgctxt "#32402"
+msgid "Backup is incomplete. An error occurred. See Kodi log for details."
+msgstr ""

--- a/resources/language/resource.language.fr_fr/strings.po
+++ b/resources/language/resource.language.fr_fr/strings.po
@@ -1174,3 +1174,7 @@ msgstr "Délai d'inactivité"
 msgctxt "#32401"
 msgid "Syncing Disks..."
 msgstr ""
+
+msgctxt "#32402"
+msgid "Backup is incomplete. An error occurred. See Kodi log for details."
+msgstr ""

--- a/resources/language/resource.language.he_il/strings.po
+++ b/resources/language/resource.language.he_il/strings.po
@@ -1174,3 +1174,7 @@ msgstr ""
 msgctxt "#32401"
 msgid "Syncing Disks..."
 msgstr ""
+
+msgctxt "#32402"
+msgid "Backup is incomplete. An error occurred. See Kodi log for details."
+msgstr ""

--- a/resources/language/resource.language.hu_hu/strings.po
+++ b/resources/language/resource.language.hu_hu/strings.po
@@ -1174,3 +1174,7 @@ msgstr "Tétlenségi Időtúllépés"
 msgctxt "#32401"
 msgid "Syncing Disks..."
 msgstr ""
+
+msgctxt "#32402"
+msgid "Backup is incomplete. An error occurred. See Kodi log for details."
+msgstr ""

--- a/resources/language/resource.language.it_it/strings.po
+++ b/resources/language/resource.language.it_it/strings.po
@@ -1174,3 +1174,7 @@ msgstr ""
 msgctxt "#32401"
 msgid "Syncing Disks..."
 msgstr ""
+
+msgctxt "#32402"
+msgid "Backup is incomplete. An error occurred. See Kodi log for details."
+msgstr ""

--- a/resources/language/resource.language.ja_jp/strings.po
+++ b/resources/language/resource.language.ja_jp/strings.po
@@ -1174,3 +1174,7 @@ msgstr ""
 msgctxt "#32401"
 msgid "Syncing Disks..."
 msgstr ""
+
+msgctxt "#32402"
+msgid "Backup is incomplete. An error occurred. See Kodi log for details."
+msgstr ""

--- a/resources/language/resource.language.ko_kr/strings.po
+++ b/resources/language/resource.language.ko_kr/strings.po
@@ -1174,3 +1174,7 @@ msgstr "가동되지 않은 시간"
 msgctxt "#32401"
 msgid "Syncing Disks..."
 msgstr ""
+
+msgctxt "#32402"
+msgid "Backup is incomplete. An error occurred. See Kodi log for details."
+msgstr ""

--- a/resources/language/resource.language.lt_lt/strings.po
+++ b/resources/language/resource.language.lt_lt/strings.po
@@ -1174,3 +1174,7 @@ msgstr ""
 msgctxt "#32401"
 msgid "Syncing Disks..."
 msgstr ""
+
+msgctxt "#32402"
+msgid "Backup is incomplete. An error occurred. See Kodi log for details."
+msgstr ""

--- a/resources/language/resource.language.lv_lv/strings.po
+++ b/resources/language/resource.language.lv_lv/strings.po
@@ -1174,3 +1174,7 @@ msgstr ""
 msgctxt "#32401"
 msgid "Syncing Disks..."
 msgstr ""
+
+msgctxt "#32402"
+msgid "Backup is incomplete. An error occurred. See Kodi log for details."
+msgstr ""

--- a/resources/language/resource.language.nb_no/strings.po
+++ b/resources/language/resource.language.nb_no/strings.po
@@ -1174,3 +1174,7 @@ msgstr ""
 msgctxt "#32401"
 msgid "Syncing Disks..."
 msgstr ""
+
+msgctxt "#32402"
+msgid "Backup is incomplete. An error occurred. See Kodi log for details."
+msgstr ""

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -1174,3 +1174,7 @@ msgstr "Idle Timeout"
 msgctxt "#32401"
 msgid "Syncing Disks..."
 msgstr ""
+
+msgctxt "#32402"
+msgid "Backup is incomplete. An error occurred. See Kodi log for details."
+msgstr ""

--- a/resources/language/resource.language.pl_pl/strings.po
+++ b/resources/language/resource.language.pl_pl/strings.po
@@ -1174,3 +1174,7 @@ msgstr ""
 msgctxt "#32401"
 msgid "Syncing Disks..."
 msgstr ""
+
+msgctxt "#32402"
+msgid "Backup is incomplete. An error occurred. See Kodi log for details."
+msgstr ""

--- a/resources/language/resource.language.pt_br/strings.po
+++ b/resources/language/resource.language.pt_br/strings.po
@@ -1174,3 +1174,7 @@ msgstr ""
 msgctxt "#32401"
 msgid "Syncing Disks..."
 msgstr ""
+
+msgctxt "#32402"
+msgid "Backup is incomplete. An error occurred. See Kodi log for details."
+msgstr ""

--- a/resources/language/resource.language.pt_pt/strings.po
+++ b/resources/language/resource.language.pt_pt/strings.po
@@ -1174,3 +1174,7 @@ msgstr ""
 msgctxt "#32401"
 msgid "Syncing Disks..."
 msgstr ""
+
+msgctxt "#32402"
+msgid "Backup is incomplete. An error occurred. See Kodi log for details."
+msgstr ""

--- a/resources/language/resource.language.ro_ro/strings.po
+++ b/resources/language/resource.language.ro_ro/strings.po
@@ -1174,3 +1174,7 @@ msgstr ""
 msgctxt "#32401"
 msgid "Syncing Disks..."
 msgstr ""
+
+msgctxt "#32402"
+msgid "Backup is incomplete. An error occurred. See Kodi log for details."
+msgstr ""

--- a/resources/language/resource.language.ru_ru/strings.po
+++ b/resources/language/resource.language.ru_ru/strings.po
@@ -1174,3 +1174,7 @@ msgstr "Таймаут неактивности"
 msgctxt "#32401"
 msgid "Syncing Disks..."
 msgstr ""
+
+msgctxt "#32402"
+msgid "Backup is incomplete. An error occurred. See Kodi log for details."
+msgstr ""

--- a/resources/language/resource.language.sk_sk/strings.po
+++ b/resources/language/resource.language.sk_sk/strings.po
@@ -1174,3 +1174,7 @@ msgstr ""
 msgctxt "#32401"
 msgid "Syncing Disks..."
 msgstr ""
+
+msgctxt "#32402"
+msgid "Backup is incomplete. An error occurred. See Kodi log for details."
+msgstr ""

--- a/resources/language/resource.language.sv_se/strings.po
+++ b/resources/language/resource.language.sv_se/strings.po
@@ -1174,3 +1174,7 @@ msgstr "Timeout"
 msgctxt "#32401"
 msgid "Syncing Disks..."
 msgstr ""
+
+msgctxt "#32402"
+msgid "Backup is incomplete. An error occurred. See Kodi log for details."
+msgstr ""

--- a/resources/language/resource.language.tr_tr/strings.po
+++ b/resources/language/resource.language.tr_tr/strings.po
@@ -1174,3 +1174,7 @@ msgstr ""
 msgctxt "#32401"
 msgid "Syncing Disks..."
 msgstr ""
+
+msgctxt "#32402"
+msgid "Backup is incomplete. An error occurred. See Kodi log for details."
+msgstr ""

--- a/resources/language/resource.language.uk_ua/strings.po
+++ b/resources/language/resource.language.uk_ua/strings.po
@@ -1174,3 +1174,7 @@ msgstr ""
 msgctxt "#32401"
 msgid "Syncing Disks..."
 msgstr ""
+
+msgctxt "#32402"
+msgid "Backup is incomplete. An error occurred. See Kodi log for details."
+msgstr ""

--- a/resources/language/resource.language.zh_cn/strings.po
+++ b/resources/language/resource.language.zh_cn/strings.po
@@ -1174,3 +1174,7 @@ msgstr ""
 msgctxt "#32401"
 msgid "Syncing Disks..."
 msgstr ""
+
+msgctxt "#32402"
+msgid "Backup is incomplete. An error occurred. See Kodi log for details."
+msgstr ""

--- a/resources/language/resource.language.zh_tw/strings.po
+++ b/resources/language/resource.language.zh_tw/strings.po
@@ -1174,3 +1174,7 @@ msgstr ""
 msgctxt "#32401"
 msgid "Syncing Disks..."
 msgstr ""
+
+msgctxt "#32402"
+msgid "Backup is incomplete. An error occurred. See Kodi log for details."
+msgstr ""

--- a/resources/lib/modules/system.py
+++ b/resources/lib/modules/system.py
@@ -568,7 +568,7 @@ class system(modules.Module):
                     tar.add(itempath)
                     if hasattr(self, 'backup_dlg'):
                         progress = round(1.0 * self.done_backup_size / self.total_backup_size * 100)
-                        self.backup_dlg.update(int(progress), f'{folder}\n{item}')
+                        self.backup_dlg.update(int(progress), f'{folder}')
         except:
             self.backup_dlg.close()
             self.backup_dlg = xbmcDialog.ok(oe._(32371), oe._(32402))

--- a/resources/lib/modules/system.py
+++ b/resources/lib/modules/system.py
@@ -480,9 +480,10 @@ class system(modules.Module):
             # Do nothing if the dialog is cancelled - path will be the backup destination
             if not os.path.isfile(restore_file_path):
                 return
+            log.log(f'Restore file: {restore_file_path}', log.INFO)
             restore_file_name = restore_file_path.split('/')[-1]
             if os.path.exists(self.RESTORE_DIR):
-                oe.execute('rm -rf %s' % self.RESTORE_DIR)
+                oe.execute(f'rm -rf {self.RESTORE_DIR}')
             os.makedirs(self.RESTORE_DIR)
             folder_stat = os.statvfs(self.RESTORE_DIR)
             file_size = os.path.getsize(restore_file_path)
@@ -492,7 +493,9 @@ class system(modules.Module):
                     os.remove(self.RESTORE_DIR + restore_file_name)
                 if oe.copy_file(restore_file_path, self.RESTORE_DIR + restore_file_name) != None:
                     copy_success = 1
+                    log.log('Restore file successfully copied.', log.INFO)
                 else:
+                    log.log(f'Failed to copy restore file to: {self.RESTORE_DIR}', log.ERROR)
                     oe.execute(f'rm -rf {self.RESTORE_DIR}')
             else:
                 txt = oe.split_dialog_text(oe._(32379))

--- a/resources/lib/modules/system.py
+++ b/resources/lib/modules/system.py
@@ -464,7 +464,11 @@ class system(modules.Module):
                 self.backup_dlg.update(100, oe._(32401))
                 os.sync()
         finally:
-            self.backup_dlg.close()
+            # possibly already closed by tar_add_folder if an error occurred
+            try:
+                self.backup_dlg.close()
+            except:
+                pass
             self.backup_dlg = None
 
     @log.log_function()
@@ -567,6 +571,7 @@ class system(modules.Module):
                         self.backup_dlg.update(int(progress), f'{folder}\n{item}')
         except:
             self.backup_dlg.close()
+            self.backup_dlg = xbmcDialog.ok('Backup', 'Backup incomplete; an error occurred. See log for details.')
             raise
 
     @log.log_function()

--- a/resources/lib/modules/system.py
+++ b/resources/lib/modules/system.py
@@ -571,7 +571,7 @@ class system(modules.Module):
                         self.backup_dlg.update(int(progress), f'{folder}\n{item}')
         except:
             self.backup_dlg.close()
-            self.backup_dlg = xbmcDialog.ok('Backup', 'Backup incomplete; an error occurred. See log for details.')
+            self.backup_dlg = xbmcDialog.ok(oe._(32371), oe._(32402))
             raise
 
     @log.log_function()

--- a/resources/lib/modules/system.py
+++ b/resources/lib/modules/system.py
@@ -426,6 +426,7 @@ class system(modules.Module):
             try:
                 for directory in self.BACKUP_DIRS:
                     self.get_folder_size(directory)
+                log.log(f'Uncompressed backup size: {total_backup_size}', log.DEBUG)
             except:
                 pass
             bckDir = xbmcDialog.browse( 0,
@@ -435,23 +436,27 @@ class system(modules.Module):
                                         False,
                                         False,
                                         self.BACKUP_DESTINATION )
+            log.log(f'Directory for backup: {bckDir}', log.INFO)
 
             if bckDir and os.path.exists(bckDir):
                 # free space check
                 try:
                     folder_stat = os.statvfs(bckDir)
                     free_space = folder_stat.f_frsize * folder_stat.f_bavail
+                    log.log(f'Available free space for backup: {free_space}', log.DEBUG)
                     if self.total_backup_size > free_space:
                         txt = oe.split_dialog_text(oe._(32379))
                         answer = xbmcDialog.ok('Backup', f'{txt[0]}\n{txt[1]}\n{txt[2]}')
                         return 0
                 except:
+                    log.log('Unable to determine free space available for backup.', log.DEBUG)
                     pass
                 self.backup_dlg = xbmcgui.DialogProgress()
                 self.backup_dlg.create('LibreELEC', oe._(32375))
                 if not os.path.exists(self.BACKUP_DESTINATION):
                     os.makedirs(self.BACKUP_DESTINATION)
                 self.backup_file = f'{oe.timestamp()}.tar'
+                log.log(f'Backup file: {bckDir + self.backup_file}', log.INFO)
                 tar = tarfile.open(bckDir + self.backup_file, 'w', format=tarfile.GNU_FORMAT)
                 for directory in self.BACKUP_DIRS:
                     self.tar_add_folder(tar, directory)
@@ -552,6 +557,7 @@ class system(modules.Module):
                         self.tar_add_folder(tar, itempath)
                 else:
                     self.done_backup_size += os.path.getsize(itempath)
+                    log.log(f'Adding to backup: {itempath}', log.DEBUG)
                     tar.add(itempath)
                     if hasattr(self, 'backup_dlg'):
                         progress = round(1.0 * self.done_backup_size / self.total_backup_size * 100)


### PR DESCRIPTION
This adds logging around the creation and restoration of a backup. This also adds a warning message in Kodi if the backup fails to be made instead of just disappearing.

If the backup fails, this is currently fairly noisy in the log from having the progress window closed. I don't know if there's a better approach. 

Goal is to have something to review for problems like: https://forum.libreelec.tv/thread/23717-le-9-95-1-backup-reboot-libreelec-on-rp4/?postID=152944

Leaving draft until I get to the locales.