### PR TITLE
regdomain: fix reading stored country code

### DIFF
--- a/resources/lib/regdomain.py
+++ b/resources/lib/regdomain.py
@@ -181,7 +181,7 @@ REGDOMAIN_LIST = [REGDOMAIN_DEFAULT] + [
 def get_regdomain():
     if not os.path.isfile(config.REGDOMAIN_CONF):
         return REGDOMAIN_DEFAULT
-    code = open(config.REGDOMAIN_CONF).readline().rstrip()[-2:]
+    code = '(' + open(config.REGDOMAIN_CONF).readline().rstrip()[-2:] + ')'
     regdomain = next((l for l in REGDOMAIN_LIST if code in l),
                      REGDOMAIN_DEFAULT)
     return regdomain


### PR DESCRIPTION
When reading configured regulatory domain from `/storage/.cache/regdomain.conf` the two letter country code is matched against the list of country names. First entry is `NOT SET (DEFAULT)` resulting in false positive matches for NO, SE, ET, DE, AU and LT.

Add brackets (again) around the country code to fix the match.

Bug was reported in the forum:
https://forum.libreelec.tv/thread/24303-i-can-t-set-the-wireless-regulatory-domain-to-germany/
https://forum.libreelec.tv/thread/23676-libreelec-10-beta-5ghz-wifi-issue/
