### PR TITLE
Add bluetooth autoconnect ability

### DIFF
--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -1016,6 +1016,14 @@ msgctxt "#32390"
 msgid "Settings addon is not yet ready, please try again later."
 msgstr ""
 
+msgctxt "#32391"
+msgid "Disable autoconnect"
+msgstr ""
+
+msgctxt "#32392"
+msgid "Enable autoconnect"
+msgstr ""
+
 msgctxt "#32393"
 msgid "** SAFE MODE! ** SAFE MODE! ** SAFE MODE! **"
 msgstr ""

--- a/resources/language/resource.language.fr_fr/strings.po
+++ b/resources/language/resource.language.fr_fr/strings.po
@@ -1147,6 +1147,14 @@ msgctxt "#32390"
 msgid "Settings addon is not yet ready, please try again later."
 msgstr "Le greffon des paramètres n'est pas encore prêt, veuillez ré-essayer plus tard."
 
+msgctxt "#32391"
+msgid "Disable autoconnect"
+msgstr "Désactiver l'autoconnexion"
+
+msgctxt "#32392"
+msgid "Enable autoconnect"
+msgstr "Activer l'autoconnexion"
+
 msgctxt "#32393"
 msgid "** SAFE MODE! ** SAFE MODE! ** SAFE MODE! **"
 msgstr "** MODE SANS ÉCHEC! ** MODE SANS ÉCHEC! ** MODE SANS ÉCHEC! **"

--- a/resources/lib/dbus_bluez.py
+++ b/resources/lib/dbus_bluez.py
@@ -178,6 +178,10 @@ def device_get_connected(path):
     return device_get_property(path, 'Connected')
 
 
+def device_get_trusted(path):
+    return device_get_property(path, 'Trusted')
+
+
 def device_connect(path):
     return dbus_utils.run_method(BUS_NAME, path, INTERFACE_DEVICE, 'Connect')
 

--- a/resources/lib/oe.py
+++ b/resources/lib/oe.py
@@ -637,6 +637,15 @@ def standby_devices():
     except Exception as e:
         dbg_log('oe::standby_devices', f'ERROR: ({repr(e)})')
 
+def autoconnect_devices():
+    global dictModules
+    try:
+        if 'bluetooth' in dictModules:
+            dictModules['bluetooth'].autoconnect_devices()
+    except Exception as e:
+        dbg_log('oe::autoconnect_devices', f'ERROR: ({repr(e)})')
+
+
 def load_config():
     try:
         global conf_lock

--- a/service.py
+++ b/service.py
@@ -81,23 +81,24 @@ class Monitor(xbmc.Monitor):
         oe.start_service()
         service_thread = Service_Thread()
         service_thread.start()
+        oe.autoconnect_devices()
         while not self.abortRequested():
-            if self.waitForAbort(60):
+            if self.waitForAbort(30):
                 break
-            if not oe.read_setting('bluetooth', 'standby'):
-                continue
-            timeout = oe.read_setting('bluetooth', 'idle_timeout')
-            if not timeout:
-                continue
-            try:
-                timeout = int(timeout)
-            except:
-                continue
-            if timeout < 1:
-                continue
-            if xbmc.getGlobalIdleTime() / 60 >= timeout:
-                log.log(f'Idle timeout reached', log.DEBUG)
+            standby_devices = oe.read_setting('bluetooth', 'standby')
+            autoconnect_devices = oe.read_setting('bluetooth', 'autoconnect')
+            timeout = None
+            if standby_devices:
+                try:
+                    timeout = int(oe.read_setting('bluetooth', 'idle_timeout'))
+                except TypeError:
+                    pass
+            if timeout and xbmc.getGlobalIdleTime() / 60 >= timeout:
+                log.log('Idle timeout reached', log.DEBUG)
                 oe.standby_devices()
+            else:
+                log.log('Autoconnect triggered', log.DEBUG)
+                oe.autoconnect_devices()
         if hasattr(oe, 'winOeMain') and hasattr(oe.winOeMain, 'visible'):
             if oe.winOeMain.visible == True:
                 oe.winOeMain.close()


### PR DESCRIPTION
Hi, 
in this patch I propose an "auto-connection" option for bluetooth devices.

Theoretically the auto-connection of Paired and Trusted devices is done without any intervention by the user.

Some resources on this subject as a reminder:
https://wiki.archlinux.org/title/Bluetooth#Auto_power-on_after_boot
https://wiki.archlinux.org/title/Bluetooth_headset#Setting_up_auto_connection
https://wiki.archlinux.org/title/bluetooth#Audio
https://askubuntu.com/questions/589885/automatically-switch-sound-output-device-to-bluetooth-headset-force-to-a2dp-pr


However on some hardware (computer or devices), the connection is not done, or succeeded with a high failure rate.

Personally on an AsusK75 and speakers "Creative T12 Wireless", the success rate is about 2/10 when I press the association button on the speakers.
Also, if the speakers are turned on before the computer, the computer has no chance to connect to them.


Many people have these problems and rely on solutions like this one:
https://github.com/jrouleau/bluetooth-autoconnect/blob/master/bluetooth-autoconnect
=> basically a script that lists trusted devices at regular intervals and initiates a blind connection.

It is important to mention that the implementation under Windows is radically different from the one under GNU/Linux because the devices are instantly hooked in all situations. This behavior is similar to what the above mentioned script offers.


So I have added the autoconnect option for any device that has been added manually.
It works similarly to the "standby" option already present.

The search interval is currently 30 seconds (this is probably too long and open to discussion).