### PR TITLE
backup: avoid printing unicode characters beside ASCII / Fix python error in get_setting()

### DIFF
--- a/resources/lib/log.py
+++ b/resources/lib/log.py
@@ -85,3 +85,6 @@ def log_function(level=_DEFAULT):
 
 def utf8ify(pstr):
     return pstr.encode('utf-8', 'replace').decode('utf-8')
+
+def asciify(pstr):
+    return pstr.encode('ascii', 'replace').decode('utf-8')

--- a/resources/lib/modules/system.py
+++ b/resources/lib/modules/system.py
@@ -602,7 +602,7 @@ class system(modules.Module):
     @log.log_function()
     def tar_add_folder(self, tar, folder):
         try:
-            print_folder = log.utf8ify(folder)
+            print_folder = log.asciify(folder)
             for item in os.listdir(folder):
                 if item == self.backup_file:
                     continue
@@ -624,11 +624,11 @@ class system(modules.Module):
                             return
                 else:
                     self.done_backup_size += os.path.getsize(itempath)
-                    log.log(f'Adding to backup: {log.utf8ify(itempath)}', log.DEBUG)
+                    log.log(f'Adding to backup: {log.asciify(itempath)}', log.DEBUG)
                     tar.add(itempath)
                     if hasattr(self, 'backup_dlg'):
                         progress = round(1.0 * self.done_backup_size / self.total_backup_size * 100)
-                        self.backup_dlg.update(int(progress), f'{print_folder}\n{log.utf8ify(item)}')
+                        self.backup_dlg.update(int(progress), f'{print_folder}\n{log.asciify(item)}')
         except:
             self.backup_dlg.close()
             self.backup_dlg = None

--- a/resources/lib/modules/system.py
+++ b/resources/lib/modules/system.py
@@ -319,7 +319,7 @@ class system(modules.Module):
 
     def get_setting(self, group, setting, allowEmpty=False):
         value = oe.read_setting('system', setting)
-        if not value is None and not (allowEmpty == False and value is ''):
+        if not value is None and not (allowEmpty == False and value == ''):
             self.struct[group]['settings'][setting]['value'] = value
 
     @log.log_function()


### PR DESCRIPTION
Reported in [forum](https://forum.libreelec.tv/thread/23717-le-9-95-1-backup-reboot-libreelec-on-rp4/?postID=160400#post160400): Kodi on RPI4 may crash when rendering some Unicode characters. I was not able to reproduce the crash on Generic.

Only printing ASCII characters avoid the issue. 

Successful tested by the affected user.

---

Second commit is to fix python error:
```
ERROR <general>: */system.py:322: SyntaxWarning: "is" with a literal. Did you mean "=="?
```