### PR TITLE
Fix it_it language

### DIFF
--- a/resources/language/resource.language.it_it/strings.po
+++ b/resources/language/resource.language.it_it/strings.po
@@ -57,7 +57,7 @@ msgid "Architecture: "
 msgstr "Architettura: "
 
 msgctxt "#609"
-msgid "LibreELEC is created by a global team of Linux and Kodi enthusiasts who"contribute time and effort to manage the project, write code, and provide support. We have fun making it. We hope you have fun using it!"
+msgid "LibreELEC is created by a global team of Linux and Kodi enthusiasts who contribute time and effort to manage the project, write code, and provide support. We have fun making it. We hope you have fun using it!"
 msgstr "LibreELEC è realizzato da un team globale di appassionati di Linux e Kodi che donano tempo e sforzi per gestire il progetto, scrivere codice e fornire supporto. Noi ci divertiamo a farlo. Speriamo voi vi divertiate ad usarlo!"
 
 msgctxt "#610"


### PR DESCRIPTION
This fixes it_it language.
It contains an extra `"` introduced here: 
https://github.com/LibreELEC/service.libreelec.settings/pull/262/files#diff-a59f2957e4233e6231d9ed22a2a1ed668d3815f1e1624f86814e1f96074eb724R60

@CvH @chewitt Please merge https://github.com/LibreELEC/service.libreelec.settings/pull/267 first.
Weblate will probably do a new PR after merging this PR.