### PR TITLE
Rework system upgrade check

### DIFF
--- a/resources/lib/defaults.py
+++ b/resources/lib/defaults.py
@@ -87,7 +87,7 @@ system = {
 updates = {
     'ENABLED': not os.path.exists('/dev/.update_disabled'),
     'UPDATE_REQUEST_URL': 'https://update.libreelec.tv/updates.php',
-    'UPDATE_DOWNLOAD_URL': 'http://%s.libreelec.tv/%s',
+    'UPDATE_DOWNLOAD_URL': 'https://releases.libreelec.tv/releases.json',
     'LOCAL_UPDATE_DIR': '/storage/.update/',
 
     'RPI_FLASHING_TRIGGER': '/storage/.rpi_flash_firmware',

--- a/resources/lib/defaults.py
+++ b/resources/lib/defaults.py
@@ -86,7 +86,7 @@ system = {
 
 updates = {
     'ENABLED': not os.path.exists('/dev/.update_disabled'),
-    'UPDATE_REQUEST_URL': 'https://update.libreelec.tv/updates.php',
+    'STATISTICS_SUBMISSION_URL': 'https://update.libreelec.tv/updates.php',
     'UPDATE_DOWNLOAD_URL': 'https://releases.libreelec.tv/releases.json',
     'LOCAL_UPDATE_DIR': '/storage/.update/',
 

--- a/resources/lib/modules/updates.py
+++ b/resources/lib/modules/updates.py
@@ -611,7 +611,13 @@ class updates(modules.Module):
         if bugfix_filename_version_bugfix > version_bugfix:
 
             update_url = release_data[f'{oe.DISTRIBUTION}-{oe.VERSION_ID}']['url']
-            self.update_file = f'{update_url}{bugfix_filename}'
+            bugfix_filename_subpath = ''
+            try:
+                bugfix_filename_subpath = release_data[f'{oe.DISTRIBUTION}-{oe.VERSION_ID}']['project'][oe.ARCHITECTURE]['releases'][highest_device_release]['file']['subpath']
+                # TODO see if presence of subpath may be assumed after LE11 releases
+            except KeyError:
+                pass
+            self.update_file = f'{update_url}{bugfix_filename_subpath}/{bugfix_filename}'
             log.log(f'Found update file: {self.update_file}', log.INFO)
 
             # show update available notification

--- a/resources/lib/modules/updates.py
+++ b/resources/lib/modules/updates.py
@@ -25,7 +25,7 @@ class updates(modules.Module):
 
     ENABLED = False
     KERNEL_CMD = None
-    UPDATE_REQUEST_URL = None
+    STATISTICS_SUBMISSION_URL = None
     UPDATE_DOWNLOAD_URL = None
     LOCAL_UPDATE_DIR = None
     menu = {'2': {
@@ -567,16 +567,16 @@ class updates(modules.Module):
             version = oe.BUILDER_VERSION
         else:
             version = oe.VERSION
-        url = f'{self.UPDATE_REQUEST_URL}?i={oe.url_quote(systemid)}&d={oe.url_quote(oe.DISTRIBUTION)}&pa={oe.url_quote(oe.ARCHITECTURE)}&v={oe.url_quote(version)}&f={oe.url_quote(self.hardware_flags)}'
+        url = f'{self.STATISTICS_SUBMISSION_URL}?i={oe.url_quote(systemid)}&d={oe.url_quote(oe.DISTRIBUTION)}&pa={oe.url_quote(oe.ARCHITECTURE)}&v={oe.url_quote(version)}&f={oe.url_quote(self.hardware_flags)}'
         if oe.BUILDER_NAME:
             url += f'&b={oe.url_quote(oe.BUILDER_NAME)}'
 
         log.log(f'URL: {url}', log.DEBUG)
-        update_json = oe.load_url(url)
-        log.log(f'RESULT: {repr(update_json)}', log.DEBUG)
+        statistics_submission = oe.load_url(url)
+        log.log(f'RESULT: {repr(statistics_submission)}', log.DEBUG)
 
-        # statistics sent to UPDATE_REQUEST_URL, but discard the response.
-        update_json = None
+        # statistics sent to STATISTICS_SUBMISSION_URL, but discard the response.
+        statistics_submission = None
 
         # devel versions manage their own updates
         if oe.VERSION.startswith('devel'):

--- a/resources/lib/modules/updates.py
+++ b/resources/lib/modules/updates.py
@@ -579,8 +579,8 @@ class updates(modules.Module):
         update_json = None
 
         # devel versions manage their own updates
-        if oe.VERSION.startswith("devel"):
-            log.log("Update check skipped because this is a development build.", log.INFO)
+        if oe.VERSION.startswith('devel'):
+            log.log('Update check skipped because this is a development build.', log.INFO)
             self.last_update_check = time.time()
             return
 
@@ -589,37 +589,37 @@ class updates(modules.Module):
         self.last_update_check = time.time()
 
         # releases.json is empty
-        if release_data is None:
-            log.log("releases.json is empty. Failed to retrieve?", log.WARNING)
+        if not release_data:
+            log.log('releases.json is empty. Failed to retrieve?', log.WARNING)
             return
 
         # parse installed VERSION for comparison
-        version_major = int(oe.VERSION.split(".")[0])
-        version_minor = int(oe.VERSION.split(".")[1])
-        version_bugfix = int(oe.VERSION.split(".")[2])
+        version_major = int(oe.VERSION.split('.')[0])
+        version_minor = int(oe.VERSION.split('.')[1])
+        version_bugfix = int(oe.VERSION.split('.')[2])
 
         # check highest bugfix release of installed branch
-        highest_device_release = get_highest_value(release_data[f"{oe.DISTRIBUTION}-{oe.VERSION_ID}"]['project'][oe.ARCHITECTURE]['releases'].keys())
+        highest_device_release = get_highest_value(release_data[f'{oe.DISTRIBUTION}-{oe.VERSION_ID}']['project'][oe.ARCHITECTURE]['releases'].keys())
 
-        bugfix_filename = release_data[f"{oe.DISTRIBUTION}-{oe.VERSION_ID}"]['project'][oe.ARCHITECTURE]['releases'][highest_device_release]['file']['name']
+        bugfix_filename = release_data[f'{oe.DISTRIBUTION}-{oe.VERSION_ID}']['project'][oe.ARCHITECTURE]['releases'][highest_device_release]['file']['name']
         # assumes filename format is "distribution-device.arch-version.tar"
         bugfix_filename_version = self.rchop(bugfix_filename.split('-')[2], '.tar')
-        bugfix_filename_version_bugfix = int(bugfix_filename_version.split(".")[2])
-#        bugfix_filename_sha256 = release_data[f"{oe.DISTRIBUTION}-{oe.VERSION_ID}"]['project'][oe.ARCHITECTURE]['releases'][highest_device_release]['file']['sha256']
+        bugfix_filename_version_bugfix = int(bugfix_filename_version.split('.')[2])
+#        bugfix_filename_sha256 = release_data[f'{oe.DISTRIBUTION}-{oe.VERSION_ID}']['project'][oe.ARCHITECTURE]['releases'][highest_device_release]['file']['sha256']
 
         # bugfix upgrade within same branch
         if bugfix_filename_version_bugfix > version_bugfix:
 
-            update_url = release_data[f"{oe.DISTRIBUTION}-{oe.VERSION_ID}"]["url"]
-            self.update_file = f"{update_url}{bugfix_filename}"
-            log.log(f"Found update file: {self.update_file}", log.INFO)
+            update_url = release_data[f'{oe.DISTRIBUTION}-{oe.VERSION_ID}']['url']
+            self.update_file = f'{update_url}{bugfix_filename}'
+            log.log(f'Found update file: {self.update_file}', log.INFO)
 
             # show update available notification
             if self.struct['update']['settings']['UpdateNotify']['value'] == '1':
                 oe.notify(oe._(32363), oe._(32364))
             # if automatic update is enabled, start it
             if self.struct['update']['settings']['AutoUpdate']['value'] == 'auto' and force == False:
-                log.log("Starting automatic update...", log.INFO)
+                log.log('Starting automatic update...', log.INFO)
                 self.update_in_progress = True
                 self.do_autoupdate(None, True)
                 return
@@ -633,8 +633,8 @@ class updates(modules.Module):
 
         for os_branch in release_data.keys():
             key_version = self.lchop(os_branch, f'{oe.DISTRIBUTION}-')
-            key_version_major = int(key_version.split(".")[0])
-            key_version_minor = int(key_version.split(".")[1])
+            key_version_major = int(key_version.split('.')[0])
+            key_version_minor = int(key_version.split('.')[1])
 
             if key_version_major > highest_version_major:
                 highest_version_major = key_version_major
@@ -642,11 +642,11 @@ class updates(modules.Module):
             elif key_version_major == highest_version_major and key_version_minor > highest_version_minor:
                 highest_version_minor = key_version_minor
 
-        release_branch = f"{oe.DISTRIBUTION}-{highest_version_major}.{highest_version_minor}"
+        release_branch = f'{oe.DISTRIBUTION}-{highest_version_major}.{highest_version_minor}'
 
         # check if installed project/device is in the release_branch series
         if not oe.ARCHITECTURE in release_data[release_branch]['project'].keys():
-            log.log(f"Device not found in releases.json: {oe.ARCHITECTURE}", log.WARNING)
+            log.log(f'Device not found in releases.json: {oe.ARCHITECTURE}', log.WARNING)
             return
 
         # determine highest 'releases' for device
@@ -658,16 +658,16 @@ class updates(modules.Module):
 #        update_filename_sha256 = release_data[release_branch]['project'][oe.ARCHITECTURE]['releases'][highest_device_release]['file']['sha256']
 
         # if a release is available on a newer branch, notify the user
-        update_filename_version_major = int(update_filename_version.split(".")[0])
-        update_filename_version_minor = int(update_filename_version.split(".")[1])
-#        update_filename_version_bugfix = int(update_filename_version.split(".")[2])
+        update_filename_version_major = int(update_filename_version.split('.')[0])
+        update_filename_version_minor = int(update_filename_version.split('.')[1])
+#        update_filename_version_bugfix = int(update_filename_version.split('.')[2])
 
         # Current to a major or minor version upgrade
         if ((update_filename_version_major > version_major) or \
             (update_filename_version_major == version_major and update_filename_version_minor > version_minor)):
 
-            update_url = release_data[release_branch]["url"]
-            log.log(f"Found update file: {update_url}{update_filename}", log.INFO)
+            update_url = release_data[release_branch]['url']
+            log.log(f'Found update file: {update_url}{update_filename}', log.INFO)
 
             # show update available notification
             if self.struct['update']['settings']['UpdateNotify']['value'] == '1':

--- a/resources/lib/modules/updates.py
+++ b/resources/lib/modules/updates.py
@@ -427,7 +427,7 @@ class updates(modules.Module):
     def get_json(self, url=None):
         """Download and extract data from a releases.json file. Complete the URL if necessary."""
         if not url:
-            url = self.UPDATE_DOWNLOAD_URL % ('releases', 'releases.json')
+            url = self.UPDATE_DOWNLOAD_URL
         if not url.startswith('http://') and not url.startswith('https://'):
             url = f'https://{url}'
         if not url.endswith('releases.json'):

--- a/resources/lib/modules/updates.py
+++ b/resources/lib/modules/updates.py
@@ -579,8 +579,8 @@ class updates(modules.Module):
         statistics_submission = None
 
         # devel versions manage their own updates
-        if oe.VERSION.startswith('devel'):
-            log.log('Update check skipped because this is a development build.', log.INFO)
+        if oe.VERSION.startswith('devel') or 'nightly' in oe.VERSION:
+            log.log('Update check skipped on nightly or development builds.', log.INFO)
             self.last_update_check = time.time()
             return
 

--- a/resources/lib/oe.py
+++ b/resources/lib/oe.py
@@ -885,15 +885,15 @@ def parse_os_release():
 
 
 def get_os_release():
-    distribution = version = architecture = build = project = device = builder_name = builder_version = ''
+    distribution = version = version_id = architecture = build = project = device = builder_name = builder_version = ''
     os_release_info = parse_os_release()
     if os_release_info is not None:
         if 'NAME' in os_release_info:
             distribution = os_release_info['NAME']
-        if 'VERSION_ID' in os_release_info:
-            version = os_release_info['VERSION_ID']
         if 'VERSION' in os_release_info:
             version = os_release_info['VERSION']
+        if 'VERSION_ID' in os_release_info:
+            version_id = os_release_info['VERSION_ID']
         if 'LIBREELEC_ARCH' in os_release_info:
             architecture = os_release_info['LIBREELEC_ARCH']
         if 'LIBREELEC_BUILD' in os_release_info:
@@ -909,6 +909,7 @@ def get_os_release():
         return (
             distribution,
             version,
+            version_id,
             architecture,
             build,
             project,
@@ -926,12 +927,13 @@ minidom.Element.writexml = fixed_writexml
 os_release_data = get_os_release()
 DISTRIBUTION = os_release_data[0]
 VERSION = os_release_data[1]
-ARCHITECTURE = os_release_data[2]
-BUILD = os_release_data[3]
-PROJECT = os_release_data[4]
-DEVICE = os_release_data[5]
-BUILDER_NAME = os_release_data[6]
-BUILDER_VERSION = os_release_data[7]
+VERSION_ID = os_release_data[2]
+ARCHITECTURE = os_release_data[3]
+BUILD = os_release_data[4]
+PROJECT = os_release_data[5]
+DEVICE = os_release_data[6]
+BUILDER_NAME = os_release_data[7]
+BUILDER_VERSION = os_release_data[8]
 DOWNLOAD_DIR = '/storage/downloads'
 XBMC_USER_HOME = os.environ.get('XBMC_USER_HOME', '/storage/.kodi')
 CONFIG_CACHE = os.environ.get('CONFIG_CACHE', '/storage/.cache')


### PR DESCRIPTION
This does a minor cleanup, and then enhances how the addon checks for LE system upgrades.

The cleanup is to convert from oe.dbg_log() to log.log() when writing to kodi's log. 

The change to the update check is as follows:

Submit information on device and statistics (if enabled).
Discard what server responds with for an update file.
Read LE's releases.json
If a device is running a development version (eg self-built), don't bother checking anything
If there is a bugfix release available (eg 10.0.1 -> 10.0.2), then show an notification (if enabled) and perform an an automatic upgrade (if enabled)
If there is a major/minor upgrade (9.0.x -> 9.2.x or 9.0.x -> 10.x), then show a notification (if enabled)

A device needs to be caught up on bugfix releases before it will notify about a major upgrade.

I've done some testing with how an RPi would update via version spoofing (my device is on self-built). I need feedback on what update file a uboot device will use. Will a `LibreELEC-A64.arm-10.0.2.tar` file upgrade any A64 device, for example?

Some further cleanup may be possible, but I need to know it's functionally complete before I try to reduce it.