### PR TITLE
Make channel name parsing more robust

### DIFF
--- a/resources/lib/modules/updates.py
+++ b/resources/lib/modules/updates.py
@@ -352,7 +352,17 @@ class updates(modules.Module):
         b_builder = b_items[0]
 
         if (a_builder == b_builder):
-          return (float(b_items[1]) - float(a_items[1]))
+          try:
+            a_float = float(a_items[1])
+          except:
+            oe.dbg_log('updates::custom_sort_train', f"invalid channel name: '{a}'", oe.LOGWARNING)
+            a_float = 0
+          try:
+            b_float = float(b_items[1])
+          except:
+            oe.dbg_log('updates::custom_sort_train', f"invalid channel name: '{b}'", oe.LOGWARNING)
+            b_float = 0
+          return (b_float - a_float)
         elif (a_builder < b_builder):
           return -1
         elif (a_builder > b_builder):


### PR DESCRIPTION
I tried to name the channel of my custom update channel (in my release.json) sth like `LibreELEC-10.0_(unofficial)`. When opening the settings addon, the list of selecting an channel is empty, because float cast for sort order of `10.0_(unofficial)` fails (obviously).

This MR makes channel order more robust, if channel name does not follow the naming convention `{text}`-`{float}`. Otherwise, a single broken or malicious update channel could break the update function in the addon.

I tested this on pi 4. 