### PR TITLE
oe.py cleanup pass

### DIFF
--- a/resources/lib/config.py
+++ b/resources/lib/config.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0
-# Copyright (C) 2020-present Team LibreELEC
+# Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 import os
 

--- a/resources/lib/dbus_bluez.py
+++ b/resources/lib/dbus_bluez.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0
-# Copyright (C) 2020-present Team LibreELEC
+# Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 import dbussy
 import ravel

--- a/resources/lib/dbus_connman.py
+++ b/resources/lib/dbus_connman.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0
-# Copyright (C) 2020-present Team LibreELEC
+# Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 import dbussy
 import ravel

--- a/resources/lib/dbus_obex.py
+++ b/resources/lib/dbus_obex.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0
-# Copyright (C) 2020-present Team LibreELEC
+# Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 import dbussy
 import ravel

--- a/resources/lib/dbus_utils.py
+++ b/resources/lib/dbus_utils.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0
-# Copyright (C) 2020-present Team LibreELEC
+# Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 import asyncio
 import threading

--- a/resources/lib/debug_utils.py
+++ b/resources/lib/debug_utils.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0
-# Copyright (C) 2020-present Team LibreELEC
+# Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 import inspect
 import sys

--- a/resources/lib/hostname.py
+++ b/resources/lib/hostname.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0
-# Copyright (C) 2020-present Team LibreELEC
+# Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 import os
 

--- a/resources/lib/log.py
+++ b/resources/lib/log.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0
-# Copyright (C) 2020-present Team LibreELEC
+# Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 import inspect
 import os

--- a/resources/lib/modules.py
+++ b/resources/lib/modules.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0
-# Copyright (C) 2020-present Team LibreELEC
+# Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 import defaults
 import log

--- a/resources/lib/modules/bluetooth.py
+++ b/resources/lib/modules/bluetooth.py
@@ -244,7 +244,7 @@ class bluetooth(modules.Module):
             listItem = oe.winOeMain.getControl(oe.listObject['btlist']).getSelectedItem()
         if listItem is None:
             return
-        oe.dbg_log('bluetooth::remove_device->entry::', listItem.getProperty('entry'), oe.LOGDEBUG)
+        log.log(f"remove_device->entry: {listItem.getProperty('entry')}", log.DEBUG)
         path = listItem.getProperty('entry')
         dbus_bluez.adapter_remove_device(self.dbusBluezAdapter, path)
         self.disable_device_standby(listItem)
@@ -256,7 +256,7 @@ class bluetooth(modules.Module):
 
     @log.log_function()
     def dbus_error_handler(self, error):
-        oe.dbg_log('bluetooth::dbus_error_handler::err_message', repr(error.message), oe.LOGDEBUG)
+        log.log(f'error message: {repr(error.message)}', log.DEBUG)
         oe.notify('Bluetooth error', error.message.split('.')[0], 'bt')
         if hasattr(self, 'pinkey_window'):
             self.close_pinkey_window()
@@ -292,7 +292,7 @@ class bluetooth(modules.Module):
             oe.winOeMain.getControl(1301).setLabel(oe._(32346))
             oe.winOeMain.getControl(int(oe.listObject['btlist'])).reset()
             self.clear_list()
-            oe.dbg_log('bluetooth::menu_connections', 'exit_function (BT Disabled)', oe.LOGDEBUG)
+            log.log('exit_function (BT Disabled)', log.DEBUG)
             oe.winOeMain.setProperty('show_bt_label', 'true')
             return
         if self.dbusBluezAdapter is None:
@@ -300,7 +300,7 @@ class bluetooth(modules.Module):
             oe.winOeMain.getControl(1301).setLabel(oe._(32338))
             oe.winOeMain.getControl(int(oe.listObject['btlist'])).reset()
             self.clear_list()
-            oe.dbg_log('bluetooth::menu_connections', 'exit_function (No Adapter)', oe.LOGDEBUG)
+            log.log('exit_function (No Adapter)', log.DEBUG)
             oe.winOeMain.setProperty('show_bt_label', 'true')
             return
         if not dbus_bluez.adapter_get_powered(self.dbusBluezAdapter):
@@ -309,7 +309,7 @@ class bluetooth(modules.Module):
             oe.winOeMain.getControl(int(oe.listObject['btlist'])).reset()
             self.clear_list()
             oe.winOeMain.setProperty('show_bt_label', 'true')
-            oe.dbg_log('bluetooth::menu_connections', 'exit_function (No Adapter Powered)', oe.LOGDEBUG)
+            log.log('exit_function (No Adapter Powered)', log.DEBUG)
             return
 
         rebuildList = False
@@ -646,7 +646,7 @@ class Obex_Agent(dbus_obex.Agent):
         xbmcDialog = xbmcgui.Dialog()
         properties = self.transfer_get_all_properties(transfer)
         answer = xbmcDialog.yesno('Bluetooth', f"{oe._(32381)}\n\n{properties['Name']}")
-        oe.dbg_log('bluetooth::obexAgent::AuthorizePush::answer=', repr(answer), oe.LOGDEBUG)
+        log.log(f'answer={repr(answer)}', log.DEBUG)
         if answer != 1:
             self.reject('Not Authorized')
         self.parent.download_path = transfer

--- a/resources/lib/modules/connman.py
+++ b/resources/lib/modules/connman.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2009-2013 Stephan Raue (stephan@openelec.tv)
 # Copyright (C) 2013 Lutz Fiebach (lufie@openelec.tv)
-# Copyright (C) 2017-present Team LibreELEC
+# Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 import os
 import random

--- a/resources/lib/modules/services.py
+++ b/resources/lib/modules/services.py
@@ -4,6 +4,7 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 import os
+import shutil
 import subprocess
 
 import xbmc
@@ -545,7 +546,9 @@ class services(modules.Module):
         newpwd = xbmcDialog.input(oe._(746))
         if newpwd:
             if newpwd == "libreelec":
-                oe.execute('cp -fp /usr/cache/shadow /storage/.cache/shadow')
+                if os.path.isfile('/storage/.cache/shadow'):
+                    os.remove('/storage/.cache/shadow')
+                shutil.copy2('/usr/cache/shadow', '/storage/.cache/shadow')
                 readout3 = "Retype password"
             else:
                 ssh = subprocess.Popen(["passwd"], shell=False, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, bufsize=0)

--- a/resources/lib/modules/system.py
+++ b/resources/lib/modules/system.py
@@ -460,7 +460,9 @@ class system(modules.Module):
 
     @log.log_function()
     def set_hw_clock(self):
-        os_tools.execute(f'{self.SET_CLOCK_CMD} 2>/dev/null')
+        # does device have an RTC?
+        if os.path.exists('/proc/driver/rtc'):
+            os_tools.execute(f'{self.SET_CLOCK_CMD} 2>/dev/null')
 
     @log.log_function()
     def reset_soft(self, listItem=None):

--- a/resources/lib/modules/system.py
+++ b/resources/lib/modules/system.py
@@ -6,7 +6,7 @@
 import glob
 import os
 import re
-import subprocess
+import shutil
 import tarfile
 from xml.dom import minidom
 
@@ -18,6 +18,7 @@ import log
 import modules
 import oe
 import oeWindows
+import os_tools
 
 
 xbmcDialog = xbmcgui.Dialog()
@@ -366,13 +367,25 @@ class system(modules.Module):
                 '-model ' + str(self.struct['keyboard']['settings']['KeyboardType']['value']),
                 '-option "grp:alt_shift_toggle"',
                 ]
-            oe.execute('setxkbmap ' + ' '.join(parameters))
+            os_tools.execute('setxkbmap ' + ' '.join(parameters))
         elif self.nox_keyboard_layouts == True:
-            log.log(str(self.struct['keyboard']['settings']['KeyboardLayout1']['value']), log.INFO)
             parameter = self.struct['keyboard']['settings']['KeyboardLayout1']['value']
-            command = f'loadkmap < `ls -1 {self.NOX_KEYBOARD_INFO}/*/{parameter}.bmap`'
-            log.log(command, log.INFO)
-            oe.execute(command)
+            log.log(f'Settings keyboard layout: {parameter}', log.INFO)
+            path_to_bmap = None
+            for dirpath, dirnames, filenames in os.walk(self.NOX_KEYBOARD_INFO):
+                for f in filenames:
+                    if f == f'{parameter}.bmap':
+                        path_to_bmap = f'{dirpath}/{f}'
+                        log.log(f'Found keyboard layout: {path_to_bmap}', log.INFO)
+                        break
+                if path_to_bmap:
+                    break
+            if path_to_bmap:
+                command = f'loadkmap < {path_to_bmap}'
+                log.log(f'Executing {command}', log.INFO)
+                os_tools.execute(command)
+            else:
+                log.log('No keyboard layout found.', log.INFO)
 
     @log.log_function()
     def set_hostname(self, listItem=None):
@@ -447,7 +460,7 @@ class system(modules.Module):
 
     @log.log_function()
     def set_hw_clock(self):
-        oe.execute(f'{self.SET_CLOCK_CMD} 2>/dev/null')
+        os_tools.execute(f'{self.SET_CLOCK_CMD} 2>/dev/null')
 
     @log.log_function()
     def reset_soft(self, listItem=None):
@@ -455,7 +468,7 @@ class system(modules.Module):
             open(self.XBMC_RESET_FILE, 'a').close()
             oe.winOeMain.close()
             oe.xbmcm.waitForAbort(1)
-            subprocess.call(['/usr/bin/systemctl', '--no-block', 'reboot'], close_fds=True)
+            os_tools.execute('/usr/bin/systemctl --no-block reboot')
 
     @log.log_function()
     def reset_hard(self, listItem=None):
@@ -463,7 +476,8 @@ class system(modules.Module):
             open(self.LIBREELEC_RESET_FILE, 'a').close()
             oe.winOeMain.close()
             oe.xbmcm.waitForAbort(1)
-            subprocess.call(['/usr/bin/systemctl', '--no-block', 'reboot'], close_fds=True)
+            os_tools.execute('/usr/bin/systemctl --no-block reboot')
+
 
     @log.log_function()
     def ask_sure_reset(self, part):
@@ -551,7 +565,7 @@ class system(modules.Module):
             log.log(f'Restore file: {restore_file_path}', log.INFO)
             restore_file_name = restore_file_path.split('/')[-1]
             if os.path.exists(self.RESTORE_DIR):
-                oe.execute(f'rm -rf {self.RESTORE_DIR}')
+                shutil.rmtree(self.RESTORE_DIR)
             os.makedirs(self.RESTORE_DIR)
             folder_stat = os.statvfs(self.RESTORE_DIR)
             file_size = os.path.getsize(restore_file_path)
@@ -564,7 +578,8 @@ class system(modules.Module):
                     log.log('Restore file successfully copied.', log.INFO)
                 else:
                     log.log(f'Failed to copy restore file to: {self.RESTORE_DIR}', log.ERROR)
-                    oe.execute(f'rm -rf {self.RESTORE_DIR}')
+                    if os.path.exists(self.RESTORE_DIR):
+                        shutil.rmtree(self.RESTORE_DIR)
             else:
                 txt = oe.split_dialog_text(oe._(32379))
                 answer = xbmcDialog.ok('Restore', f'{txt[0]}\n{txt[1]}\n{txt[2]}')
@@ -575,10 +590,11 @@ class system(modules.Module):
                     if oe.reboot_counter(10, oe._(32371)) == 1:
                         oe.winOeMain.close()
                         oe.xbmcm.waitForAbort(1)
-                        subprocess.call(['/usr/bin/systemctl', '--no-block', 'reboot'], close_fds=True)
+                        os_tools.execute('/usr/bin/systemctl --no-block reboot')
                 else:
                     log.log('User Abort!')
-                    oe.execute(f'rm -rf {self.RESTORE_DIR}')
+                    if os.path.exists(self.RESTORE_DIR):
+                        shutil.rmtree(self.RESTORE_DIR)
 
     @log.log_function()
     def do_send_system_logs(self, listItem=None):
@@ -592,7 +608,7 @@ class system(modules.Module):
     def do_send_logs(self, log_cmd):
         paste_dlg = xbmcgui.DialogProgress()
         paste_dlg.create('Pasting log files', 'Pasting...')
-        result = oe.execute(log_cmd, get_result=1)
+        result = os_tools.execute(log_cmd, get_result=True)
         if not paste_dlg.iscanceled():
             paste_dlg.close()
             link = result.find('http')

--- a/resources/lib/modules/updates.py
+++ b/resources/lib/modules/updates.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2009-2013 Stephan Raue (stephan@openelec.tv)
 # Copyright (C) 2013 Lutz Fiebach (lufie@openelec.tv)
-# Copyright (C) 2018-present Team LibreELEC
+# Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 import json
 import os

--- a/resources/lib/oe.py
+++ b/resources/lib/oe.py
@@ -813,9 +813,12 @@ if os.path.exists('/etc/machine-id'):
 else:
     SYSTEMID = os.environ.get('SYSTEMID', '')
 
-if PROJECT == 'RPi':
-    RPI_CPU_VER = os_tools.execute('vcgencmd otp_dump 2>/dev/null | grep 30: | cut -c8', get_result=True).replace('\n','')
-else:
+try:
+    if PROJECT == 'RPi':
+        RPI_CPU_VER = os_tools.execute('vcgencmd otp_dump 2>/dev/null | grep 30: | cut -c8', get_result=True).replace('\n','')
+    else:
+        RPI_CPU_VER = None
+except Exception:
     RPI_CPU_VER = None
 
 BOOT_STATUS = load_file('/storage/.config/boot.status')

--- a/resources/lib/oe.py
+++ b/resources/lib/oe.py
@@ -72,12 +72,12 @@ try:
     imp.reload(sys)
     # sys.setdefaultencoding(encoding)
 except Exception as e:
-    xbmc.log(f'## LibreELEC Addon ## oe:encoding: ERROR: ({repr(e)})', xbmc.LOGERROR)
+    log.log(f'## LibreELEC Addon ## oe:encoding: ERROR: ({repr(e)})', log.ERROR)
 
 ## load oeSettings modules
 
 import oeWindows
-xbmc.log(f"## LibreELEC Addon ## {str(__addon__.getAddonInfo('version'))}")
+log.log(f"## LibreELEC Addon ## {str(__addon__.getAddonInfo('version'))}", log.INFO)
 
 class PINStorage:
     def __init__(self, module='system', prefix='pinlock', maxAttempts=4, delay=300):
@@ -520,7 +520,7 @@ def stop_service():
         module = dictModules[strModule]
         if hasattr(module, 'stop_service') and module.ENABLED:
             module.stop_service()
-    xbmc.log('## LibreELEC Addon ## STOP SERVICE DONE !')
+    log.log('## LibreELEC Addon ## STOP SERVICE DONE !', log.INFO)
 
 
 @log.log_function()

--- a/resources/lib/oe.py
+++ b/resources/lib/oe.py
@@ -11,7 +11,6 @@ import imp
 import locale
 import os
 import re
-import subprocess
 import sys
 import time
 import tarfile
@@ -290,23 +289,6 @@ def notify(title, message, icon='icon'):
     log.log('enter_function', log.DEBUG)
     msg = f'Notification("{title}", "{message[0:64]}", 5000, "{__media__}/{icon}.png")'
     xbmc.executebuiltin(msg)
-    log.log('exit_function', log.DEBUG)
-
-
-@log.log_function()
-def execute(command_line, get_result=0):
-    log.log('enter_function', log.DEBUG)
-    log.log(f'oe: executing command: {command_line}', log.DEBUG)
-    if get_result == 0:
-        process = subprocess.Popen(command_line, shell=True, close_fds=True)
-        process.wait()
-    else:
-        result = ''
-        process = subprocess.Popen(command_line, shell=True, close_fds=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-        process.wait()
-        for line in process.stdout.readlines():
-            result = result + line.decode('utf-8')
-        return result
     log.log('exit_function', log.DEBUG)
 
 

--- a/resources/lib/oe.py
+++ b/resources/lib/oe.py
@@ -27,6 +27,7 @@ import xbmcvfs
 
 import defaults
 import log
+import os_tools
 
 
 __author__ = 'LibreELEC'
@@ -380,7 +381,7 @@ def set_service(service, options, state):
     if not __oe__.is_service:
         if service in defaults._services:
             for svc in defaults._services[service]:
-                execute(f'systemctl restart {svc}')
+                os_tools.execute(f'systemctl restart {svc}')
     log.log('exit_function', log.DEBUG)
 
 
@@ -831,9 +832,9 @@ else:
     SYSTEMID = os.environ.get('SYSTEMID', '')
 
 if PROJECT == 'RPi':
-  RPI_CPU_VER = execute('vcgencmd otp_dump 2>/dev/null | grep 30: | cut -c8', get_result=1).replace('\n','')
+    RPI_CPU_VER = os_tools.execute('vcgencmd otp_dump 2>/dev/null | grep 30: | cut -c8', get_result=True).replace('\n','')
 else:
-  RPI_CPU_VER = ''
+    RPI_CPU_VER = None
 
 BOOT_STATUS = load_file('/storage/.config/boot.status')
 

--- a/resources/lib/oe.py
+++ b/resources/lib/oe.py
@@ -24,7 +24,6 @@ import xbmc
 import xbmcaddon
 import xbmcgui
 import xbmcvfs
-from xbmc import LOGDEBUG, LOGINFO, LOGWARNING, LOGERROR
 
 import defaults
 import log
@@ -73,7 +72,7 @@ try:
     imp.reload(sys)
     # sys.setdefaultencoding(encoding)
 except Exception as e:
-    xbmc.log(f'## LibreELEC Addon ## oe:encoding: ERROR: ({repr(e)})', LOGERROR)
+    xbmc.log(f'## LibreELEC Addon ## oe:encoding: ERROR: ({repr(e)})', xbmc.LOGERROR)
 
 ## load oeSettings modules
 
@@ -292,15 +291,6 @@ def _(code):
             codeNew = __addon__.getLocalizedString(code)
     return codeNew
 
-
-def dbg_log(source, text, level=LOGERROR):
-    if level == LOGDEBUG and os.environ.get('DEBUG', 'no') == 'no':
-        return
-    xbmc.log(f"## LibreELEC Addon ## {source} ## {text}", level)
-    if level == LOGERROR:
-        tracedata = traceback.format_exc()
-        if tracedata != "NoneType: None\n":
-            xbmc.log(tracedata, level)
 
 @log.log_function()
 def notify(title, message, icon='icon'):

--- a/resources/lib/oe.py
+++ b/resources/lib/oe.py
@@ -27,6 +27,7 @@ import xbmcvfs
 from xbmc import LOGDEBUG, LOGINFO, LOGWARNING, LOGERROR
 
 import defaults
+import log
 
 
 __author__ = 'LibreELEC'
@@ -301,190 +302,160 @@ def dbg_log(source, text, level=LOGERROR):
         if tracedata != "NoneType: None\n":
             xbmc.log(tracedata, level)
 
+@log.log_function()
 def notify(title, message, icon='icon'):
-    try:
-        dbg_log('oe::notify', 'enter_function', LOGDEBUG)
-        msg = f'Notification("{title}", "{message[0:64]}", 5000, "{__media__}/{icon}.png")'
-        xbmc.executebuiltin(msg)
-        dbg_log('oe::notify', 'exit_function', LOGDEBUG)
-    except Exception as e:
-        dbg_log('oe::notify', f'ERROR: ({repr(e)})')
+    log.log('enter_function', log.DEBUG)
+    msg = f'Notification("{title}", "{message[0:64]}", 5000, "{__media__}/{icon}.png")'
+    xbmc.executebuiltin(msg)
+    log.log('exit_function', log.DEBUG)
 
 
+@log.log_function()
 def execute(command_line, get_result=0):
-    try:
-        dbg_log('oe::execute', 'enter_function', LOGDEBUG)
-        dbg_log('oe::execute::command', command_line, LOGDEBUG)
-        if get_result == 0:
-            process = subprocess.Popen(command_line, shell=True, close_fds=True)
-            process.wait()
-        else:
-            result = ''
-            process = subprocess.Popen(command_line, shell=True, close_fds=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-            process.wait()
-            for line in process.stdout.readlines():
-                result = result + line.decode('utf-8')
-            return result
-        dbg_log('oe::execute', 'exit_function', LOGDEBUG)
-    except Exception as e:
-        dbg_log('oe::execute', f'ERROR: ({repr(e)})')
+    log.log('enter_function', log.DEBUG)
+    log.log(f'oe: executing command: {command_line}', log.DEBUG)
+    if get_result == 0:
+        process = subprocess.Popen(command_line, shell=True, close_fds=True)
+        process.wait()
+    else:
+        result = ''
+        process = subprocess.Popen(command_line, shell=True, close_fds=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        process.wait()
+        for line in process.stdout.readlines():
+            result = result + line.decode('utf-8')
+        return result
+    log.log('exit_function', log.DEBUG)
 
 
+@log.log_function()
 def enable_service(service):
-    try:
-        if os.path.exists(f'{CONFIG_CACHE}/services/{service}'):
-            pass
-        if os.path.exists(f'{CONFIG_CACHE}/services/{service}.disabled'):
-            pass
-        service_file = f'{CONFIG_CACHE}/services/{service}'
-    except Exception as e:
-        dbg_log('oe::enable_service', f'ERROR: ({repr(e)})')
+    if os.path.exists(f'{CONFIG_CACHE}/services/{service}'):
+        pass
+    if os.path.exists(f'{CONFIG_CACHE}/services/{service}.disabled'):
+        pass
+    service_file = f'{CONFIG_CACHE}/services/{service}'
 
 
+@log.log_function()
 def set_service_option(service, option, value):
-    try:
-        lines = []
-        changed = False
-        conf_file_name = f'{CONFIG_CACHE}/services/{service}.conf'
-        if os.path.isfile(conf_file_name):
-            with open(conf_file_name, 'r') as conf_file:
-                for line in conf_file:
-                    if option in line:
-                        line = f'{option}={value}'
-                        changed = True
-                    lines.append(line.strip())
-        if changed == False:
-            lines.append(f'{option}={value}')
-        with open(conf_file_name, 'w') as conf_file:
-            conf_file.write('\n'.join(lines) + '\n')
-    except Exception as e:
-        dbg_log('oe::set_service_option', f'ERROR: ({repr(e)})')
+    lines = []
+    changed = False
+    conf_file_name = f'{CONFIG_CACHE}/services/{service}.conf'
+    if os.path.isfile(conf_file_name):
+        with open(conf_file_name, 'r') as conf_file:
+            for line in conf_file:
+                if option in line:
+                    line = f'{option}={value}'
+                    changed = True
+                lines.append(line.strip())
+    if changed == False:
+        lines.append(f'{option}={value}')
+    with open(conf_file_name, 'w') as conf_file:
+        conf_file.write('\n'.join(lines) + '\n')
 
 
+@log.log_function()
 def get_service_option(service, option, default=None):
-    try:
-        lines = []
-        conf_file_name = ''
-        if os.path.exists(f'{CONFIG_CACHE}/services/{service}.conf'):
-            conf_file_name = f'{CONFIG_CACHE}/services/{service}.conf'
-        if os.path.exists(f'{CONFIG_CACHE}/services/{service}.disabled'):
-            conf_file_name = f'{CONFIG_CACHE}/services/{service}.disabled'
-        if os.path.exists(conf_file_name):
-            with open(conf_file_name, 'r') as conf_file:
-                for line in conf_file:
-                    if option in line:
-                        if '=' in line:
-                            default = line.strip().split('=')[-1]
-        return default
-    except Exception as e:
-        dbg_log('oe::get_service_option', f'ERROR: ({repr(e)})')
+    lines = []
+    conf_file_name = ''
+    if os.path.exists(f'{CONFIG_CACHE}/services/{service}.conf'):
+        conf_file_name = f'{CONFIG_CACHE}/services/{service}.conf'
+    if os.path.exists(f'{CONFIG_CACHE}/services/{service}.disabled'):
+        conf_file_name = f'{CONFIG_CACHE}/services/{service}.disabled'
+    if os.path.exists(conf_file_name):
+        with open(conf_file_name, 'r') as conf_file:
+            for line in conf_file:
+                if option in line:
+                    if '=' in line:
+                        default = line.strip().split('=')[-1]
+    return default
 
 
+@log.log_function()
 def get_service_state(service):
-    try:
-        if os.path.exists(f'{CONFIG_CACHE}/services/{service}.conf'):
-            return '1'
-        else:
-            return '0'
-    except Exception as e:
-        dbg_log('oe::get_service_state', f'ERROR: ({repr(e)})')
+    if os.path.exists(f'{CONFIG_CACHE}/services/{service}.conf'):
+        return '1'
+    else:
+        return '0'
 
 
+@log.log_function()
 def set_service(service, options, state):
-    try:
-        dbg_log('oe::set_service', 'enter_function', LOGDEBUG)
-        dbg_log('oe::set_service::service', repr(service), LOGDEBUG)
-        dbg_log('oe::set_service::options', repr(options), LOGDEBUG)
-        dbg_log('oe::set_service::state', repr(state), LOGDEBUG)
-        config = {}
-        changed = False
+    log.log('enter_function', log.DEBUG)
+    log.log(f'service: {repr(service)}', log.DEBUG)
+    log.log(f'options: {repr(options)}', log.DEBUG)
+    log.log(f'state: {repr(state)}', log.DEBUG)
+    config = {}
+    changed = False
 
-        # Service Enabled
-
-        if state == 1:
-
-            # Is Service alwys enabled ?
-
-            if get_service_state(service) == '1':
-                cfn = f'{CONFIG_CACHE}/services/{service}.conf'
-                cfo = cfn
-            else:
-                cfn = f'{CONFIG_CACHE}/services/{service}.conf'
-                cfo = f'{CONFIG_CACHE}/services/{service}.disabled'
-            if os.path.exists(cfo) and not cfo == cfn:
-                os.remove(cfo)
-            with open(cfn, 'w') as cf:
-                for option in options:
-                    cf.write(f'{option}={options[option]}\n')
+    # Service Enabled
+    if state == 1:
+        # Is Service alwys enabled ?
+        if get_service_state(service) == '1':
+            cfn = f'{CONFIG_CACHE}/services/{service}.conf'
+            cfo = cfn
         else:
+            cfn = f'{CONFIG_CACHE}/services/{service}.conf'
+            cfo = f'{CONFIG_CACHE}/services/{service}.disabled'
+        if os.path.exists(cfo) and not cfo == cfn:
+            os.remove(cfo)
+        with open(cfn, 'w') as cf:
+            for option in options:
+                cf.write(f'{option}={options[option]}\n')
+    # Service Disabled
+    else:
+        cfo = f'{CONFIG_CACHE}/services/{service}.conf'
+        cfn = f'{CONFIG_CACHE}/services/{service}.disabled'
+        if os.path.exists(cfo):
+            os.rename(cfo, cfn)
+    if not __oe__.is_service:
+        if service in defaults._services:
+            for svc in defaults._services[service]:
+                execute(f'systemctl restart {svc}')
+    log.log('exit_function', log.DEBUG)
 
-        # Service Disabled
 
-            cfo = f'{CONFIG_CACHE}/services/{service}.conf'
-            cfn = f'{CONFIG_CACHE}/services/{service}.disabled'
-            if os.path.exists(cfo):
-                os.rename(cfo, cfn)
-        if not __oe__.is_service:
-            if service in defaults._services:
-                for svc in defaults._services[service]:
-                    execute(f'systemctl restart {svc}')
-        dbg_log('oe::set_service', 'exit_function', LOGDEBUG)
-    except Exception as e:
-        dbg_log('oe::set_service', f'ERROR: ({repr(e)})')
-
-
+@log.log_function()
 def load_file(filename):
-    try:
-        if os.path.isfile(filename):
-            objFile = open(filename, 'r', encoding='utf-8')
-            content = objFile.read()
-            objFile.close()
-        else:
-            content = ''
-        return content.strip()
-    except Exception as e:
-        dbg_log(f'oe::load_file({filename})', f'ERROR: ({repr(e)})')
+    if os.path.isfile(filename):
+        objFile = open(filename, 'r', encoding='utf-8')
+        content = objFile.read()
+        objFile.close()
+    else:
+        content = ''
+    return content.strip()
 
 def url_quote(var):
     return urllib.parse.quote(var, safe="")
 
+@log.log_function()
 def load_url(url):
-    try:
-        request = urllib.request.Request(url)
-        response = urllib.request.urlopen(request)
-        content = response.read()
-        return content.decode('utf-8').strip()
-    except Exception as e:
-        dbg_log(f'oe::load_url({url})', f'ERROR: ({repr(e)})')
+    request = urllib.request.Request(url)
+    response = urllib.request.urlopen(request)
+    content = response.read()
+    return content.decode('utf-8').strip()
 
 
 def download_file(source, destination, silent=False):
     try:
         local_file = open(destination, 'wb')
-
         response = urllib.request.urlopen(urllib.parse.quote(source, safe=':/'))
 
         progress = ProgressDialog()
         if not silent:
             progress.open()
-
         progress.setSource(source)
         progress.setSize(int(response.getheader('Content-Length').strip()))
-
         last_percent = 0
-
         while not (progress.iscanceled() or xbmcm.abortRequested()):
             part = response.read(32768)
-
             progress.sample(part)
-
             if not silent:
                 progress.update(part)
             else:
                 if progress.getPercent() - last_percent > 5 or not part:
-                    dbg_log(f'oe::download_file({destination})', f'{progress.getPercent()}%% with {progress.getSpeed()} KB/s', LOGINFO)
+                    log.log(f'download file: {destination} progress: {progress.getPercent()}%% with {progress.getSpeed()} KB/s', log.INFO)
                     last_percent = progress.getPercent()
-
             if part:
                 local_file.write(part)
             else:
@@ -497,46 +468,37 @@ def download_file(source, destination, silent=False):
         if progress.iscanceled() or xbmcm.abortRequested():
             os.remove(destination)
             return None
-
         return destination
 
     except Exception as e:
-        dbg_log(f'oe::download_file({source},{destination})', f'ERROR: ({repr(e)})')
+        log.log(f'oe::download_file(src: {source}, dest: {destination}): ERROR: ({repr(e)})', log.ERROR)
 
 
 def copy_file(source, destination, silent=False):
     try:
-        dbg_log('oe::copy_file', f'SOURCE: {source}, DEST: {destination}', LOGINFO)
-
+        log.log(f'oe: copy file: SOURCE: {source}, DEST: {destination}', log.INFO)
         source_file = open(source, 'rb')
         destination_file = open(destination, 'wb')
 
         progress = ProgressDialog()
         if not silent:
             progress.open()
-
         progress.setSource(source)
         progress.setSize(os.path.getsize(source))
-
         last_percent = 0
-
         while not (progress.iscanceled() or xbmcm.abortRequested()):
             part = source_file.read(32768)
-
             progress.sample(part)
-
             if not silent:
                 progress.update(part)
             else:
                 if progress.getPercent() - last_percent > 5 or not part:
-                    dbg_log(f'oe::copy_file({destination})', f'{progress.getPercent()}%% with {progress.getSpeed()} KB/s', LOGINFO)
+                    log.log(f'oe: copy file {destination}: {progress.getPercent()}%% with {progress.getSpeed()} KB/s', log.INFO)
                     last_percent = progress.getPercent()
-
             if part:
                 destination_file.write(part)
             else:
                 break
-
         progress.close()
         source_file.close()
         destination_file.close()
@@ -544,262 +506,233 @@ def copy_file(source, destination, silent=False):
         if progress.iscanceled() or xbmcm.abortRequested():
             os.remove(destination)
             return None
-
         return destination
 
     except Exception as e:
-        dbg_log(f'oe::copy_file({source},{destination})', f'ERROR: ({repr(e)})')
+        log.log(f'oe::copy_file(src: {source}, dest: {destination}): ERROR: ({repr(e)})', log.ERROR)
 
 
+@log.log_function()
 def start_service():
     global dictModules, __oe__
-    try:
-        __oe__.is_service = True
-        for strModule in sorted(dictModules, key=lambda x: list(dictModules[x].menu.keys())):
-            module = dictModules[strModule]
-            if hasattr(module, 'start_service') and module.ENABLED:
-                module.start_service()
-        __oe__.is_service = False
-    except Exception as e:
-        dbg_log('oe::start_service', f'ERROR: ({repr(e)})')
+    __oe__.is_service = True
+    for strModule in sorted(dictModules, key=lambda x: list(dictModules[x].menu.keys())):
+        module = dictModules[strModule]
+        if hasattr(module, 'start_service') and module.ENABLED:
+            module.start_service()
+    __oe__.is_service = False
 
 
+@log.log_function()
 def stop_service():
     global dictModules
-    try:
-        for strModule in dictModules:
-            module = dictModules[strModule]
-            if hasattr(module, 'stop_service') and module.ENABLED:
-                module.stop_service()
-        xbmc.log('## LibreELEC Addon ## STOP SERVICE DONE !')
-    except Exception as e:
-        dbg_log('oe::stop_service', f'ERROR: ({repr(e)})')
+    for strModule in dictModules:
+        module = dictModules[strModule]
+        if hasattr(module, 'stop_service') and module.ENABLED:
+            module.stop_service()
+    xbmc.log('## LibreELEC Addon ## STOP SERVICE DONE !')
 
 
+@log.log_function()
 def openWizard():
     global winOeMain, __cwd__, __oe__
-    try:
-        winOeMain = oeWindows.wizard('service-LibreELEC-Settings-wizard.xml', __cwd__, 'Default', oeMain=__oe__)
-        winOeMain.doModal()
-        winOeMain = oeWindows.mainWindow('service-LibreELEC-Settings-mainWindow.xml', __cwd__, 'Default', oeMain=__oe__)  # None
-    except Exception as e:
-        dbg_log('oe::openWizard', f'ERROR: ({repr(e)})')
+    winOeMain = oeWindows.wizard('service-LibreELEC-Settings-wizard.xml', __cwd__, 'Default', oeMain=__oe__)
+    winOeMain.doModal()
+    winOeMain = oeWindows.mainWindow('service-LibreELEC-Settings-mainWindow.xml', __cwd__, 'Default', oeMain=__oe__)  # None
 
 
+@log.log_function()
 def openConfigurationWindow():
     global winOeMain, __cwd__, __oe__, dictModules, PIN
-    try:
-        match = True
+    match = True
 
-        if PIN.isEnabled():
-            match = False
+    if PIN.isEnabled():
+        match = False
 
-            if PIN.isDelayed():
-                timeleft = PIN.delayRemaining()
-                timeleft_mins, timeleft_secs = divmod(timeleft, 60)
-                timeleft_hours, timeleft_mins = divmod(timeleft_mins, 60)
-                xbmcDialog.ok(_(32237), _(32238) % (timeleft_mins, timeleft_secs))
-                return
+        if PIN.isDelayed():
+            timeleft = PIN.delayRemaining()
+            timeleft_mins, timeleft_secs = divmod(timeleft, 60)
+            timeleft_hours, timeleft_mins = divmod(timeleft_mins, 60)
+            xbmcDialog.ok(_(32237), _(32238) % (timeleft_mins, timeleft_secs))
+            return
 
-            while PIN.attemptsRemaining() > 0:
-                lockcode = xbmcDialog.numeric(0, _(32233), bHiddenInput=True)
-                if lockcode == '':
-                    break
+        while PIN.attemptsRemaining() > 0:
+            lockcode = xbmcDialog.numeric(0, _(32233), bHiddenInput=True)
+            if lockcode == '':
+                break
 
-                if PIN.verify(lockcode):
-                    match = True
-                    PIN.success()
-                    break
+            if PIN.verify(lockcode):
+                match = True
+                PIN.success()
+                break
 
-                PIN.fail()
+            PIN.fail()
 
-                if PIN.attemptsRemaining() > 0:
-                    xbmcDialog.ok(_(32234), f'{PIN.attemptsRemaining()} {_(32235)}')
+            if PIN.attemptsRemaining() > 0:
+                xbmcDialog.ok(_(32234), f'{PIN.attemptsRemaining()} {_(32235)}')
 
-            if not match and PIN.attemptsRemaining() <= 0:
-              xbmcDialog.ok(_(32234), _(32236))
-              return
+        if not match and PIN.attemptsRemaining() <= 0:
+            xbmcDialog.ok(_(32234), _(32236))
+            return
 
-        if match == True:
-            winOeMain = oeWindows.mainWindow('service-LibreELEC-Settings-mainWindow.xml', __cwd__, 'Default', oeMain=__oe__)
-            winOeMain.doModal()
-            for strModule in dictModules:
-                dictModules[strModule].exit()
-            winOeMain = None
-            del winOeMain
+    if match == True:
+        winOeMain = oeWindows.mainWindow('service-LibreELEC-Settings-mainWindow.xml', __cwd__, 'Default', oeMain=__oe__)
+        winOeMain.doModal()
+        for strModule in dictModules:
+            dictModules[strModule].exit()
+        winOeMain = None
+        del winOeMain
 
-    except Exception as e:
-        dbg_log('oe::openConfigurationWindow', f'ERROR: ({repr(e)})')
 
+@log.log_function()
 def standby_devices():
     global dictModules
-    try:
-        if 'bluetooth' in dictModules:
-            dictModules['bluetooth'].standby_devices()
-    except Exception as e:
-        dbg_log('oe::standby_devices', f'ERROR: ({repr(e)})')
+    if 'bluetooth' in dictModules:
+        dictModules['bluetooth'].standby_devices()
 
+@log.log_function()
 def load_config():
-    try:
-        global conf_lock
-        while conf_lock:
-            time.sleep(0.2)
-        conf_lock = True
-        if os.path.exists(configFile):
-            config_file = open(configFile, 'r')
-            config_text = config_file.read()
-            config_file.close()
-        else:
-            config_text = ''
-        if config_text == '':
-            xml_conf = minidom.Document()
-            xml_main = xml_conf.createElement('libreelec')
-            xml_conf.appendChild(xml_main)
-            xml_sub = xml_conf.createElement('addon_config')
-            xml_main.appendChild(xml_sub)
-            xml_sub = xml_conf.createElement('settings')
-            xml_main.appendChild(xml_sub)
-            config_text = xml_conf.toprettyxml()
-        else:
-            xml_conf = minidom.parseString(config_text)
-        conf_lock = False
-        return xml_conf
-    except Exception as e:
-        dbg_log('oe::load_config', f'ERROR: ({repr(e)})')
-
-
-def save_config(xml_conf):
-    try:
-        global configFile, conf_lock
-        while conf_lock:
-            time.sleep(0.2)
-        conf_lock = True
-        config_file = open(configFile, 'w')
-        config_file.write(xml_conf.toprettyxml())
+    global conf_lock
+    while conf_lock:
+        time.sleep(0.2)
+    conf_lock = True
+    if os.path.exists(configFile):
+        config_file = open(configFile, 'r')
+        config_text = config_file.read()
         config_file.close()
-        conf_lock = False
-    except Exception as e:
-        dbg_log('oe::save_config', f'ERROR: ({repr(e)})')
+    else:
+        config_text = ''
+    if config_text == '':
+        xml_conf = minidom.Document()
+        xml_main = xml_conf.createElement('libreelec')
+        xml_conf.appendChild(xml_main)
+        xml_sub = xml_conf.createElement('addon_config')
+        xml_main.appendChild(xml_sub)
+        xml_sub = xml_conf.createElement('settings')
+        xml_main.appendChild(xml_sub)
+        config_text = xml_conf.toprettyxml()
+    else:
+        xml_conf = minidom.parseString(config_text)
+    conf_lock = False
+    return xml_conf
 
 
+@log.log_function()
+def save_config(xml_conf):
+    global configFile, conf_lock
+    while conf_lock:
+        time.sleep(0.2)
+    conf_lock = True
+    config_file = open(configFile, 'w')
+    config_file.write(xml_conf.toprettyxml())
+    config_file.close()
+    conf_lock = False
+
+
+@log.log_function()
 def read_module(module):
-    try:
-        xml_conf = load_config()
-        xml_settings = xml_conf.getElementsByTagName('settings')
-        for xml_setting in xml_settings:
-            for xml_modul in xml_setting.getElementsByTagName(module):
-                return xml_modul
-    except Exception as e:
-        dbg_log('oe::read_module', f'ERROR: ({repr(e)})')
+    xml_conf = load_config()
+    xml_settings = xml_conf.getElementsByTagName('settings')
+    for xml_setting in xml_settings:
+        for xml_modul in xml_setting.getElementsByTagName(module):
+            return xml_modul
 
 
+@log.log_function()
 def read_node(node_name):
-    try:
-        xml_conf = load_config()
-        xml_node = xml_conf.getElementsByTagName(node_name)
-        value = {}
-        for xml_main_node in xml_node:
-            value[xml_main_node.nodeName] = {}
-            for xml_sub_node in xml_main_node.childNodes:
-                if len(xml_sub_node.childNodes) == 0:
-                    continue
-                value[xml_main_node.nodeName][xml_sub_node.nodeName] = {}
-                for xml_value in xml_sub_node.childNodes:
-                    if hasattr(xml_value.firstChild, 'nodeValue'):
-                        value[xml_main_node.nodeName][xml_sub_node.nodeName][xml_value.nodeName] = xml_value.firstChild.nodeValue
-                    else:
-                        value[xml_main_node.nodeName][xml_sub_node.nodeName][xml_value.nodeName] = ''
-        return value
-    except Exception as e:
-        dbg_log('oe::read_node', f'ERROR: ({repr(e)})')
+    xml_conf = load_config()
+    xml_node = xml_conf.getElementsByTagName(node_name)
+    value = {}
+    for xml_main_node in xml_node:
+        value[xml_main_node.nodeName] = {}
+        for xml_sub_node in xml_main_node.childNodes:
+            if len(xml_sub_node.childNodes) == 0:
+                continue
+            value[xml_main_node.nodeName][xml_sub_node.nodeName] = {}
+            for xml_value in xml_sub_node.childNodes:
+                if hasattr(xml_value.firstChild, 'nodeValue'):
+                    value[xml_main_node.nodeName][xml_sub_node.nodeName][xml_value.nodeName] = xml_value.firstChild.nodeValue
+                else:
+                    value[xml_main_node.nodeName][xml_sub_node.nodeName][xml_value.nodeName] = ''
+    return value
 
 
+@log.log_function()
 def remove_node(node_name):
-    try:
-        xml_conf = load_config()
-        xml_node = xml_conf.getElementsByTagName(node_name)
-        for xml_main_node in xml_node:
-            xml_main_node.parentNode.removeChild(xml_main_node)
-        save_config(xml_conf)
-    except Exception as e:
-        dbg_log('oe::remove_node', f'ERROR: ({repr(e)})')
+    xml_conf = load_config()
+    xml_node = xml_conf.getElementsByTagName(node_name)
+    for xml_main_node in xml_node:
+        xml_main_node.parentNode.removeChild(xml_main_node)
+    save_config(xml_conf)
 
 
+@log.log_function()
 def read_setting(module, setting, default=None):
-    try:
-        xml_conf = load_config()
-        xml_settings = xml_conf.getElementsByTagName('settings')
-        value = default
-        for xml_setting in xml_settings:
-            for xml_modul in xml_setting.getElementsByTagName(module):
-                for xml_modul_setting in xml_modul.getElementsByTagName(setting):
-                    if hasattr(xml_modul_setting.firstChild, 'nodeValue'):
-                        value = xml_modul_setting.firstChild.nodeValue
-        return value
-    except Exception as e:
-        dbg_log('oe::read_setting', f'ERROR: ({repr(e)})')
+    xml_conf = load_config()
+    xml_settings = xml_conf.getElementsByTagName('settings')
+    value = default
+    for xml_setting in xml_settings:
+        for xml_modul in xml_setting.getElementsByTagName(module):
+            for xml_modul_setting in xml_modul.getElementsByTagName(setting):
+                if hasattr(xml_modul_setting.firstChild, 'nodeValue'):
+                    value = xml_modul_setting.firstChild.nodeValue
+    return value
 
 
+@log.log_function()
 def write_setting(module, setting, value, main_node='settings'):
-    try:
-        xml_conf = load_config()
-        xml_settings = xml_conf.getElementsByTagName(main_node)
-        if len(xml_settings) == 0:
-            for xml_main in xml_conf.getElementsByTagName('libreelec'):
-                xml_sub = xml_conf.createElement(main_node)
-                xml_main.appendChild(xml_sub)
-                xml_settings = xml_conf.getElementsByTagName(main_node)
-        module_found = 0
-        setting_found = 0
-        for xml_setting in xml_settings:
-            for xml_modul in xml_setting.getElementsByTagName(module):
-                module_found = 1
-                for xml_modul_setting in xml_modul.getElementsByTagName(setting):
-                    setting_found = 1
-        if setting_found == 1:
-            if hasattr(xml_modul_setting.firstChild, 'nodeValue'):
-                xml_modul_setting.firstChild.nodeValue = value
-            else:
-                xml_value = xml_conf.createTextNode(value)
-                xml_modul_setting.appendChild(xml_value)
+    xml_conf = load_config()
+    xml_settings = xml_conf.getElementsByTagName(main_node)
+    if len(xml_settings) == 0:
+        for xml_main in xml_conf.getElementsByTagName('libreelec'):
+            xml_sub = xml_conf.createElement(main_node)
+            xml_main.appendChild(xml_sub)
+            xml_settings = xml_conf.getElementsByTagName(main_node)
+    module_found = 0
+    setting_found = 0
+    for xml_setting in xml_settings:
+        for xml_modul in xml_setting.getElementsByTagName(module):
+            module_found = 1
+            for xml_modul_setting in xml_modul.getElementsByTagName(setting):
+                setting_found = 1
+    if setting_found == 1:
+        if hasattr(xml_modul_setting.firstChild, 'nodeValue'):
+            xml_modul_setting.firstChild.nodeValue = value
         else:
-            if module_found == 0:
-                xml_modul = xml_conf.createElement(module)
-                xml_setting.appendChild(xml_modul)
-            xml_setting = xml_conf.createElement(setting)
-            xml_modul.appendChild(xml_setting)
             xml_value = xml_conf.createTextNode(value)
-            xml_setting.appendChild(xml_value)
-        save_config(xml_conf)
-    except Exception as e:
-        dbg_log('oe::write_setting', f'ERROR: ({repr(e)})')
+            xml_modul_setting.appendChild(xml_value)
+    else:
+        if module_found == 0:
+            xml_modul = xml_conf.createElement(module)
+            xml_setting.appendChild(xml_modul)
+        xml_setting = xml_conf.createElement(setting)
+        xml_modul.appendChild(xml_setting)
+        xml_value = xml_conf.createTextNode(value)
+        xml_setting.appendChild(xml_value)
+    save_config(xml_conf)
 
 
+@log.log_function()
 def load_modules():
-
-  # # load libreelec configuration modules
-
-    try:
-        global dictModules, __oe__, __cwd__, init_done
-        for strModule in dictModules:
-            dictModules[strModule] = None
-        dict_names = {}
-        dictModules = {}
-        for file_name in sorted(os.listdir(f'{__cwd__}/resources/lib/modules')):
-            if not file_name.startswith('__') and (file_name.endswith('.py') or file_name.endswith('.pyc')):
-                (name, ext) = file_name.split('.')
-                dict_names[name] = None
-        for module_name in dict_names:
-            try:
-                if not module_name in dictModules:
-                    dictModules[module_name] = getattr(__import__(module_name), module_name)(__oe__)
-                    if hasattr(defaults, module_name):
-                        for key in getattr(defaults, module_name):
-                            setattr(dictModules[module_name], key, getattr(defaults, module_name)[key])
-            except Exception as e:
-                dbg_log('oe::MAIN(loadingModules)(strModule)', f'ERROR: ({repr(e)})')
-    except Exception as e:
-        dbg_log('oe::MAIN(loadingModules)', f'ERROR: ({repr(e)})')
+    # # load libreelec configuration modules
+    global dictModules, __oe__, __cwd__, init_done
+    for strModule in dictModules:
+        dictModules[strModule] = None
+    dict_names = {}
+    dictModules = {}
+    for file_name in sorted(os.listdir(f'{__cwd__}/resources/lib/modules')):
+        if not file_name.startswith('__') and (file_name.endswith('.py') or file_name.endswith('.pyc')):
+            (name, ext) = file_name.split('.')
+            dict_names[name] = None
+    for module_name in dict_names:
+        try:
+            if not module_name in dictModules:
+                dictModules[module_name] = getattr(__import__(module_name), module_name)(__oe__)
+                if hasattr(defaults, module_name):
+                    for key in getattr(defaults, module_name):
+                        setattr(dictModules[module_name], key, getattr(defaults, module_name)[key])
+        except Exception as e:
+            log.log(f'oe::MAIN(loadingModules)(strModule): ERROR: ({repr(e)})', log.ERROR)
 
 
 def timestamp():

--- a/resources/lib/oeWindows.py
+++ b/resources/lib/oeWindows.py
@@ -13,6 +13,7 @@ import xbmc
 import xbmcgui
 import xbmcaddon
 
+import log
 import oe
 
 
@@ -63,128 +64,119 @@ class mainWindow(xbmcgui.WindowXMLDialog):
             self.isChild = True
         pass
 
+    @log.log_function()
     def onInit(self):
         self.visible = True
-        try:
-            if self.isChild:
-                self.setFocusId(self.guiMenList)
-                self.onFocus(self.guiMenList)
-                return
-            self.setProperty('arch', oe.ARCHITECTURE)
-            self.setProperty('distri', oe.DISTRIBUTION)
-            self.setProperty('version', oe.VERSION)
-            self.setProperty('build', oe.BUILD)
-            oe.winOeMain = self
-            for strModule in sorted(oe.dictModules, key=lambda x: list(oe.dictModules[x].menu.keys())):
-                module = oe.dictModules[strModule]
-                oe.dbg_log('init module', strModule, oe.LOGDEBUG)
-                if module.ENABLED:
-                    if hasattr(module, 'do_init'):
-                        Thread(target=module.do_init(), args=()).start()
-                    for men in module.menu:
-                        if 'listTyp' in module.menu[men] and 'menuLoader' in module.menu[men]:
-                            dictProperties = {
-                                'modul': strModule,
-                                'listTyp': oe.listObject[module.menu[men]['listTyp']],
-                                'menuLoader': module.menu[men]['menuLoader'],
-                                }
-                            if 'InfoText' in module.menu[men]:
-                                dictProperties['InfoText'] = oe._(module.menu[men]['InfoText'])
-                            self.addMenuItem(module.menu[men]['name'], dictProperties)
+        if self.isChild:
             self.setFocusId(self.guiMenList)
             self.onFocus(self.guiMenList)
-        except Exception as e:
-            oe.dbg_log('oeWindows.mainWindow::onInit', f'ERROR: ({repr(e)})')
+            return
+        self.setProperty('arch', oe.ARCHITECTURE)
+        self.setProperty('distri', oe.DISTRIBUTION)
+        self.setProperty('version', oe.VERSION)
+        self.setProperty('build', oe.BUILD)
+        oe.winOeMain = self
+        for strModule in sorted(oe.dictModules, key=lambda x: list(oe.dictModules[x].menu.keys())):
+            module = oe.dictModules[strModule]
+            log.log(f'init module: {strModule}', log.DEBUG)
+            if module.ENABLED:
+                if hasattr(module, 'do_init'):
+                    Thread(target=module.do_init(), args=()).start()
+                for men in module.menu:
+                    if 'listTyp' in module.menu[men] and 'menuLoader' in module.menu[men]:
+                        dictProperties = {
+                            'modul': strModule,
+                            'listTyp': oe.listObject[module.menu[men]['listTyp']],
+                            'menuLoader': module.menu[men]['menuLoader'],
+                            }
+                        if 'InfoText' in module.menu[men]:
+                            dictProperties['InfoText'] = oe._(module.menu[men]['InfoText'])
+                        self.addMenuItem(module.menu[men]['name'], dictProperties)
+        self.setFocusId(self.guiMenList)
+        self.onFocus(self.guiMenList)
 
+    @log.log_function()
     def addMenuItem(self, strName, dictProperties):
-        try:
-            lstItem = xbmcgui.ListItem(label=oe._(strName))
-            for strProp in dictProperties:
-                lstItem.setProperty(strProp, str(dictProperties[strProp]))
-            self.getControl(self.guiMenList).addItem(lstItem)
-        except Exception as e:
-            oe.dbg_log(f'oeWindows.mainWindow::addMenuItem({str(strName)})', f'ERROR: ({repr(e)})')
+        lstItem = xbmcgui.ListItem(label=oe._(strName))
+        for strProp in dictProperties:
+            lstItem.setProperty(strProp, str(dictProperties[strProp]))
+        self.getControl(self.guiMenList).addItem(lstItem)
 
+    @log.log_function()
     def addConfigItem(self, strName, dictProperties, strType):
-        try:
-            lstItem = xbmcgui.ListItem(label=strName)
-            for strProp in dictProperties:
-                lstItem.setProperty(strProp, str(dictProperties[strProp]))
-            self.getControl(int(strType)).addItem(lstItem)
-            return lstItem
-        except Exception as e:
-            oe.dbg_log(f'oeWindows.mainWindow::addConfigItem({strName})', f'ERROR: ({repr(e)})')
+        lstItem = xbmcgui.ListItem(label=strName)
+        for strProp in dictProperties:
+            lstItem.setProperty(strProp, str(dictProperties[strProp]))
+        self.getControl(int(strType)).addItem(lstItem)
+        return lstItem
 
+    @log.log_function()
     def build_menu(self, struct, fltr=[], optional='0'):
-        try:
-            self.getControl(1100).reset()
-            m_menu = []
-            for category in sorted(struct, key=lambda x: struct[x]['order']):
-                if not 'hidden' in struct[category]:
-                    if fltr == []:
+        self.getControl(1100).reset()
+        m_menu = []
+        for category in sorted(struct, key=lambda x: struct[x]['order']):
+            if not 'hidden' in struct[category]:
+                if fltr == []:
+                    m_entry = {}
+                    m_entry['name'] = oe._(struct[category]['name'])
+                    m_entry['properties'] = {'typ': 'separator'}
+                    m_entry['list'] = 1100
+                    m_menu.append(m_entry)
+                else:
+                    if category not in fltr:
+                        continue
+                for entry in sorted(struct[category]['settings'], key=lambda x: struct[category]['settings'][x]['order']):
+                    setting = struct[category]['settings'][entry]
+                    if not 'hidden' in setting:
+                        dictProperties = {
+                            'value': setting['value'],
+                            'typ': setting['type'],
+                            'entry': entry,
+                            'category': category,
+                            'action': setting['action'],
+                            }
+                        if 'InfoText' in setting:
+                            dictProperties['InfoText'] = oe._(setting['InfoText'])
+                        if 'validate' in setting:
+                            dictProperties['validate'] = setting['validate']
+                        if 'values' in setting and setting['values'] is not None:
+                            dictProperties['values'] = '|'.join(setting['values'])
+                        if isinstance(setting['name'], str):
+                            name = setting['name']
+                        else:
+                            name = oe._(setting['name'])
+                            dictProperties['menuname'] = oe._(setting['name'])
                         m_entry = {}
-                        m_entry['name'] = oe._(struct[category]['name'])
-                        m_entry['properties'] = {'typ': 'separator'}
-                        m_entry['list'] = 1100
-                        m_menu.append(m_entry)
-                    else:
-                        if category not in fltr:
-                            continue
-                    for entry in sorted(struct[category]['settings'], key=lambda x: struct[category]['settings'][x]['order']):
-                        setting = struct[category]['settings'][entry]
-                        if not 'hidden' in setting:
-                            dictProperties = {
-                                'value': setting['value'],
-                                'typ': setting['type'],
-                                'entry': entry,
-                                'category': category,
-                                'action': setting['action'],
-                                }
-                            if 'InfoText' in setting:
-                                dictProperties['InfoText'] = oe._(setting['InfoText'])
-                            if 'validate' in setting:
-                                dictProperties['validate'] = setting['validate']
-                            if 'values' in setting and setting['values'] is not None:
-                                dictProperties['values'] = '|'.join(setting['values'])
-                            if isinstance(setting['name'], str):
-                                name = setting['name']
-                            else:
-                                name = oe._(setting['name'])
-                                dictProperties['menuname'] = oe._(setting['name'])
-                            m_entry = {}
-                            if not 'parent' in setting:
-                                m_entry['name'] = name
-                                m_entry['properties'] = dictProperties
-                                m_entry['list'] = 1100
-                                m_menu.append(m_entry)
-                            else:
-                                if struct[category]['settings'][setting['parent']['entry']]['value'] in setting['parent']['value']:
-                                    if not 'optional' in setting or 'optional' in setting and optional != '0':
-                                        m_entry['name'] = name
-                                        m_entry['properties'] = dictProperties
-                                        m_entry['list'] = 1100
-                                        m_menu.append(m_entry)
-            for m_entry in m_menu:
-                self.addConfigItem(m_entry['name'], m_entry['properties'], m_entry['list'])
-        except Exception as e:
-            oe.dbg_log('oeWindows.mainWindow::build_menu', f'ERROR: ({repr(e)})')
+                        if not 'parent' in setting:
+                            m_entry['name'] = name
+                            m_entry['properties'] = dictProperties
+                            m_entry['list'] = 1100
+                            m_menu.append(m_entry)
+                        else:
+                            if struct[category]['settings'][setting['parent']['entry']]['value'] in setting['parent']['value']:
+                                if not 'optional' in setting or 'optional' in setting and optional != '0':
+                                    m_entry['name'] = name
+                                    m_entry['properties'] = dictProperties
+                                    m_entry['list'] = 1100
+                                    m_menu.append(m_entry)
+        for m_entry in m_menu:
+            self.addConfigItem(m_entry['name'], m_entry['properties'], m_entry['list'])
 
+    @log.log_function()
     def showButton(self, number, name, module, action, onup=None, onleft=None):
-        try:
-            oe.dbg_log('oeWindows::showButton', 'enter_function', oe.LOGDEBUG)
-            button = self.getControl(self.buttons[number]['id'])
-            self.buttons[number]['modul'] = module
-            self.buttons[number]['action'] = action
-            button.setLabel(oe._(name))
-            if onup != None:
-                button.controlUp(self.getControl(onup))
-            if onleft != None:
-                button.controlLeft(self.getControl(onleft))
-            button.setVisible(True)
-            oe.dbg_log('oeWindows::showButton', 'exit_function', oe.LOGDEBUG)
-        except Exception as e:
-            oe.dbg_log(f'oeWindows.mainWindow::showButton({str(number)}, {str(action)})', f'ERROR: ({repr(e)})')
+        log.log('enter_function', log.DEBUG)
+        button = self.getControl(self.buttons[number]['id'])
+        self.buttons[number]['modul'] = module
+        self.buttons[number]['action'] = action
+        button.setLabel(oe._(name))
+        if onup != None:
+            button.controlUp(self.getControl(onup))
+        if onleft != None:
+            button.controlLeft(self.getControl(onleft))
+        button.setVisible(True)
+        log.log('exit_function', log.DEBUG)
 
+    @log.log_function()
     def onAction(self, action):
         try:
             focusId = self.getFocusId()
@@ -222,166 +214,161 @@ class mainWindow(xbmcgui.WindowXMLDialog):
                     self.setProperty('InfoText', nextItem.getProperty('InfoText'))
             if focusId == self.guiMenList:
                 self.setFocusId(focusId)
-        except Exception as e:
-            oe.dbg_log(f'oeWindows.mainWindow::onAction({str(action)})', f'ERROR: ({repr(e)})')
+        except Exception:
             if actionId in oe.CANCEL:
                 self.close()
 
+    @log.log_function()
     def onClick(self, controlID):
-        oe.dbg_log('oeWindows::onClick', 'enter_function', oe.LOGDEBUG)
-        try:
-            for btn in self.buttons:
-                if controlID == self.buttons[btn]['id']:
-                    modul = self.buttons[btn]['modul']
-                    action = self.buttons[btn]['action']
-                    if hasattr(oe.dictModules[modul], action):
-                        if getattr(oe.dictModules[modul], action)() == 'close':
-                            self.close()
-                        return
-            if controlID in self.guiLists:
-                selectedPosition = self.getControl(controlID).getSelectedPosition()
-                selectedMenuItem = self.getControl(self.guiMenList).getSelectedItem()
-                selectedItem = self.getControl(controlID).getSelectedItem()
-                strTyp = selectedItem.getProperty('typ')
-                strValue = selectedItem.getProperty('value')
-                if strTyp == 'multivalue':
-                    items1 = []
-                    items2 = []
-                    for item in selectedItem.getProperty('values').split('|'):
-                        if item != ':':
-                            boo = item.split(':')
-                            if len(boo) > 1:
-                                i1 = boo[0]
-                                i2 = boo[1]
-                            else:
-                                i1 = item
-                                i2 = item
+        log.log('enter_function', log.DEBUG)
+        for btn in self.buttons:
+            if controlID == self.buttons[btn]['id']:
+                modul = self.buttons[btn]['modul']
+                action = self.buttons[btn]['action']
+                if hasattr(oe.dictModules[modul], action):
+                    if getattr(oe.dictModules[modul], action)() == 'close':
+                        self.close()
+                    return
+        if controlID in self.guiLists:
+            selectedPosition = self.getControl(controlID).getSelectedPosition()
+            selectedMenuItem = self.getControl(self.guiMenList).getSelectedItem()
+            selectedItem = self.getControl(controlID).getSelectedItem()
+            strTyp = selectedItem.getProperty('typ')
+            strValue = selectedItem.getProperty('value')
+            if strTyp == 'multivalue':
+                items1 = []
+                items2 = []
+                for item in selectedItem.getProperty('values').split('|'):
+                    if item != ':':
+                        boo = item.split(':')
+                        if len(boo) > 1:
+                            i1 = boo[0]
+                            i2 = boo[1]
                         else:
-                            i1 = ''
-                            i2 = ''
-                        if i2 == strValue:
-                            items1.insert(0, i1)
-                            items2.insert(0, i2)
-                        else:
-                            # move current on top of the list
-                            items1.append(i1)
-                            items2.append(i2)
-                    select_window = xbmcgui.Dialog()
-                    title = selectedItem.getProperty('menuname')
-                    result = select_window.select(title, items1)
-                    if result >= 0:
-                        selectedItem.setProperty('value', items2[result])
-                elif strTyp == 'text':
-                    xbmcKeyboard = xbmc.Keyboard(strValue)
-                    result_is_valid = False
-                    while not result_is_valid:
-                        xbmcKeyboard.doModal()
-                        if xbmcKeyboard.isConfirmed():
-                            result_is_valid = True
-                            validate_string = selectedItem.getProperty('validate')
-                            if validate_string != '':
-                                if not re.search(validate_string, xbmcKeyboard.getText()):
-                                    result_is_valid = False
-                        else:
-                            result_is_valid = True
-                    if xbmcKeyboard.isConfirmed():
-                        selectedItem.setProperty('value', xbmcKeyboard.getText())
-                elif strTyp == 'file':
-                    xbmcDialog = xbmcgui.Dialog()
-                    returnValue = xbmcDialog.browse(1, 'LibreELEC.tv', 'files', '', False, False, '/')
-                    if returnValue != '' and returnValue != '/':
-                        selectedItem.setProperty('value', str(returnValue))
-                elif strTyp == 'folder':
-                    xbmcDialog = xbmcgui.Dialog()
-                    returnValue = xbmcDialog.browse(0, 'LibreELEC.tv', 'files', '', False, False, '/storage')
-                    if returnValue != '' and returnValue != '/':
-                        selectedItem.setProperty('value', str(returnValue))
-                elif strTyp == 'ip':
-                    if strValue == '':
-                        strValue = '0.0.0.0'
-                    xbmcDialog = xbmcgui.Dialog()
-                    returnValue = xbmcDialog.numeric(3, 'LibreELEC.tv', strValue)
-                    if returnValue != '':
-                        if returnValue == '0.0.0.0':
-                            selectedItem.setProperty('value', '')
-                        else:
-                            selectedItem.setProperty('value', returnValue)
-                elif strTyp == 'num':
-                    if strValue == 'None' or strValue == '':
-                        strValue = '0'
-                    xbmcDialog = xbmcgui.Dialog()
-                    returnValue = xbmcDialog.numeric(0, 'LibreELEC.tv', strValue)
-                    if returnValue != '':
-                        selectedItem.setProperty('value', returnValue)
-                elif strTyp == 'bool':
-                    strValue = strValue.lower()
-                    if strValue == '0':
-                        selectedItem.setProperty('value', '1')
-                    elif strValue == '1':
-                        selectedItem.setProperty('value', '0')
-                    elif strValue == 'true':
-                        selectedItem.setProperty('value', 'false')
-                    elif strValue == 'false':
-                        selectedItem.setProperty('value', 'true')
+                            i1 = item
+                            i2 = item
                     else:
-                        selectedItem.setProperty('value', '1')
-                if selectedItem.getProperty('action') != '':
-                    if hasattr(oe.dictModules[selectedMenuItem.getProperty('modul')], selectedItem.getProperty('action')):
-                        getattr(oe.dictModules[selectedMenuItem.getProperty('modul')], selectedItem.getProperty('action'
-                                ))(listItem=selectedItem)
-                        self.emptyButtonLabels()
-                self.lastMenu = -1
-                self.onFocus(self.guiMenList)
-                self.setFocusId(controlID)
-                self.getControl(controlID).selectItem(selectedPosition)
-            oe.dbg_log('oeWindows::onClick', 'exit_function', oe.LOGDEBUG)
-        except Exception as e:
-            oe.dbg_log(f'oeWindows.mainWindow::onClick({str(controlID)})', f'ERROR: ({repr(e)})')
+                        i1 = ''
+                        i2 = ''
+                    if i2 == strValue:
+                        items1.insert(0, i1)
+                        items2.insert(0, i2)
+                    else:
+                        # move current on top of the list
+                        items1.append(i1)
+                        items2.append(i2)
+                select_window = xbmcgui.Dialog()
+                title = selectedItem.getProperty('menuname')
+                result = select_window.select(title, items1)
+                if result >= 0:
+                    selectedItem.setProperty('value', items2[result])
+            elif strTyp == 'text':
+                xbmcKeyboard = xbmc.Keyboard(strValue)
+                result_is_valid = False
+                while not result_is_valid:
+                    xbmcKeyboard.doModal()
+                    if xbmcKeyboard.isConfirmed():
+                        result_is_valid = True
+                        validate_string = selectedItem.getProperty('validate')
+                        if validate_string != '':
+                            if not re.search(validate_string, xbmcKeyboard.getText()):
+                                result_is_valid = False
+                    else:
+                        result_is_valid = True
+                if xbmcKeyboard.isConfirmed():
+                    selectedItem.setProperty('value', xbmcKeyboard.getText())
+            elif strTyp == 'file':
+                xbmcDialog = xbmcgui.Dialog()
+                returnValue = xbmcDialog.browse(1, 'LibreELEC.tv', 'files', '', False, False, '/')
+                if returnValue != '' and returnValue != '/':
+                    selectedItem.setProperty('value', str(returnValue))
+            elif strTyp == 'folder':
+                xbmcDialog = xbmcgui.Dialog()
+                returnValue = xbmcDialog.browse(0, 'LibreELEC.tv', 'files', '', False, False, '/storage')
+                if returnValue != '' and returnValue != '/':
+                    selectedItem.setProperty('value', str(returnValue))
+            elif strTyp == 'ip':
+                if strValue == '':
+                    strValue = '0.0.0.0'
+                xbmcDialog = xbmcgui.Dialog()
+                returnValue = xbmcDialog.numeric(3, 'LibreELEC.tv', strValue)
+                if returnValue != '':
+                    if returnValue == '0.0.0.0':
+                        selectedItem.setProperty('value', '')
+                    else:
+                        selectedItem.setProperty('value', returnValue)
+            elif strTyp == 'num':
+                if strValue == 'None' or strValue == '':
+                    strValue = '0'
+                xbmcDialog = xbmcgui.Dialog()
+                returnValue = xbmcDialog.numeric(0, 'LibreELEC.tv', strValue)
+                if returnValue != '':
+                    selectedItem.setProperty('value', returnValue)
+            elif strTyp == 'bool':
+                strValue = strValue.lower()
+                if strValue == '0':
+                    selectedItem.setProperty('value', '1')
+                elif strValue == '1':
+                    selectedItem.setProperty('value', '0')
+                elif strValue == 'true':
+                    selectedItem.setProperty('value', 'false')
+                elif strValue == 'false':
+                    selectedItem.setProperty('value', 'true')
+                else:
+                    selectedItem.setProperty('value', '1')
+            if selectedItem.getProperty('action') != '':
+                if hasattr(oe.dictModules[selectedMenuItem.getProperty('modul')], selectedItem.getProperty('action')):
+                    getattr(oe.dictModules[selectedMenuItem.getProperty('modul')], selectedItem.getProperty('action'
+                            ))(listItem=selectedItem)
+                    self.emptyButtonLabels()
+            self.lastMenu = -1
+            self.onFocus(self.guiMenList)
+            self.setFocusId(controlID)
+            self.getControl(controlID).selectItem(selectedPosition)
+        log.log('exit_function', log.DEBUG)
 
     def onUnload(self):
         pass
 
+    @log.log_function()
     def onFocus(self, controlID):
-        try:
-            if controlID in self.guiLists:
-                currentEntry = self.getControl(controlID).getSelectedPosition()
-                selectedEntry = self.getControl(controlID).getSelectedItem()
-                if controlID == self.guiList:
-                    self.setProperty('InfoText', selectedEntry.getProperty('InfoText'))
-                if currentEntry != self.lastGuiList:
-                    self.lastGuiList = currentEntry
-                    if selectedEntry is not None:
-                        strHoover = selectedEntry.getProperty('hooverValidate')
-                        if strHoover != '':
-                            if hasattr(oe.dictModules[selectedEntry.getProperty('modul')], strHoover):
-                                self.emptyButtonLabels()
-                                getattr(oe.dictModules[selectedEntry.getProperty('modul')], strHoover)(selectedEntry)
-            if controlID == self.guiMenList:
-                lastMenu = self.getControl(controlID).getSelectedPosition()
-                selectedMenuItem = self.getControl(controlID).getSelectedItem()
-                self.setProperty('InfoText', selectedMenuItem.getProperty('InfoText'))
-                if lastMenu != self.lastMenu:
-                    if self.lastListType == int(selectedMenuItem.getProperty('listTyp')):
-                        self.getControl(int(selectedMenuItem.getProperty('listTyp'))).setAnimations([('conditional',
-                                'effect=fade start=100 end=0 time=100 condition=True')])
-                    self.getControl(1100).setAnimations([('conditional', 'effect=fade start=0 end=0 time=1 condition=True')])
-                    self.getControl(1200).setAnimations([('conditional', 'effect=fade start=0 end=0 time=1 condition=True')])
-                    self.getControl(1300).setAnimations([('conditional', 'effect=fade start=0 end=0 time=1 condition=True')])
-                    self.getControl(1900).setAnimations([('conditional', 'effect=fade start=0 end=0 time=1 condition=True')])
-                    self.lastModul = selectedMenuItem.getProperty('Modul')
-                    self.lastMenu = lastMenu
-                    for btn in self.buttons:
-                        self.getControl(self.buttons[btn]['id']).setVisible(False)
-                    strMenuLoader = selectedMenuItem.getProperty('menuLoader')
-                    objList = self.getControl(int(selectedMenuItem.getProperty('listTyp')))
-                    self.getControl(controlID).controlRight(objList)
-                    if strMenuLoader != '':
-                        if hasattr(oe.dictModules[selectedMenuItem.getProperty('modul')], strMenuLoader):
-                            getattr(oe.dictModules[selectedMenuItem.getProperty('modul')], strMenuLoader)(selectedMenuItem)
+        if controlID in self.guiLists:
+            currentEntry = self.getControl(controlID).getSelectedPosition()
+            selectedEntry = self.getControl(controlID).getSelectedItem()
+            if controlID == self.guiList:
+                self.setProperty('InfoText', selectedEntry.getProperty('InfoText'))
+            if currentEntry != self.lastGuiList:
+                self.lastGuiList = currentEntry
+                if selectedEntry is not None:
+                    strHoover = selectedEntry.getProperty('hooverValidate')
+                    if strHoover != '':
+                        if hasattr(oe.dictModules[selectedEntry.getProperty('modul')], strHoover):
+                            self.emptyButtonLabels()
+                            getattr(oe.dictModules[selectedEntry.getProperty('modul')], strHoover)(selectedEntry)
+        if controlID == self.guiMenList:
+            lastMenu = self.getControl(controlID).getSelectedPosition()
+            selectedMenuItem = self.getControl(controlID).getSelectedItem()
+            self.setProperty('InfoText', selectedMenuItem.getProperty('InfoText'))
+            if lastMenu != self.lastMenu:
+                if self.lastListType == int(selectedMenuItem.getProperty('listTyp')):
                     self.getControl(int(selectedMenuItem.getProperty('listTyp'))).setAnimations([('conditional',
-                            'effect=fade start=0 end=100 time=100 condition=true')])
-        except Exception as e:
-            oe.dbg_log(f'oeWindows.mainWindow::onFocus({repr(controlID)})', f'ERROR: ({repr(e)})')
+                            'effect=fade start=100 end=0 time=100 condition=True')])
+                self.getControl(1100).setAnimations([('conditional', 'effect=fade start=0 end=0 time=1 condition=True')])
+                self.getControl(1200).setAnimations([('conditional', 'effect=fade start=0 end=0 time=1 condition=True')])
+                self.getControl(1300).setAnimations([('conditional', 'effect=fade start=0 end=0 time=1 condition=True')])
+                self.getControl(1900).setAnimations([('conditional', 'effect=fade start=0 end=0 time=1 condition=True')])
+                self.lastModul = selectedMenuItem.getProperty('Modul')
+                self.lastMenu = lastMenu
+                for btn in self.buttons:
+                    self.getControl(self.buttons[btn]['id']).setVisible(False)
+                strMenuLoader = selectedMenuItem.getProperty('menuLoader')
+                objList = self.getControl(int(selectedMenuItem.getProperty('listTyp')))
+                self.getControl(controlID).controlRight(objList)
+                if strMenuLoader != '':
+                    if hasattr(oe.dictModules[selectedMenuItem.getProperty('modul')], strMenuLoader):
+                        getattr(oe.dictModules[selectedMenuItem.getProperty('modul')], strMenuLoader)(selectedMenuItem)
+                self.getControl(int(selectedMenuItem.getProperty('listTyp'))).setAnimations([('conditional',
+                        'effect=fade start=0 end=100 time=100 condition=true')])
 
     def emptyButtonLabels(self):
         for btn in self.buttons:
@@ -465,269 +452,243 @@ class wizard(xbmcgui.WindowXMLDialog):
         self.wizards = []
         self.last_wizard = None
 
+    @log.log_function()
     def onInit(self):
         self.visible = True
-        try:
-            self.setProperty('arch', oe.ARCHITECTURE)
-            self.setProperty('distri', oe.DISTRIBUTION)
-            self.setProperty('version', oe.VERSION)
-            self.setProperty('build', oe.BUILD)
-            oe.dictModules['system'].do_init()
-            self.getControl(self.wizWinTitle).setLabel(oe._(32300))
-            self.getControl(self.buttons[3]['id']).setVisible(False)
-            self.getControl(self.buttons[4]['id']).setVisible(False)
-            self.getControl(self.radiobuttons[1]['id']).setVisible(False)
-            self.getControl(self.radiobuttons[2]['id']).setVisible(False)
-            self.getControl(self.buttons[2]['id']).setVisible(False)
-            if oe.BOOT_STATUS == "SAFE":
-              self.set_wizard_title(f"[COLOR red][B]{oe._(32393)}[/B][/COLOR]")
-              self.set_wizard_text(oe._(32394))
-            else:
-              self.set_wizard_title(oe._(32301))
-              self.set_wizard_text(oe._(32302))
-              oe.winOeMain.set_wizard_button_title(oe._(32310))
-              cur_lang = xbmc.getLanguage()
-              oe.winOeMain.set_wizard_button_1(cur_lang, self, 'wizard_set_language')
-            self.showButton(1, 32303)
-            self.setFocusId(self.buttons[1]['id'])
-        except Exception as e:
-            oe.dbg_log('oeWindows.wizard::onInit()', f'ERROR: ({repr(e)})')
+        self.setProperty('arch', oe.ARCHITECTURE)
+        self.setProperty('distri', oe.DISTRIBUTION)
+        self.setProperty('version', oe.VERSION)
+        self.setProperty('build', oe.BUILD)
+        oe.dictModules['system'].do_init()
+        self.getControl(self.wizWinTitle).setLabel(oe._(32300))
+        self.getControl(self.buttons[3]['id']).setVisible(False)
+        self.getControl(self.buttons[4]['id']).setVisible(False)
+        self.getControl(self.radiobuttons[1]['id']).setVisible(False)
+        self.getControl(self.radiobuttons[2]['id']).setVisible(False)
+        self.getControl(self.buttons[2]['id']).setVisible(False)
+        if oe.BOOT_STATUS == "SAFE":
+            self.set_wizard_title(f"[COLOR red][B]{oe._(32393)}[/B][/COLOR]")
+            self.set_wizard_text(oe._(32394))
+        else:
+            self.set_wizard_title(oe._(32301))
+            self.set_wizard_text(oe._(32302))
+            oe.winOeMain.set_wizard_button_title(oe._(32310))
+            cur_lang = xbmc.getLanguage()
+            oe.winOeMain.set_wizard_button_1(cur_lang, self, 'wizard_set_language')
+        self.showButton(1, 32303)
+        self.setFocusId(self.buttons[1]['id'])
 
+    @log.log_function()
     def wizard_set_language(self):
         global lang_new
-        try:
-            oe.dbg_log('oeWindows::wizard_set_language', 'enter_function', oe.LOGDEBUG)
-            langCodes = {"Bulgarian":"resource.language.bg_bg","Czech":"resource.language.cs_cz","German":"resource.language.de_de","English":"resource.language.en_gb","Spanish":"resource.language.es_es","Basque":"resource.language.eu_es","Finnish":"resource.language.fi_fi","French":"resource.language.fr_fr","Hebrew":"resource.language.he_il","Hungarian":"resource.language.hu_hu","Italian":"resource.language.it_it","Lithuanian":"resource.language.lt_lt","Latvian":"resource.language.lv_lv","Norwegian":"resource.language.nb_no","Dutch":"resource.language.nl_nl","Polish":"resource.language.pl_pl","Portuguese (Brazil)":"resource.language.pt_br","Portuguese":"resource.language.pt_pt","Romanian":"resource.language.ro_ro","Russian":"resource.language.ru_ru","Slovak":"resource.language.sk_sk","Swedish":"resource.language.sv_se","Turkish":"resource.language.tr_tr","Ukrainian":"resource.language.uk_ua"}
-            languagesList = sorted(list(langCodes.keys()))
-            cur_lang = xbmc.getLanguage()
-            for index, lang in enumerate(languagesList):
-                if cur_lang in lang:
-                    langIndex = index
-                    break
-                else:
-                    pass
-            selLanguage = xbmcDialog.select(oe._(32310), languagesList, preselect=langIndex)
-            if selLanguage >= 0:
-                langKey = languagesList[selLanguage]
-                lang_new = langCodes[langKey]
-                if lang_new == "resource.language.en_gb":
-                    oe.write_setting("system", "language", "")
-                else:
-                    oe.write_setting("system", "language", str(lang_new))
-                self.getControl(self.wizWinTitle).setLabel(oe._(32300))
-                self.set_wizard_title(oe._(32301))
-                self.set_wizard_text(oe._(32302))
-                oe.winOeMain.set_wizard_button_title(oe._(32310))
-                oe.winOeMain.set_wizard_button_1(langKey, self, 'wizard_set_language')
-                self.showButton(1, 32303)
-                self.setFocusId(self.buttons[1]['id'])
-            oe.dbg_log('oeWindows::wizard_set_language', 'exit_function', oe.LOGDEBUG)
-        except Exception as e:
-            oe.dbg_log('oeWindows::wizard_set_language', f'ERROR: ({repr(e)})')
-
-    def set_wizard_text(self, text):
-        try:
-            self.getControl(self.wizTextbox).setText(text)
-        except Exception as e:
-            oe.dbg_log('oeWindows.wizard::set_wizard_text()', f'ERROR: ({repr(e)})')
-
-    def set_wizard_title(self, title):
-        try:
-            self.getControl(self.wizTitle).setLabel(title)
-        except Exception as e:
-            oe.dbg_log('oeWindows.wizard::set_wizard_title()', f'ERROR: ({repr(e)})')
-
-    def set_wizard_button_title(self, title):
-        try:
-            self.getControl(self.wizBtnTitle).setLabel(title)
-        except Exception as e:
-            oe.dbg_log('oeWindows.wizard::set_wizard_button_title()', f'ERROR: ({repr(e)})')
-
-    def set_wizard_list_title(self, title):
-        try:
-            self.getControl(self.wizLstTitle).setLabel(title)
-        except Exception as e:
-            oe.dbg_log('oeWindows.wizard::set_wizard_list_title()', f'ERROR: ({repr(e)})')
-
-    def set_wizard_button_1(self, label, modul, action):
-        try:
-            self.buttons[3]['modul'] = modul
-            self.buttons[3]['action'] = action
-            self.getControl(self.buttons[3]['id']).setLabel(label)
-            self.getControl(self.buttons[3]['id']).setVisible(True)
-            self.getControl(self.buttons[3]['id']).controlRight(self.getControl(self.buttons[1]['id']))
-            self.getControl(self.buttons[3]['id']).controlDown(self.getControl(self.buttons[1]['id']))
-            self.getControl(self.buttons[1]['id']).controlUp(self.getControl(self.buttons[3]['id']))
-            if self.buttons[2]['id']:
-                self.getControl(self.buttons[1]['id']).controlLeft(self.getControl(self.buttons[2]['id']))
+        log.log('enter_function', log.DEBUG)
+        langCodes = {"Bulgarian":"resource.language.bg_bg","Czech":"resource.language.cs_cz","German":"resource.language.de_de","English":"resource.language.en_gb","Spanish":"resource.language.es_es","Basque":"resource.language.eu_es","Finnish":"resource.language.fi_fi","French":"resource.language.fr_fr","Hebrew":"resource.language.he_il","Hungarian":"resource.language.hu_hu","Italian":"resource.language.it_it","Lithuanian":"resource.language.lt_lt","Latvian":"resource.language.lv_lv","Norwegian":"resource.language.nb_no","Dutch":"resource.language.nl_nl","Polish":"resource.language.pl_pl","Portuguese (Brazil)":"resource.language.pt_br","Portuguese":"resource.language.pt_pt","Romanian":"resource.language.ro_ro","Russian":"resource.language.ru_ru","Slovak":"resource.language.sk_sk","Swedish":"resource.language.sv_se","Turkish":"resource.language.tr_tr","Ukrainian":"resource.language.uk_ua"}
+        languagesList = sorted(list(langCodes.keys()))
+        cur_lang = xbmc.getLanguage()
+        for index, lang in enumerate(languagesList):
+            if cur_lang in lang:
+                langIndex = index
+                break
             else:
-                self.getControl(self.buttons[1]['id']).controlLeft(self.getControl(self.buttons[3]['id']))
-            self.getControl(self.buttons[2]['id']).controlUp(self.getControl(self.buttons[3]['id']))
-            self.getControl(self.buttons[2]['id']).controlRight(self.getControl(self.buttons[1]['id']))
-        except Exception as e:
-            oe.dbg_log('oeWindows.wizard::set_wizard_button_1()', f'ERROR: ({repr(e)})')
+                pass
+        selLanguage = xbmcDialog.select(oe._(32310), languagesList, preselect=langIndex)
+        if selLanguage >= 0:
+            langKey = languagesList[selLanguage]
+            lang_new = langCodes[langKey]
+            if lang_new == "resource.language.en_gb":
+                oe.write_setting("system", "language", "")
+            else:
+                oe.write_setting("system", "language", str(lang_new))
+            self.getControl(self.wizWinTitle).setLabel(oe._(32300))
+            self.set_wizard_title(oe._(32301))
+            self.set_wizard_text(oe._(32302))
+            oe.winOeMain.set_wizard_button_title(oe._(32310))
+            oe.winOeMain.set_wizard_button_1(langKey, self, 'wizard_set_language')
+            self.showButton(1, 32303)
+            self.setFocusId(self.buttons[1]['id'])
+        log.log('exit_function', log.DEBUG)
 
+    @log.log_function()
+    def set_wizard_text(self, text):
+        self.getControl(self.wizTextbox).setText(text)
+
+    @log.log_function()
+    def set_wizard_title(self, title):
+        self.getControl(self.wizTitle).setLabel(title)
+
+    @log.log_function()
+    def set_wizard_button_title(self, title):
+        self.getControl(self.wizBtnTitle).setLabel(title)
+
+    @log.log_function()
+    def set_wizard_list_title(self, title):
+        self.getControl(self.wizLstTitle).setLabel(title)
+
+    @log.log_function()
+    def set_wizard_button_1(self, label, modul, action):
+        self.buttons[3]['modul'] = modul
+        self.buttons[3]['action'] = action
+        self.getControl(self.buttons[3]['id']).setLabel(label)
+        self.getControl(self.buttons[3]['id']).setVisible(True)
+        self.getControl(self.buttons[3]['id']).controlRight(self.getControl(self.buttons[1]['id']))
+        self.getControl(self.buttons[3]['id']).controlDown(self.getControl(self.buttons[1]['id']))
+        self.getControl(self.buttons[1]['id']).controlUp(self.getControl(self.buttons[3]['id']))
+        if self.buttons[2]['id']:
+            self.getControl(self.buttons[1]['id']).controlLeft(self.getControl(self.buttons[2]['id']))
+        else:
+            self.getControl(self.buttons[1]['id']).controlLeft(self.getControl(self.buttons[3]['id']))
+        self.getControl(self.buttons[2]['id']).controlUp(self.getControl(self.buttons[3]['id']))
+        self.getControl(self.buttons[2]['id']).controlRight(self.getControl(self.buttons[1]['id']))
+
+    @log.log_function()
     def set_wizard_button_2(self, label, modul, action):
-        try:
-            self.buttons[4]['modul'] = modul
-            self.buttons[4]['action'] = action
-            self.getControl(self.buttons[4]['id']).setLabel(label)
-            self.getControl(self.buttons[4]['id']).setVisible(True)
-            self.getControl(self.buttons[4]['id']).controlLeft(self.getControl(self.buttons[3]['id']))
-            self.getControl(self.buttons[4]['id']).controlDown(self.getControl(self.buttons[1]['id']))
-            self.getControl(self.buttons[4]['id']).controlRight(self.getControl(self.buttons[1]['id']))
-            self.getControl(self.buttons[1]['id']).controlUp(self.getControl(self.buttons[4]['id']))
-            self.getControl(self.buttons[1]['id']).controlLeft(self.getControl(self.buttons[4]['id']))
-            self.getControl(self.buttons[2]['id']).controlUp(self.getControl(self.buttons[4]['id']))
-            self.getControl(self.buttons[2]['id']).controlRight(self.getControl(self.buttons[1]['id']))
-            self.getControl(self.buttons[3]['id']).controlRight(self.getControl(self.buttons[4]['id']))
-        except Exception as e:
-            oe.dbg_log('oeWindows.wizard::set_wizard_button_2()', 'ERROR: (' + repr(e) + ')')
+        self.buttons[4]['modul'] = modul
+        self.buttons[4]['action'] = action
+        self.getControl(self.buttons[4]['id']).setLabel(label)
+        self.getControl(self.buttons[4]['id']).setVisible(True)
+        self.getControl(self.buttons[4]['id']).controlLeft(self.getControl(self.buttons[3]['id']))
+        self.getControl(self.buttons[4]['id']).controlDown(self.getControl(self.buttons[1]['id']))
+        self.getControl(self.buttons[4]['id']).controlRight(self.getControl(self.buttons[1]['id']))
+        self.getControl(self.buttons[1]['id']).controlUp(self.getControl(self.buttons[4]['id']))
+        self.getControl(self.buttons[1]['id']).controlLeft(self.getControl(self.buttons[4]['id']))
+        self.getControl(self.buttons[2]['id']).controlUp(self.getControl(self.buttons[4]['id']))
+        self.getControl(self.buttons[2]['id']).controlRight(self.getControl(self.buttons[1]['id']))
+        self.getControl(self.buttons[3]['id']).controlRight(self.getControl(self.buttons[4]['id']))
 
+    @log.log_function()
     def set_wizard_radiobutton_1(self, label, modul, action, selected=False):
-        try:
-            self.radiobuttons[1]['modul'] = modul
-            self.radiobuttons[1]['action'] = action
-            self.getControl(self.radiobuttons[1]['id']).setLabel(label)
-            self.getControl(self.radiobuttons[1]['id']).setVisible(True)
-            self.getControl(self.radiobuttons[1]['id']).controlRight(self.getControl(self.buttons[1]['id']))
-            self.getControl(self.radiobuttons[1]['id']).controlDown(self.getControl(self.buttons[1]['id']))
-            self.getControl(self.buttons[1]['id']).controlUp(self.getControl(self.buttons[3]['id']))
-            self.getControl(self.buttons[1]['id']).controlLeft(self.getControl(self.buttons[2]['id']))
-            self.getControl(self.buttons[2]['id']).controlUp(self.getControl(self.radiobuttons[1]['id']))
-            self.getControl(self.buttons[2]['id']).controlRight(self.getControl(self.buttons[1]['id']))
-            self.getControl(self.radiobuttons[1]['id']).setSelected(selected)
-        except Exception as e:
-            oe.dbg_log('oeWindows.wizard::set_wizard_button_1()', f'ERROR: ({repr(e)})')
+        self.radiobuttons[1]['modul'] = modul
+        self.radiobuttons[1]['action'] = action
+        self.getControl(self.radiobuttons[1]['id']).setLabel(label)
+        self.getControl(self.radiobuttons[1]['id']).setVisible(True)
+        self.getControl(self.radiobuttons[1]['id']).controlRight(self.getControl(self.buttons[1]['id']))
+        self.getControl(self.radiobuttons[1]['id']).controlDown(self.getControl(self.buttons[1]['id']))
+        self.getControl(self.buttons[1]['id']).controlUp(self.getControl(self.buttons[3]['id']))
+        self.getControl(self.buttons[1]['id']).controlLeft(self.getControl(self.buttons[2]['id']))
+        self.getControl(self.buttons[2]['id']).controlUp(self.getControl(self.radiobuttons[1]['id']))
+        self.getControl(self.buttons[2]['id']).controlRight(self.getControl(self.buttons[1]['id']))
+        self.getControl(self.radiobuttons[1]['id']).setSelected(selected)
 
+    @log.log_function()
     def set_wizard_radiobutton_2(self, label, modul, action, selected=False):
-        try:
-            self.radiobuttons[2]['modul'] = modul
-            self.radiobuttons[2]['action'] = action
-            self.getControl(self.radiobuttons[2]['id']).setLabel(label)
-            self.getControl(self.radiobuttons[2]['id']).setVisible(True)
-            self.getControl(self.radiobuttons[2]['id']).controlLeft(self.getControl(self.radiobuttons[1]['id']))
-            self.getControl(self.radiobuttons[2]['id']).controlDown(self.getControl(self.buttons[1]['id']))
-            self.getControl(self.radiobuttons[2]['id']).controlRight(self.getControl(self.buttons[1]['id']))
-            self.getControl(self.buttons[1]['id']).controlUp(self.getControl(self.radiobuttons[2]['id']))
-            self.getControl(self.buttons[1]['id']).controlLeft(self.getControl(self.buttons[2]['id']))
-            self.getControl(self.buttons[2]['id']).controlUp(self.getControl(self.radiobuttons[1]['id']))
-            self.getControl(self.buttons[2]['id']).controlRight(self.getControl(self.buttons[1]['id']))
-            self.getControl(self.radiobuttons[1]['id']).controlRight(self.getControl(self.radiobuttons[2]['id']))
-            self.getControl(self.radiobuttons[2]['id']).setSelected(selected)
-        except Exception as e:
-            oe.dbg_log('oeWindows.wizard::set_wizard_button_2()', f'ERROR: ({repr(e)})')
+        self.radiobuttons[2]['modul'] = modul
+        self.radiobuttons[2]['action'] = action
+        self.getControl(self.radiobuttons[2]['id']).setLabel(label)
+        self.getControl(self.radiobuttons[2]['id']).setVisible(True)
+        self.getControl(self.radiobuttons[2]['id']).controlLeft(self.getControl(self.radiobuttons[1]['id']))
+        self.getControl(self.radiobuttons[2]['id']).controlDown(self.getControl(self.buttons[1]['id']))
+        self.getControl(self.radiobuttons[2]['id']).controlRight(self.getControl(self.buttons[1]['id']))
+        self.getControl(self.buttons[1]['id']).controlUp(self.getControl(self.radiobuttons[2]['id']))
+        self.getControl(self.buttons[1]['id']).controlLeft(self.getControl(self.buttons[2]['id']))
+        self.getControl(self.buttons[2]['id']).controlUp(self.getControl(self.radiobuttons[1]['id']))
+        self.getControl(self.buttons[2]['id']).controlRight(self.getControl(self.buttons[1]['id']))
+        self.getControl(self.radiobuttons[1]['id']).controlRight(self.getControl(self.radiobuttons[2]['id']))
+        self.getControl(self.radiobuttons[2]['id']).setSelected(selected)
 
     def onAction(self, action):
         pass
 
+    @log.log_function()
     def onClick(self, controlID):
         global strModule
         global prevModule
-        try:
-            oe.dbg_log(f'wizard::onClick({str(controlID)})', 'enter_function', oe.LOGDEBUG)
-            for btn in self.buttons:
-                if controlID == self.buttons[btn]['id'] and self.buttons[btn]['id'] > 2:
-                    if hasattr(self.buttons[btn]['modul'], self.buttons[btn]['action']):
-                        getattr(self.buttons[btn]['modul'], self.buttons[btn]['action'])()
-            for btn in self.radiobuttons:
-                if controlID == self.radiobuttons[btn]['id'] and self.radiobuttons[btn]['id'] > 1:
-                    if hasattr(self.radiobuttons[btn]['modul'], self.radiobuttons[btn]['action']):
-                        getattr(self.radiobuttons[btn]['modul'], self.radiobuttons[btn]['action'])()
-            if controlID == self.guiNetList:
-                selectedItem = self.getControl(controlID).getSelectedItem()
-                if selectedItem.getProperty('action') != '':
-                    if hasattr(oe.dictModules[self.last_wizard], selectedItem.getProperty('action')):
-                        getattr(oe.dictModules[self.last_wizard], selectedItem.getProperty('action'))(selectedItem)
-                        return
-            if controlID == 1501:
-                self.wizards.remove(strModule)
-                oe.remove_node(strModule)
-                if strModule == "system":
-                    self.onInit()
-                else:
-                    self.wizards.remove(prevModule)
-                    oe.remove_node(prevModule)
-                    self.onClick(1500)
-                oe.dbg_log(f'wizard::onClick({str(controlID)})', 'exit_function', oe.LOGDEBUG)
+        log.log(f'{str(controlID)}: enter_function', log.DEBUG)
+        for btn in self.buttons:
+            if controlID == self.buttons[btn]['id'] and self.buttons[btn]['id'] > 2:
+                if hasattr(self.buttons[btn]['modul'], self.buttons[btn]['action']):
+                    getattr(self.buttons[btn]['modul'], self.buttons[btn]['action'])()
+        for btn in self.radiobuttons:
+            if controlID == self.radiobuttons[btn]['id'] and self.radiobuttons[btn]['id'] > 1:
+                if hasattr(self.radiobuttons[btn]['modul'], self.radiobuttons[btn]['action']):
+                    getattr(self.radiobuttons[btn]['modul'], self.radiobuttons[btn]['action'])()
+        if controlID == self.guiNetList:
+            selectedItem = self.getControl(controlID).getSelectedItem()
+            if selectedItem.getProperty('action') != '':
+                if hasattr(oe.dictModules[self.last_wizard], selectedItem.getProperty('action')):
+                    getattr(oe.dictModules[self.last_wizard], selectedItem.getProperty('action'))(selectedItem)
+                    return
+        if controlID == 1501:
+            self.wizards.remove(strModule)
+            oe.remove_node(strModule)
+            if strModule == "system":
+                self.onInit()
+            else:
+                self.wizards.remove(prevModule)
+                oe.remove_node(prevModule)
+                self.onClick(1500)
+            log.log(f'{str(controlID)}: exit_function', log.DEBUG)
 
-            if controlID == 1500:
-                self.getControl(1390).setLabel('1')
+        if controlID == 1500:
+            self.getControl(1390).setLabel('1')
+            oe.xbmcm.waitForAbort(0.5)
+            self.is_last_wizard = True
+            self.getControl(1391).setLabel('')
+            self.getControl(self.buttons[3]['id']).setVisible(False)
+            self.getControl(self.buttons[4]['id']).setVisible(False)
+            self.getControl(self.radiobuttons[1]['id']).setVisible(False)
+            self.getControl(self.radiobuttons[2]['id']).setVisible(False)
+            self.showButton(2, 32307)
+            self.set_wizard_title('')
+            self.set_wizard_text('')
+            self.set_wizard_list_title('')
+            self.set_wizard_button_title('')
+
+            if strModule == 'connman':
+                xbmc.executebuiltin('UpdateAddonRepos')
+
+            for module in sorted(oe.dictModules, key=lambda x: list(oe.dictModules[x].menu.keys())):
+                strModule = module
+                if hasattr(oe.dictModules[strModule], 'do_wizard') and oe.dictModules[strModule].ENABLED:
+                    if strModule == self.last_wizard:
+                        if hasattr(oe.dictModules[strModule], 'exit'):
+                            oe.dictModules[strModule].exit()
+                            if hasattr(oe.dictModules[strModule], 'is_wizard'):
+                                del oe.dictModules[strModule].is_wizard
+                    setting = oe.read_setting(strModule, 'wizard_completed')
+                    if self.wizards != []:
+                        prevModule = self.wizards[-1]
+                    if oe.read_setting(strModule, 'wizard_completed') == None and strModule not in self.wizards:
+                        self.last_wizard = strModule
+                        if hasattr(oe.dictModules[strModule], 'do_init'):
+                            oe.dictModules[strModule].do_init()
+                        self.getControl(1390).setLabel('')
+                        oe.dictModules[strModule].do_wizard()
+                        self.wizards.append(strModule)
+                        oe.write_setting(strModule, 'wizard_completed', 'True')
+                        self.is_last_wizard = False
+                        break
+            if self.is_last_wizard == True:
+                if lang_new and xbmc.getCondVisibility(f'System.HasAddon({lang_new})') == False:
+                    xbmc.executebuiltin(f'InstallAddon({lang_new})')
                 oe.xbmcm.waitForAbort(0.5)
-                self.is_last_wizard = True
-                self.getControl(1391).setLabel('')
-                self.getControl(self.buttons[3]['id']).setVisible(False)
-                self.getControl(self.buttons[4]['id']).setVisible(False)
-                self.getControl(self.radiobuttons[1]['id']).setVisible(False)
-                self.getControl(self.radiobuttons[2]['id']).setVisible(False)
-                self.showButton(2, 32307)
-                self.set_wizard_title('')
-                self.set_wizard_text('')
-                self.set_wizard_list_title('')
-                self.set_wizard_button_title('')
-
-                if strModule == 'connman':
-                    xbmc.executebuiltin('UpdateAddonRepos')
-
-                for module in sorted(oe.dictModules, key=lambda x: list(oe.dictModules[x].menu.keys())):
-                    strModule = module
-                    if hasattr(oe.dictModules[strModule], 'do_wizard') and oe.dictModules[strModule].ENABLED:
-                        if strModule == self.last_wizard:
-                            if hasattr(oe.dictModules[strModule], 'exit'):
-                                oe.dictModules[strModule].exit()
-                                if hasattr(oe.dictModules[strModule], 'is_wizard'):
-                                    del oe.dictModules[strModule].is_wizard
-                        setting = oe.read_setting(strModule, 'wizard_completed')
-                        if self.wizards != []:
-                            prevModule = self.wizards[-1]
-                        if oe.read_setting(strModule, 'wizard_completed') == None and strModule not in self.wizards:
-                            self.last_wizard = strModule
-                            if hasattr(oe.dictModules[strModule], 'do_init'):
-                                oe.dictModules[strModule].do_init()
-                            self.getControl(1390).setLabel('')
-                            oe.dictModules[strModule].do_wizard()
-                            self.wizards.append(strModule)
-                            oe.write_setting(strModule, 'wizard_completed', 'True')
-                            self.is_last_wizard = False
+                xbmc.executebuiltin('SendClick(10100,11)')
+                oe.write_setting('libreelec', 'wizard_completed', 'True')
+                self.visible = False
+                self.close()
+                if lang_new:
+                    for _ in range(20):
+                        if xbmc.getCondVisibility(f'System.HasAddon({lang_new})'):
                             break
-                if self.is_last_wizard == True:
-                    if lang_new and xbmc.getCondVisibility(f'System.HasAddon({lang_new})') == False:
-                        xbmc.executebuiltin(f'InstallAddon({lang_new})')
-                    oe.xbmcm.waitForAbort(0.5)
-                    xbmc.executebuiltin('SendClick(10100,11)')
-                    oe.write_setting('libreelec', 'wizard_completed', 'True')
-                    self.visible = False
-                    self.close()
-                    if lang_new:
-                        for _ in range(20):
-                            if xbmc.getCondVisibility(f'System.HasAddon({lang_new})'):
-                                break
-                            oe.xbmcm.waitForAbort(0.5)
-                        if xbmc.getCondVisibility(f'System.HasAddon({lang_new})') == True:
-                            xbmc.executebuiltin(f'SetGUILanguage({str(lang_new)})')
-                        else:
-                            oe.dbg_log(f'wizard::onClick({str(controlID)})', f"ERROR: Unable to switch language to: {lang_new}. Language addon is not installed.")
-            oe.dbg_log(f'wizard::onClick({str(controlID)})', 'exit_function', oe.LOGDEBUG)
-        except Exception as e:
-            oe.dbg_log('oeWindows.wizard::onClick()', f'ERROR: ({repr(e)})')
+                        oe.xbmcm.waitForAbort(0.5)
+                    if xbmc.getCondVisibility(f'System.HasAddon({lang_new})') == True:
+                        xbmc.executebuiltin(f'SetGUILanguage({str(lang_new)})')
+                    else:
+                        log.log(f'{str(controlID)}: ERROR: Unable to switch language to: {lang_new}. Language addon is not installed.', log.INFO)
+        log.log(f'{str(controlID)}: exit_function', log.DEBUG)
 
     def onFocus(self, controlID):
         pass
 
+    @log.log_function()
     def showButton(self, number, name):
-        try:
-            button = self.getControl(self.buttons[number]['id'])
-            button.setLabel(oe._(name))
-            button.setVisible(True)
-        except Exception as e:
-            oe.dbg_log(f'oeWindows.wizard::showButton({str(number)})', f'ERROR: ({repr(e)})')
+        button = self.getControl(self.buttons[number]['id'])
+        button.setLabel(oe._(name))
+        button.setVisible(True)
 
+    @log.log_function()
     def addConfigItem(self, strName, dictProperties, strType):
-        try:
-            lstItem = xbmcgui.ListItem(label=strName)
-            for strProp in dictProperties:
-                lstItem.setProperty(strProp, str(dictProperties[strProp]))
-            self.getControl(int(strType)).addItem(lstItem)
-            return lstItem
-        except Exception as e:
-            oe.dbg_log(f'oeWindows.wizard::addConfigItem({strName})', f'ERROR: ({repr(e)})')
+        lstItem = xbmcgui.ListItem(label=strName)
+        for strProp in dictProperties:
+            lstItem.setProperty(strProp, str(dictProperties[strProp]))
+        self.getControl(int(strType)).addItem(lstItem)
+        return lstItem

--- a/resources/lib/os_tools.py
+++ b/resources/lib/os_tools.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0
-# Copyright (C) 2020-present Team LibreELEC
+# Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 import os
 

--- a/resources/lib/os_tools.py
+++ b/resources/lib/os_tools.py
@@ -1,9 +1,20 @@
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
+'''This module holds support functions for interacting with the underlying OS.
+
+Support functions are grouped by purpose:
+1. File access: read / write / copy / move / download
+2. System access: executing system commands
+'''
+
 import os
+import subprocess
+
+import log
 
 
+### FILE ACCESS ###
 def read_shell_setting(file, default):
     setting = default
     if os.path.isfile(file):
@@ -22,3 +33,26 @@ def read_shell_settings(file, defaults={}):
                     value = value[1:-1]
                 settings[name] = value
     return settings
+
+
+### SYSTEM ACCESS ###
+def execute(command, get_result=False):
+    '''Run command, waiting for it to finish. Returns: command output or None'''
+    log.log(f'Executing command: {command}', log.DEBUG)
+    try:
+        cmd_status = subprocess.run(command, shell=True, check=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    except subprocess.CalledProcessError as e:
+        log.log(f'Command failed: {command}', log.ERROR)
+        log.log(f'Executed command: {e.cmd}', log.DEBUG)
+        # with shell=True, this is the shell's exit code
+        log.log(f'shell exit code: {e.returncode}', log.ERROR)
+        log.log(f'START COMMAND OUTPUT:\n{e.stdout.decode()}\nEND COMMAND OUTPUT', log.ERROR)
+        # return None on failure. Commands that want output get nothing; remainder weren't expecting output
+        return None
+    except FileNotFoundError:
+        # this will be whether the shell is found while shell=True
+#        log.log(f'os_tools.execute: Command not found: {command.split(" ")[0]}', log.ERROR)
+        log.log('os_tools.execute: Failed to find shell.', log.ERROR)
+        return None
+    # return output if requested, otherwise None
+    return cmd_status.stdout.decode() if get_result else None

--- a/resources/lib/regdomain.py
+++ b/resources/lib/regdomain.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0
-# Copyright (C) 2020-present Team LibreELEC
+# Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 import os
 import subprocess

--- a/resources/lib/regdomain.py
+++ b/resources/lib/regdomain.py
@@ -2,9 +2,9 @@
 # Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 import os
-import subprocess
 
 import config
+import os_tools
 
 
 REGDOMAIN_DEFAULT = 'NOT SET (DEFAULT)'
@@ -197,4 +197,4 @@ def set_regdomain(regdomain):
         code = regdomain[-3:-1]
         with open(config.REGDOMAIN_CONF, 'w') as file:
             file.write(f'REGDOMAIN={code}\n')
-    subprocess.check_output(config.SETREGDOMAIN)
+    os_tools.execute(config.SETREGDOMAIN)

--- a/resources/lib/ui_tools.py
+++ b/resources/lib/ui_tools.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0
-# Copyright (C) 2020-present Team LibreELEC
+# Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 import xbmcaddon
 import xbmcgui

--- a/syspath.py
+++ b/syspath.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0
-# Copyright (C) 2020-present Team LibreELEC
+# Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 import os
 import sys


### PR DESCRIPTION
This cleanup pass does: 

converts bluetooth.py to use log.log
converts oe.py and oeWindows.py to use the log.log_function decorator / log.log
removes oe.dbg_log
cleanup other oe.py functions

Everything should still be working in the same general way. No intentional changes were made to how functions were used. I've tested some of the addon, but I don't use all of its features so issues may be lurking.