### PR TITLE
Filter Update channels older than current version

### DIFF
--- a/resources/lib/modules/updates.py
+++ b/resources/lib/modules/updates.py
@@ -388,7 +388,20 @@ class updates(modules.Module):
         log.log(str(self.update_json), log.DEBUG)
         if self.update_json:
             for channel in self.update_json:
-                channels.append(channel)
+                # filter versions older than current; just add when unknown
+                try:
+                    channel_version = channel.split('-')[1]
+                except IndexError:
+                    channel_version = False
+                if channel_version and channel_version.replace('.','',1).isdigit():
+                    channel_version = float(channel_version)
+                else:
+                    channel_version = False
+                if channel_version:
+                    if float(oe.VERSION_ID) <= channel_version:
+                        channels.append(channel)
+                else:
+                    channels.append(channel)
         return sorted(list(set(channels)), key=cmp_to_key(self.custom_sort_train))
 
     @log.log_function()

--- a/resources/lib/oe.py
+++ b/resources/lib/oe.py
@@ -885,15 +885,15 @@ def parse_os_release():
 
 
 def get_os_release():
-    distribution = version = architecture = build = project = device = builder_name = builder_version = ''
+    distribution = version = version_id = architecture = build = project = device = builder_name = builder_version = ''
     os_release_info = parse_os_release()
     if os_release_info is not None:
         if 'NAME' in os_release_info:
             distribution = os_release_info['NAME']
-        if 'VERSION_ID' in os_release_info:
-            version = os_release_info['VERSION_ID']
         if 'VERSION' in os_release_info:
             version = os_release_info['VERSION']
+        if 'VERSION_ID' in os_release_info:
+            version_id = os_release_info['VERSION_ID']
         if 'LIBREELEC_ARCH' in os_release_info:
             architecture = os_release_info['LIBREELEC_ARCH']
         if 'LIBREELEC_BUILD' in os_release_info:
@@ -909,6 +909,7 @@ def get_os_release():
         return (
             distribution,
             version,
+            version_id,
             architecture,
             build,
             project,
@@ -926,12 +927,13 @@ minidom.Element.writexml = fixed_writexml
 os_release_data = get_os_release()
 DISTRIBUTION = os_release_data[0]
 VERSION = os_release_data[1]
-ARCHITECTURE = os_release_data[2]
-BUILD = os_release_data[3]
-PROJECT = os_release_data[4]
-DEVICE = os_release_data[5]
-BUILDER_NAME = os_release_data[6]
-BUILDER_VERSION = os_release_data[7]
+VERSION_ID = os_release_data[2]
+ARCHITECTURE = os_release_data[3]
+BUILD = os_release_data[4]
+PROJECT = os_release_data[5]
+DEVICE = os_release_data[6]
+BUILDER_NAME = os_release_data[7]
+BUILDER_VERSION = os_release_data[8]
 DOWNLOAD_DIR = '/storage/downloads'
 XBMC_USER_HOME = os.environ.get('XBMC_USER_HOME', '/storage/.kodi')
 CONFIG_CACHE = os.environ.get('CONFIG_CACHE', '/storage/.cache')


### PR DESCRIPTION
This alters the update channels users are able to select in manual updates by removing channels that belong to versions older than what the device is running. A device on LE10 will see the LE10 + LE11 channel, but not LE7 -> LE9, for example.

This exposes `/etc/os-releases`'s VERSION_ID to the addon in order to establish the running version. I'm not sure why oe.VERSION was being set to VERSION_ID and then being changed to VERSION, if present. The implication is that VERSION wasn't always there. It's been in the image building at least 4 years, so it's present in releases that'll see this change.

This relies on the naming scheme of LE's release.json's channels, so a custom channel may bypass it. The filter is simple, comparing a channel named `$something-$version` and checking `$version` against VERSION_ID.