### PR TITLE
samba reload config / samba escape saved strings / service handling

### DIFF
--- a/resources/lib/defaults.py
+++ b/resources/lib/defaults.py
@@ -99,7 +99,7 @@ about = {'ENABLED': True}
 _services = {
     'sshd': ['sshd.service'],
     'avahi': ['avahi-daemon.service'],
-    'samba': ['nmbd.service', 'smbd.service'],
+    'samba': ['samba-config.service', 'nmbd.service', 'smbd.service'],
     'bluez': ['bluetooth.service'],
     'obexd': ['obex.service'],
     'crond': ['cron.service'],

--- a/resources/lib/modules/services.py
+++ b/resources/lib/modules/services.py
@@ -312,10 +312,10 @@ class services(modules.Module):
                     self.D_SAMBA_WORKGROUP).replace('"', '')
             self.struct['samba']['settings']['samba_secure']['value'] = oe.get_service_option('samba', 'SAMBA_SECURE',
                     self.D_SAMBA_SECURE).replace('true', '1').replace('false', '0').replace('"', '')
-            self.struct['samba']['settings']['samba_username']['value'] = oe.get_service_option('samba', 'SAMBA_USERNAME',
-                    self.D_SAMBA_USERNAME).replace('"', '')
-            self.struct['samba']['settings']['samba_password']['value'] = oe.get_service_option('samba', 'SAMBA_PASSWORD',
-                    self.D_SAMBA_PASSWORD).replace('"', '')
+            self.struct['samba']['settings']['samba_username']['value'] = self.sh_unesc_str(oe.get_service_option('samba', 'SAMBA_USERNAME',
+                    self.D_SAMBA_USERNAME).replace('"', ''))
+            self.struct['samba']['settings']['samba_password']['value'] = self.sh_unesc_str(oe.get_service_option('samba', 'SAMBA_PASSWORD',
+                    self.D_SAMBA_PASSWORD).replace('"', ''))
             self.struct['samba']['settings']['samba_minprotocol']['value'] = oe.get_service_option('samba', 'SAMBA_MINPROTOCOL',
                     self.D_SAMBA_MINPROTOCOL).replace('"', '')
             self.struct['samba']['settings']['samba_maxprotocol']['value'] = oe.get_service_option('samba', 'SAMBA_MAXPROTOCOL',
@@ -390,8 +390,8 @@ class services(modules.Module):
             options['SAMBA_AUTOSHARE'] = val_autoshare
             options['SAMBA_MINPROTOCOL'] = self.struct['samba']['settings']['samba_minprotocol']['value']
             options['SAMBA_MAXPROTOCOL'] = self.struct['samba']['settings']['samba_maxprotocol']['value']
-            options['SAMBA_USERNAME'] = self.struct['samba']['settings']['samba_username']['value']
-            options['SAMBA_PASSWORD'] = self.struct['samba']['settings']['samba_password']['value']
+            options['SAMBA_USERNAME'] = self.sh_esc_str(self.struct['samba']['settings']['samba_username']['value'])
+            options['SAMBA_PASSWORD'] = self.sh_esc_str(self.struct['samba']['settings']['samba_password']['value'])
         else:
             state = 0
             self.struct['samba']['settings']['samba_username']['hidden'] = True
@@ -569,3 +569,17 @@ class services(modules.Module):
         else:
             log.log('User cancelled')
         return SSHchange
+
+    def sh_esc_str(self, string):
+        escape = ''
+        for c in string:
+            escape += '\\' + c
+        return escape
+
+    def sh_unesc_str(self, string):
+        size = len(string)
+        if size % 2:
+            return string
+        if string[0::2] != '\\' * (size // 2):
+            return string
+        return string[1::2]

--- a/resources/lib/oe.py
+++ b/resources/lib/oe.py
@@ -328,7 +328,9 @@ def get_service_option(service, option, default=None):
 
 @log.log_function()
 def get_service_state(service):
-    return '1' if os.path.exists(f'{CONFIG_CACHE}/services/{service}.conf') else '0'
+    base_name = f'{CONFIG_CACHE}/services/{service}'
+    return '1' if os.path.exists(f'{base_name}.conf') \
+                  and not os.path.exists(f'{base_name}.disabled') else '0'
 
 
 @log.log_function()
@@ -343,13 +345,9 @@ def set_service(service, options, state):
     # Service Enabled
     if state == 1:
         # Is Service alwys enabled ?
-        if get_service_state(service) == '1':
-            cfn = f'{CONFIG_CACHE}/services/{service}.conf'
-            cfo = cfn
-        else:
-            cfn = f'{CONFIG_CACHE}/services/{service}.conf'
-            cfo = f'{CONFIG_CACHE}/services/{service}.disabled'
-        if os.path.exists(cfo) and not cfo == cfn:
+        cfo = f'{CONFIG_CACHE}/services/{service}.disabled'
+        cfn = f'{CONFIG_CACHE}/services/{service}.conf'
+        if os.path.exists(cfo):
             os.remove(cfo)
         with open(cfn, 'w') as cf:
             for option in options:
@@ -360,6 +358,9 @@ def set_service(service, options, state):
         cfn = f'{CONFIG_CACHE}/services/{service}.disabled'
         if os.path.exists(cfo):
             os.rename(cfo, cfn)
+        else:
+            with open(cfn, 'w') as cf:
+                pass
     if not __oe__.is_service:
         if service in defaults._services:
             for svc in defaults._services[service]:


### PR DESCRIPTION
This PR contains two samba server related fixes reported in the forum.

[First report](https://forum.libreelec.tv/thread/26942-samba-service-query-about-default-settings-and-users/) shows that samba configuration is not updated until reboot - although smbd and nmbd are restarted. This is fixed by adding `samba-confiig.service` to the list of services to be reloaded.

In the [second issue reported](https://forum.libreelec.tv/thread/26994-samba-password-authentication/) samba user names and passwords are not escaped when saved and do fail when sourced by the samba-config shell script.  Simple solution is to escape any single character with functions sh_esc_str() and sh_unesc_str(). The second function is able to read previous not escaped strings too. Note that samba-config is compatible with that but requires some modifications too to support all characters, e.g. spaces.

With  third commit the service enable/disable logic is more bullet proof. During development I did create both .conf and .disabled files and could only solve the issue by manually deleting one.