### PR TITLE
backup: store directories if not root/root 0755

### DIFF
--- a/resources/lib/modules/system.py
+++ b/resources/lib/modules/system.py
@@ -624,6 +624,13 @@ class system(modules.Module):
     def tar_add_folder(self, tar, folder):
         try:
             print_folder = log.asciify(folder)
+            try:
+                fsr = os.lstat(folder)
+            except:
+                pass
+            else:
+                if fsr.st_mode != 0o40755 or fsr.st_uid or fsr.st_gid:
+                    tar.add(folder, recursive=False)
             for item in os.listdir(folder):
                 if item == self.backup_file:
                     continue


### PR DESCRIPTION
The LE backup code assume that all directories are of root/root 0755.

This was correct in the past but at least since using docker overlays directories may be restored with wrong modes or owners.

Add code to store directories with different modes or owners in the backup.