### PR TITLE
hostname.py: use network-base.service for /etc/hosts editing

### DIFF
--- a/resources/lib/hostname.py
+++ b/resources/lib/hostname.py
@@ -12,13 +12,11 @@ def get_hostname():
 
 
 def set_hostname(hostname):
-    with open(config.HOSTNAME, 'w') as output:
-        output.write(hostname)
-    with open('/proc/sys/kernel/hostname', 'w') as output:
-        output.write(hostname)
-    with open('/etc/hosts', 'w') as output:
-        if os.path.isfile(config.HOSTS_CONF):
-            with open(config.HOSTS_CONF) as input:
-                output.write(input.read())
-        output.write(f'127.0.0.1 localhost {hostname}\n')
-        output.write(f'::1 localhost ip6-localhost ip6-loopback {hostname}\n')
+    # network-base.service handles user created persistent settings
+    if os.path.isfile(config.HOSTNAME):
+        with open(config.HOSTNAME, 'r') as input:
+            current_hostname = input.read().strip()
+        if current_hostname != hostname:
+            with open(config.HOSTNAME, 'w') as output:
+                output.write(hostname)
+            os_tools.execute('systemctl restart network-base')


### PR DESCRIPTION
This rewrites most of hostname.set_hostname(). It's reduced to writing the hostname to a file, and then calling the network-base.service to set up hostname/hosts/resolv.conf as needed again. The writing hostname to file is changed so that it's only written to file if the hostname is different than what is currently in the file. Pre-PR it's writing the hostname everytime the system boots / kodi starts regardless of what's in the file already, so this gets rid of a useless write.

Merge after https://github.com/LibreELEC/LibreELEC.tv/pull/7696