### PR TITLE
backup: do not crash when print or log file and path names / fix error detection and remove failed backup

### DIFF
--- a/resources/lib/log.py
+++ b/resources/lib/log.py
@@ -50,3 +50,6 @@ def log_function(level=_DEFAULT):
                 _log(traceback.format_exc(), ERROR)
         return _log_function_2
     return _log_function_1
+
+def utf8ify(pstr):
+    return pstr.encode('utf-8', 'replace').decode('utf-8')

--- a/resources/lib/modules/system.py
+++ b/resources/lib/modules/system.py
@@ -541,6 +541,7 @@ class system(modules.Module):
     @log.log_function()
     def tar_add_folder(self, tar, folder):
         try:
+            print_folder = log.utf8ify(folder)
             for item in os.listdir(folder):
                 if item == self.backup_file:
                     continue
@@ -564,11 +565,11 @@ class system(modules.Module):
                         self.tar_add_folder(tar, itempath)
                 else:
                     self.done_backup_size += os.path.getsize(itempath)
-                    log.log(f'Adding to backup: {itempath}', log.DEBUG)
+                    log.log(f'Adding to backup: {log.utf8ify(itempath)}', log.DEBUG)
                     tar.add(itempath)
                     if hasattr(self, 'backup_dlg'):
                         progress = round(1.0 * self.done_backup_size / self.total_backup_size * 100)
-                        self.backup_dlg.update(int(progress), f'{folder}')
+                        self.backup_dlg.update(int(progress), f'{print_folder}\n{log.utf8ify(item)}')
         except:
             self.backup_dlg.close()
             self.backup_dlg = xbmcDialog.ok(oe._(32371), oe._(32402))


### PR DESCRIPTION
1) Fix possible print crash avoided with 4882595085. The debug log  and printing the folder name may crash too. See comments in commits.

2) Fix error handling in backup: do not continue on error (and create further errors in log). Remove the partial created backup file in this case.
