### PR TITLE
updates.py: relax releases.json url autocompletion

### DIFF
--- a/resources/lib/modules/updates.py
+++ b/resources/lib/modules/updates.py
@@ -446,7 +446,7 @@ class updates(modules.Module):
             url = self.UPDATE_DOWNLOAD_URL % ('releases', 'releases.json')
         if not url.startswith('http://') and not url.startswith('https://'):
             url = f'https://{url}'
-        if not url.endswith('releases.json'):
+        if not url.endswith('.json'):
             url = f'{url}/releases.json'
         data = oe.load_url(url)
         return json.loads(data) if data else None


### PR DESCRIPTION
The addon will attempt to autocomplete a URL to retrieve releases.json from, so 'test.libreelec.tv' becomes 'https://test.libreelec.tv/releases.json'. 

This relaxes a test for adding '/releases.json' at the end to checking if it doesn't end with '.json' instead. This avoids mandating the json file's name to be 'releases.json', permitting something like 'releases_v2.json' or 'releases-for-my-project.json'.

While this shouldn't be needed in the long term, it doesn't get in the way and may make life easier in the short term.

Motivated by https://forum.libreelec.tv/thread/27101-empty-list-under-available-versions/?postID=180474