### PR TITLE
service_set_autoconnect(): check used parameters '0' and '1'

### DIFF
--- a/resources/lib/dbus_connman.py
+++ b/resources/lib/dbus_connman.py
@@ -166,7 +166,7 @@ def service_remove(path):
 
 
 def service_set_autoconnect(path, autoconnect):
-    autoconnect = True if autoconnect == True else False
+    autoconnect = True if autoconnect == '1' else False
     return service_set_property(path, 'AutoConnect', (dbussy.DBUS.Signature('b'), autoconnect))
 
 


### PR DESCRIPTION
Fix connman autoconnect is always disabled when saved.

Reported multiple times in the forum, e.g.:
https://forum.libreelec.tv/thread/24297-9-97-1-rpi4-ethernet-issue/
https://forum.libreelec.tv/thread/24271-libreleec-9-97-1-10-0-matrix-networking-not-connecting-automatically/
