### PR TITLE
Fixes, including working bluetooth PinKey window

### DIFF
--- a/resources/lib/dbus_utils.py
+++ b/resources/lib/dbus_utils.py
@@ -44,8 +44,8 @@ class Agent(object):
 
     @log.log_function()
     def unregister_agent(self):
-        BUS.unregister(path=self.path_agent)
         self.manager_unregister_agent()
+        BUS.unregister(path=self.path_agent)
 
     def manager_register_agent(self):
         pass

--- a/resources/lib/modules/bluetooth.py
+++ b/resources/lib/modules/bluetooth.py
@@ -273,7 +273,7 @@ class bluetooth(modules.Module):
     @log.log_function()
     def menu_connections(self, focusItem=None):
         self.discover_devices()
-        if not hasattr(self, 'discovery_thread') or self.discovery_thread.stopped:
+        if self.dbusBluezAdapter is not None and (not hasattr(self, 'discovery_thread') or self.discovery_thread.stopped):
             if hasattr(self, 'discovery_thread') and self.discovery_thread.stopped:
                 del self.discovery_thread
             self.start_discovery()

--- a/resources/lib/modules/bluetooth.py
+++ b/resources/lib/modules/bluetooth.py
@@ -360,7 +360,10 @@ class bluetooth(modules.Module):
                 if dbusDevice in self.listItems:
                     self.listItems[dbusDevice].setLabel(apName)
                     for dictProperty in dictProperties:
-                        self.listItems[dbusDevice].setProperty(dictProperty, dictProperties[dictProperty])
+                        try:
+                            self.listItems[dbusDevice].setProperty(dictProperty, dictProperties[dictProperty])
+                        except KeyError as e:
+                            log.log(f'Suppressed error: {repr(e)}', log.INFO)
 
     @log.log_function()
     def open_context_menu(self, listItem):

--- a/resources/lib/modules/bluetooth.py
+++ b/resources/lib/modules/bluetooth.py
@@ -697,7 +697,6 @@ class discoveryThread(threading.Thread):
 
 class pinkeyTimer(threading.Thread):
 
-    @log.log_function()
     def __init__(self, parent, runtime=60):
         self.parent = weakref.proxy(parent)
         self.start_time = time.time()

--- a/resources/lib/modules/bluetooth.py
+++ b/resources/lib/modules/bluetooth.py
@@ -90,7 +90,8 @@ class bluetooth(modules.Module):
 
     @log.log_function()
     def stop_service(self):
-        self.bluez_agent.unregister_agent()
+        if hasattr(self, 'dbusBluezAdapter') and self.dbusBluezAdapter is not None:
+            self.bluez_agent.unregister_agent()
         if hasattr(self, 'discovery_thread'):
             try:
                 self.discovery_thread.stop()

--- a/resources/lib/modules/connman.py
+++ b/resources/lib/modules/connman.py
@@ -272,7 +272,7 @@ class connmanService(object):
             for (key, value) in self.datamap[entry].items():
                 if self.struct[value]['type'] == 'Boolean':
                     if key in self.service_properties:
-                        self.struct[value]['settings'][value]['value'] = self.service_properties[key]
+                        self.struct[value]['settings'][value]['value'] = str(self.service_properties[key])
                 if self.struct[value]['type'] == 'Dictionary':
                     if key in self.service_properties:
                         for setting in self.struct[value]['settings']:


### PR DESCRIPTION
Some fixes, mostly oneliner.

### dbus_utils.py: BUS must be unregistered last

BUS can be used in manager_unregister_agent()

Fix for:

```
2022-09-17 19:04:32.815 T:1363    error <general>: SETTINGS: Agent.unregister_agent 
                                                   *********************************** Unhandled exception detected ***********************************
                                                   ####################################################################################################
                                                                                              Diagnostic info
                                                   ----------------------------------------------------------------------------------------------------
                                                   Exception type  : DBusError
                                                   Exception value : org.freedesktop.DBus.Error.ServiceUnknown -- The name org.bluez was not provided by any .service files
                                                   System info     : uname_result(system='Linux', node='le10mars', release='5.10.142', version='#1 SMP Sat Sep 10 17:06:14 UTC 2022', machine='x86_64', processor='')
                                                   Python version  : 3.8.9 (default, Oct 13 2021, 13:15:24)  [GCC 10.2.0]
                                                   Kodi version    : 19.4 (19.4.0) Git:aac12f6fc42510b9fed6aea9cbfa9f07c41e379e
                                                   sys.argv        : ['']
                                                   ----------------------------------------------------------------------------------------------------
                                                   sys.path:
                                                   ['/storage/.kodi/addons/service.libreelec.settings',
                                                    '/usr/lib/python38.zip',
                                                    '/usr/lib/python3.8',
                                                    '/usr/lib/python3.8/lib-dynload',
                                                    '/usr/lib/python3.8/site-packages',
                                                    '/storage/.kodi/addons/service.libreelec.settings/resources/lib',
                                                    '/storage/.kodi/addons/service.libreelec.settings/resources/lib/modules']
                                                   
                                                   ####################################################################################################
                                                                                               Stack Trace
                                                   ====================================================================================================
                                                   File:
                                                   /storage/.kodi/addons/service.libreelec.settings/service.py:110
                                                   ----------------------------------------------------------------------------------------------------
                                                   Code context:
                                                     106:         dbus_utils.LOOP_THREAD.stop()
                                                     107: 
                                                     108: 
                                                     109: if __name__ == '__main__':
                                                     110:>    Monitor().run()
                                                   
                                                   ----------------------------------------------------------------------------------------------------
                                                   Local variables:
                                                   Monitor = <class '__main__.Monitor'>
                                                   Service_Thread = <class '__main__.Service_Thread'>
                                                   dbus_utils = <module 'dbus_utils' from '/storage/.kodi/addons/service.libreelec.settings/resources/lib/dbus_utils.py'>
                                                   log = <module 'log' from '/storage/.kodi/addons/service.libreelec.settings/resources/lib/log.py'>
                                                   oe = <module 'oe' from '/storage/.kodi/addons/service.libreelec.settings/resources/lib/oe.py'>
                                                   os = <module 'os' from '/usr/lib/python3.8/os.pyc'>
                                                   socket = <module 'socket' from '/usr/lib/python3.8/socket.pyc'>
                                                   sys = <module 'sys' (built-in)>
                                                   syspath = <module 'syspath' from '/storage/.kodi/addons/service.libreelec.settings/syspath.py'>
                                                   threading = <module 'threading' from '/usr/lib/python3.8/threading.pyc'>
                                                   xbmc = <module 'xbmc' (built-in)>
                                                   xbmcout = <class '__main__.xbmcout'>
                                                   ====================================================================================================
                                                   File:
                                                   /storage/.kodi/addons/service.libreelec.settings/resources/lib/log.py:69
                                                   ----------------------------------------------------------------------------------------------------
                                                   Code context:
                                                      67:                 for key, value in kwargs.items():
                                                      68:                     _log(f'{header}< {key}={pprint.pformat(value)}', level)
                                                      69:>                result = function(*args, **kwargs)
                                                      70:                 _log(f'{header}> {pprint.pformat(result)}', level)
                                                      71:                 return result
                                                   
                                                   ----------------------------------------------------------------------------------------------------
                                                   Local variables:
                                                   arg = <__main__.Monitor object at 0x7ff8988c4150>
                                                   args = (<__main__.Monitor object at 0x7ff8988c4150>,)
                                                   function = <function Monitor.run at 0x7ff898d0a930>
                                                   header = 'SETTINGS: Monitor.run '
                                                   kwargs = {}
                                                   level = 0
                                                   ====================================================================================================
                                                   File:
                                                   /storage/.kodi/addons/service.libreelec.settings/service.py:104
                                                   ----------------------------------------------------------------------------------------------------
                                                   Code context:
                                                     102:             if oe.winOeMain.visible == True:
                                                     103:                 oe.winOeMain.close()
                                                     104:>        oe.stop_service()
                                                     105:         service_thread.stop()
                                                     106:         dbus_utils.LOOP_THREAD.stop()
                                                   
                                                   ----------------------------------------------------------------------------------------------------
                                                   Local variables:
                                                   self = <__main__.Monitor object at 0x7ff8988c4150>
                                                   service_thread = <Service_Thread(Thread-3, started daemon 140705145988672)>
                                                   ====================================================================================================
                                                   File:
                                                   /storage/.kodi/addons/service.libreelec.settings/resources/lib/oe.py:572
                                                   ----------------------------------------------------------------------------------------------------
                                                   Code context:
                                                     570:             module = dictModules[strModule]
                                                     571:             if hasattr(module, 'stop_service') and module.ENABLED:
                                                     572:>                module.stop_service()
                                                     573:         xbmc.log('## LibreELEC Addon ## STOP SERVICE DONE !')
                                                     574:     except Exception as e:
                                                   
                                                   ----------------------------------------------------------------------------------------------------
                                                   Local variables:
                                                   module = <bluetooth.bluetooth object at 0x7ff898d11610>
                                                   strModule = 'bluetooth'
                                                   ====================================================================================================
                                                   File:
                                                   /storage/.kodi/addons/service.libreelec.settings/resources/lib/log.py:69
                                                   ----------------------------------------------------------------------------------------------------
                                                   Code context:
                                                      67:                 for key, value in kwargs.items():
                                                      68:                     _log(f'{header}< {key}={pprint.pformat(value)}', level)
                                                      69:>                result = function(*args, **kwargs)
                                                      70:                 _log(f'{header}> {pprint.pformat(result)}', level)
                                                      71:                 return result
                                                   
                                                   ----------------------------------------------------------------------------------------------------
                                                   Local variables:
                                                   arg = <bluetooth.bluetooth object at 0x7ff898d11610>
                                                   args = (<bluetooth.bluetooth object at 0x7ff898d11610>,)
                                                   function = <function bluetooth.stop_service at 0x7ff898cf5530>
                                                   header = 'SETTINGS: bluetooth.stop_service '
                                                   kwargs = {}
                                                   level = 0
                                                   ====================================================================================================
                                                   File:
                                                   /storage/.kodi/addons/service.libreelec.settings/resources/lib/modules/bluetooth.py:93
                                                   ----------------------------------------------------------------------------------------------------
                                                   Code context:
                                                      91:     @log.log_function()
                                                      92:     def stop_service(self):
                                                      93:>        self.bluez_agent.unregister_agent()
                                                      94:         if hasattr(self, 'discovery_thread'):
                                                      95:             try:
                                                   
                                                   ----------------------------------------------------------------------------------------------------
                                                   Local variables:
                                                   self = <bluetooth.bluetooth object at 0x7ff898d11610>
                                                   ====================================================================================================
                                                   File:
                                                   /storage/.kodi/addons/service.libreelec.settings/resources/lib/log.py:69
                                                   ----------------------------------------------------------------------------------------------------
                                                   Code context:
                                                      67:                 for key, value in kwargs.items():
                                                      68:                     _log(f'{header}< {key}={pprint.pformat(value)}', level)
                                                      69:>                result = function(*args, **kwargs)
                                                      70:                 _log(f'{header}> {pprint.pformat(result)}', level)
                                                      71:                 return result
                                                   
                                                   ----------------------------------------------------------------------------------------------------
                                                   Local variables:
                                                   arg = <bluetooth.Bluez_Agent object at 0x7ff899048e60>
                                                   args = (<bluetooth.Bluez_Agent object at 0x7ff899048e60>,)
                                                   e = DBusError('org.freedesktop.DBus.Error.ServiceUnknown -- The name org.bluez was not provided by any .service files')
                                                   function = <function Agent.unregister_agent at 0x7ff8988cb7d0>
                                                   header = 'SETTINGS: Agent.unregister_agent '
                                                   kwargs = {}
                                                   level = 0
                                                   outer_stack = [   FrameInfo(frame=<frame at 0x7ff89815b600, file '/storage/.kodi/addons/service.libreelec.settings/service.py', line 110, code <module>>, filename='/storage/.kodi/addons/service.libreelec.settings/service.py', lineno=110, function='<module>', code_context=['        dbus_utils.LOOP_THREAD.stop()\n', '\n', '\n', "if __name__ == '__main__':\n", '    Monitor().run()\n'], index=4),
                                                       FrameInfo(frame=<frame at 0x7ff898938d70, file '/storage/.kodi/addons/service.libreelec.settings/resources/lib/log.py', line 69, code _log_function_2>, filename='/storage/.kodi/addons/service.libreelec.settings/resources/lib/log.py', lineno=69, function='_log_function_2', code_context=['                for key, value in kwargs.items():\n', "                    _log(f'{header}< {key}={pprint.pformat(value)}', level)\n", '                result = function(*args, **kwargs)\n', "                _log(f'{header}> {pprint.pformat(result)}', level)\n", '                return result\n'], index=2),
                                                       FrameInfo(frame=<frame at 0x7ff898929650, file '/storage/.kodi/addons/service.libreelec.settings/service.py', line 104, code run>, filename='/storage/.kodi/addons/service.libreelec.settings/service.py', lineno=104, function='run', code_context=['            if oe.winOeMain.visible == True:\n', '                oe.winOeMain.close()\n', '        oe.stop_service()\n', '        service_thread.stop()\n', '        dbus_utils.LOOP_THREAD.stop()\n'], index=2),
                                                       FrameInfo(frame=<frame at 0x7ff898e500e0, file '/storage/.kodi/addons/service.libreelec.settings/resources/lib/oe.py', line 572, code stop_service>, filename='/storage/.kodi/addons/service.libreelec.settings/resources/lib/oe.py', lineno=572, function='stop_service', code_context=['            module = dictModules[strModule]\n', "            if hasattr(module, 'stop_service') and module.ENABLED:\n", '                module.stop_service()\n', "        xbmc.log('## LibreELEC Addon ## STOP SERVICE DONE !')\n", '    except Exception as e:\n'], index=2),
                                                       FrameInfo(frame=<frame at 0x7ff899009200, file '/storage/.kodi/addons/service.libreelec.settings/resources/lib/log.py', line 69, code _log_function_2>, filename='/storage/.kodi/addons/service.libreelec.settings/resources/lib/log.py', lineno=69, function='_log_function_2', code_context=['                for key, value in kwargs.items():\n', "                    _log(f'{header}< {key}={pprint.pformat(value)}', level)\n", '                result = function(*args, **kwargs)\n', "                _log(f'{header}> {pprint.pformat(result)}', level)\n", '                return result\n'], index=2),
                                                       FrameInfo(frame=<frame at 0x7ff8990da800, file '/storage/.kodi/addons/service.libreelec.settings/resources/lib/modules/bluetooth.py', line 93, code stop_service>, filename='/storage/.kodi/addons/service.libreelec.settings/resources/lib/modules/bluetooth.py', lineno=93, function='stop_service', code_context=['    @log.log_function()\n', '    def stop_service(self):\n', '        self.bluez_agent.unregister_agent()\n', "        if hasattr(self, 'discovery_thread'):\n", '            try:\n'], index=2)]
                                                   ====================================================================================================
                                                   File:
                                                   /storage/.kodi/addons/service.libreelec.settings/resources/lib/dbus_utils.py:48
                                                   ----------------------------------------------------------------------------------------------------
                                                   Code context:
                                                      46:     def unregister_agent(self):
                                                      47:         BUS.unregister(path=self.path_agent)
                                                      48:>        self.omanager_unregister_agent()
                                                      49: 
                                                      50:     def manager_register_agent(self):
                                                   
                                                   ----------------------------------------------------------------------------------------------------
                                                   Local variables:
                                                   self = <bluetooth.Bluez_Agent object at 0x7ff899048e60>
                                                   ====================================================================================================
                                                   File:
                                                   /storage/.kodi/addons/service.libreelec.settings/resources/lib/dbus_bluez.py:29
                                                   ----------------------------------------------------------------------------------------------------
                                                   Code context:
                                                      27: 
                                                      28:     def manager_unregister_agent(self):
                                                      29:>        dbus_utils.call_method(BUS_NAME, PATH_BLUEZ, INTERFACE_AGENT_MANAGER,
                                                      30:                                'UnregisterAgent', PATH_AGENT)
                                                      31: 
                                                   
                                                   ----------------------------------------------------------------------------------------------------
                                                   Local variables:
                                                   self = <bluetooth.Bluez_Agent object at 0x7ff899048e60>
                                                   ====================================================================================================
                                                   File:
                                                   /storage/.kodi/addons/service.libreelec.settings/resources/lib/dbus_utils.py:106
                                                   ----------------------------------------------------------------------------------------------------
                                                   Code context:
                                                     104: 
                                                     105: def call_method(bus_name, path, interface, method_name, *args, **kwargs):
                                                     106:>    interface = BUS[bus_name][path].get_interface(interface)
                                                     107:     method = getattr(interface, method_name)
                                                     108:     result = method(*args, **kwargs)
                                                   
                                                   ----------------------------------------------------------------------------------------------------
                                                   Local variables:
                                                   args = ('/kodi/agent/bluez',)
                                                   bus_name = 'org.bluez'
                                                   interface = 'org.bluez.AgentManager1'
                                                   kwargs = {}
                                                   method_name = 'UnregisterAgent'
                                                   path = '/org/bluez'
                                                   ====================================================================================================
                                                   File:
                                                   /usr/lib/python3.8/site-packages/ravel.py:1686
                                                   ----------------------------------------------------------------------------------------------------
                                                   Code context:
                                                   
                                                   ----------------------------------------------------------------------------------------------------
                                                   Local variables:
                                                   interface = 'org.bluez.AgentManager1'
                                                   self = <ravel.BusPeer.Object object at 0x7ff899011fc0>
                                                   timeout = -1
                                                   ====================================================================================================
                                                   File:
                                                   /usr/lib/python3.8/site-packages/ravel.py:1427
                                                   ----------------------------------------------------------------------------------------------------
                                                   Code context:
                                                   
                                                   ----------------------------------------------------------------------------------------------------
                                                   Local variables:
                                                   destination = 'org.bluez'
                                                   interface = 'org.bluez.AgentManager1'
                                                   path = '/org/bluez'
                                                   self = <ravel.Connection object at 0x7ff8988cda10>
                                                   timeout = -1
                                                   ====================================================================================================
                                                   File:
                                                   /usr/lib/python3.8/site-packages/ravel.py:1378
                                                   ----------------------------------------------------------------------------------------------------
                                                   Code context:
                                                   
                                                   ----------------------------------------------------------------------------------------------------
                                                   Local variables:
                                                   destination = 'org.bluez'
                                                   message = <dbussy.Message object at 0x7ff8980e11a0>
                                                   path = '/org/bluez'
                                                   self = <ravel.Connection object at 0x7ff8988cda10>
                                                   timeout = -1
                                                   ====================================================================================================
                                                   File:
                                                   /usr/lib/python3.8/site-packages/dbussy.py:2262
                                                   ----------------------------------------------------------------------------------------------------
                                                   Code context:
                                                   
                                                   ----------------------------------------------------------------------------------------------------
                                                   Local variables:
                                                   error = <dbussy.Error object at 0x7ff898e5be70>
                                                   message = <dbussy.Message object at 0x7ff8980e11a0>
                                                   my_error = <dbussy.Error object at 0x7ff898e5be70>
                                                   reply = None
                                                   self = <dbussy.Connection object at 0x7ff8988f5470>
                                                   timeout = -1
                                                   ====================================================================================================
                                                   File:
                                                   /usr/lib/python3.8/site-packages/dbussy.py:5041
                                                   ----------------------------------------------------------------------------------------------------
                                                   Code context:
                                                   
                                                   ----------------------------------------------------------------------------------------------------
                                                   Local variables:
                                                   self = <dbussy.Error object at 0x7ff898e5be70>
                                                   ====================================================================================================
                                                   
                                                   
                                                   ************************************* End of diagnostic info ***************************************
```

### bluetooth.py: only start discovery_thread if BT is available and enabled

discovery_thread is not working without or with disabled BT HW.

### bluetooth.py: pinkeyTimer(): remove @log.log_function() from __init_()

Using @log.log_function() results in 'AssertionError: Thread.__init__() not called'
and PinKey value is not displayed.

Before:
![screenshot00000](https://user-images.githubusercontent.com/8526926/191123816-6ec199d8-d8b8-4201-ba9a-87fa27c99a2f.png)

After:
![screenshot00001](https://user-images.githubusercontent.com/8526926/191123843-73720466-e09e-4760-9528-4a6b8df75be9.png)

### bluetooth.py: discover_devices(): work around random KeyError
    
Catch and log the random (?) bluetooth KeyErrors in just one line to reduce spam.

Without the work around:
```
2022-09-17 18:54:41.304 T:1712    error <general>: SETTINGS: bluetooth.discover_devices # KeyError(ObjectPath('/org/bluez/hci0/dev_00_12_3D_00_3C_1F'))
2022-09-17 18:54:41.495 T:1712    error <general>: SETTINGS: bluetooth.discover_devices 
                                                   *********************************** Unhandled exception detected ***********************************
                                                   ####################################################################################################
                                                                                              Diagnostic info
                                                   ----------------------------------------------------------------------------------------------------
                                                   Exception type  : KeyError
                                                   Exception value : ObjectPath('/org/bluez/hci0/dev_00_12_3D_00_3C_1F')
                                                   System info     : uname_result(system='Linux', node='le10mars', release='5.10.142', version='#1 SMP Sat Sep 10 17:06:14 UTC 2022', machine='x86_64', processor='')
                                                   Python version  : 3.8.9 (default, Oct 13 2021, 13:15:24)  [GCC 10.2.0]
                                                   Kodi version    : 19.4 (19.4.0) Git:aac12f6fc42510b9fed6aea9cbfa9f07c41e379e
                                                   sys.argv        : ['']
                                                   ----------------------------------------------------------------------------------------------------
                                                   sys.path:
                                                   ['/storage/.kodi/addons/service.libreelec.settings',
                                                    '/usr/lib/python38.zip',
                                                    '/usr/lib/python3.8',
                                                    '/usr/lib/python3.8/lib-dynload',
                                                    '/usr/lib/python3.8/site-packages',
                                                    '/storage/.kodi/addons/service.libreelec.settings/resources/lib',
                                                    '/storage/.kodi/addons/service.libreelec.settings/resources/lib/modules']
                                                   
                                                   ####################################################################################################
                                                                                               Stack Trace
                                                   ====================================================================================================
                                                   File:
                                                   /usr/lib/python3.8/threading.py:890
                                                   ----------------------------------------------------------------------------------------------------
                                                   Code context:
                                                   
                                                   ----------------------------------------------------------------------------------------------------
                                                   Local variables:
                                                   self = <discoveryThread(Thread-11, started daemon 140706878318144)>
                                                   ====================================================================================================
                                                   File:
                                                   /usr/lib/python3.8/threading.py:932
                                                   ----------------------------------------------------------------------------------------------------
                                                   Code context:
                                                   
                                                   ----------------------------------------------------------------------------------------------------
                                                   Local variables:
                                                   self = <discoveryThread(Thread-11, started daemon 140706878318144)>
                                                   ====================================================================================================
                                                   File:
                                                   /storage/.kodi/addons/service.libreelec.settings/resources/lib/log.py:69
                                                   ----------------------------------------------------------------------------------------------------
                                                   Code context:
                                                      67:                 for key, value in kwargs.items():
                                                      68:                     _log(f'{header}< {key}={pprint.pformat(value)}', level)
                                                      69:>                result = function(*args, **kwargs)
                                                      70:                 _log(f'{header}> {pprint.pformat(result)}', level)
                                                      71:                 return result
                                                   
                                                   ----------------------------------------------------------------------------------------------------
                                                   Local variables:
                                                   arg = <discoveryThread(Thread-11, started daemon 140706878318144)>
                                                   args = (<discoveryThread(Thread-11, started daemon 140706878318144)>,)
                                                   function = <function discoveryThread.run at 0x7ff898c038a0>
                                                   header = 'SETTINGS: discoveryThread.run '
                                                   kwargs = {}
                                                   level = 0
                                                   ====================================================================================================
                                                   File:
                                                   /storage/.kodi/addons/service.libreelec.settings/resources/lib/modules/bluetooth.py:691
                                                   ----------------------------------------------------------------------------------------------------
                                                   Code context:
                                                     689:             if (self.main_menu.getSelectedItem().getProperty('modul') == 'bluetooth'
                                                     690:                     and current_time > self.last_run + 5):
                                                     691:>                self.parent.discover_devices()
                                                     692:                 self.last_run = current_time
                                                     693:             elif self.main_menu.getSelectedItem().getProperty('modul') != 'bluetooth':
                                                   
                                                   ----------------------------------------------------------------------------------------------------
                                                   Local variables:
                                                   current_time = 1663433680.8990724
                                                   self = <discoveryThread(Thread-11, started daemon 140706878318144)>
                                                   ====================================================================================================
                                                   File:
                                                   /storage/.kodi/addons/service.libreelec.settings/resources/lib/log.py:69
                                                   ----------------------------------------------------------------------------------------------------
                                                   Code context:
                                                      67:                 for key, value in kwargs.items():
                                                      68:                     _log(f'{header}< {key}={pprint.pformat(value)}', level)
                                                      69:>                result = function(*args, **kwargs)
                                                      70:                 _log(f'{header}> {pprint.pformat(result)}', level)
                                                      71:                 return result
                                                   
                                                   ----------------------------------------------------------------------------------------------------
                                                   Local variables:
                                                   arg = <bluetooth.bluetooth object at 0x7ff898d11610>
                                                   args = (<bluetooth.bluetooth object at 0x7ff898d11610>,)
                                                   e = KeyError(ObjectPath('/org/bluez/hci0/dev_00_12_3D_00_3C_1F'))
                                                   function = <function bluetooth.discover_devices at 0x7ff898cf4dc0>
                                                   header = 'SETTINGS: bluetooth.discover_devices '
                                                   kwargs = {}
                                                   level = 0
                                                   outer_stack = [   FrameInfo(frame=<frame at 0x7ff8e02c2a80, file '/usr/lib/python3.8/threading.py', line 890, code _bootstrap>, filename='/usr/lib/python3.8/threading.py', lineno=890, function='_bootstrap', code_context=None, index=None),
                                                       FrameInfo(frame=<frame at 0x7ff8e02b96f0, file '/usr/lib/python3.8/threading.py', line 932, code _bootstrap_inner>, filename='/usr/lib/python3.8/threading.py', lineno=932, function='_bootstrap_inner', code_context=None, index=None),
                                                       FrameInfo(frame=<frame at 0x7ff8e40311a0, file '/storage/.kodi/addons/service.libreelec.settings/resources/lib/log.py', line 69, code _log_function_2>, filename='/storage/.kodi/addons/service.libreelec.settings/resources/lib/log.py', lineno=69, function='_log_function_2', code_context=['                for key, value in kwargs.items():\n', "                    _log(f'{header}< {key}={pprint.pformat(value)}', level)\n", '                result = function(*args, **kwargs)\n', "                _log(f'{header}> {pprint.pformat(result)}', level)\n", '                return result\n'], index=2),
                                                       FrameInfo(frame=<frame at 0x7ff90c05f190, file '/storage/.kodi/addons/service.libreelec.settings/resources/lib/modules/bluetooth.py', line 691, code run>, filename='/storage/.kodi/addons/service.libreelec.settings/resources/lib/modules/bluetooth.py', lineno=691, function='run', code_context=["            if (self.main_menu.getSelectedItem().getProperty('modul') == 'bluetooth'\n", '                    and current_time > self.last_run + 5):\n', '                self.parent.discover_devices()\n', '                self.last_run = current_time\n', "            elif self.main_menu.getSelectedItem().getProperty('modul') != 'bluetooth':\n"], index=2)]
                                                   ====================================================================================================
                                                   File:
                                                   /storage/.kodi/addons/service.libreelec.settings/resources/lib/modules/bluetooth.py:363
                                                   ----------------------------------------------------------------------------------------------------
                                                   Code context:
                                                     361:                     self.listItems[dbusDevice].setLabel(apName)
                                                     362:                     for dictProperty in dictProperties:
                                                     363:>                        self.listItems[dbusDevice].setProperty(dictProperty, dictProperties[dictProperty])
                                                     364: 
                                                     365:     @log.log_function()
                                                   
                                                   ----------------------------------------------------------------------------------------------------
                                                   Local variables:
                                                   apName = 'TT-BR01'
                                                   dbusDevice = ObjectPath('/org/bluez/hci0/dev_00_12_3D_00_3C_1F')
                                                   device_properties = {   'Adapter': ObjectPath('/org/bluez/hci0'),
                                                       'Address': '00:12:3D:00:3C:1F',
                                                       'AddressType': 'public',
                                                       'Alias': 'TT-BR01',
                                                       'Blocked': 0,
                                                       'Class': 2360324,
                                                       'Connected': 0,
                                                       'Icon': 'audio-card',
                                                       'LegacyPairing': 0,
                                                       'Name': 'TT-BR01',
                                                       'Paired': 1,
                                                       'ServicesResolved': 0,
                                                       'Trusted': 1,
                                                       'UUIDs': [   '00001108-0000-1000-8000-00805f9b34fb',
                                                                    '0000110b-0000-1000-8000-00805f9b34fb',
                                                                    '0000110c-0000-1000-8000-00805f9b34fb',
                                                                    '0000110d-0000-1000-8000-00805f9b34fb',
                                                                    '0000110e-0000-1000-8000-00805f9b34fb',
                                                                    '0000111e-0000-1000-8000-00805f9b34fb']}
                                                   dictProperties = {   'Adapter': '/org/bluez/hci0',
                                                       'Address': '00:12:3D:00:3C:1F',
                                                       'Class': '2360324',
                                                       'Connected': '0',
                                                       'ConnectedState': 'Nein',
                                                       'Icon': 'audio-card',
                                                       'Paired': '1',
                                                       'Trusted': '1',
                                                       'action': 'open_context_menu',
                                                       'entry': ObjectPath('/org/bluez/hci0/dev_00_12_3D_00_3C_1F'),
                                                       'modul': 'bluetooth'}
                                                   dictProperty = 'entry'
                                                   found_devices = frozenset({   ObjectPath('/org/bluez/hci0/dev_00_12_3D_00_3C_1F'),
                                                                 ObjectPath('/org/bluez/hci0/dev_00_1A_7D_DA_71_0D'),
                                                                 ObjectPath('/org/bluez/hci0/dev_0C_FC_83_81_35_39'),
                                                                 ObjectPath('/org/bluez/hci0/dev_88_B4_A6_0B_63_48')})
                                                   name = 'Icon'
                                                   prop = 7
                                                   rebuildList = False
                                                   self = <bluetooth.bluetooth object at 0x7ff898d11610>
                                                   value = 'audio-card'
                                                   ====================================================================================================
                                                   
                                                   
                                                   ************************************* End of diagnostic info ***************************************
```

### connman.py: 'value' dict type has to be str. Fix for 'Boolean'
    
dbussy is returning bool values as 0 and 1 ints. We only compare with
'0' and/or '1'. Convert them to str.

Note for testing: 'Boolean' is only used for 'AutoConnect'.
