### PR TITLE
hostnames: create on clean install

### DIFF
--- a/resources/lib/hostname.py
+++ b/resources/lib/hostname.py
@@ -14,13 +14,13 @@ def get_hostname():
 def set_hostname(hostname):
     # network-base.service handles user created persistent settings
     if os.path.isfile(config.HOSTNAME):
-        with open(config.HOSTNAME, mode='r', encoding='utf-8') as input:
-            current_hostname = input.read().strip()
+        with open(config.HOSTNAME, mode='r', encoding='utf-8') as in_file:
+            current_hostname = in_file.read().strip()
         if current_hostname != hostname:
-            with open(config.HOSTNAME, mode='w', encoding='utf-8') as output:
-                output.write(f'{hostname}\n')
+            with open(config.HOSTNAME, mode='w', encoding='utf-8') as out_file:
+                out_file.write(f'{hostname}\n')
             os_tools.execute('systemctl restart network-base')
     else:
-        with open(config.HOSTNAME, mode='w', encoding='utf-8') as output:
-            output.write(f'{hostname}\n')
+        with open(config.HOSTNAME, mode='w', encoding='utf-8') as out_file:
+            out_file.write(f'{hostname}\n')
         os_tools.execute('systemctl restart network-base')

--- a/resources/lib/hostname.py
+++ b/resources/lib/hostname.py
@@ -14,9 +14,13 @@ def get_hostname():
 def set_hostname(hostname):
     # network-base.service handles user created persistent settings
     if os.path.isfile(config.HOSTNAME):
-        with open(config.HOSTNAME, 'r') as input:
+        with open(config.HOSTNAME, mode='r', encoding='utf-8') as input:
             current_hostname = input.read().strip()
         if current_hostname != hostname:
-            with open(config.HOSTNAME, 'w') as output:
-                output.write(hostname)
+            with open(config.HOSTNAME, mode='w', encoding='utf-8') as output:
+                output.write(f'{hostname}\n')
             os_tools.execute('systemctl restart network-base')
+    else:
+        with open(config.HOSTNAME, mode='w', encoding='utf-8') as output:
+            output.write(f'{hostname}\n')
+        os_tools.execute('systemctl restart network-base')


### PR DESCRIPTION
Creates `/storage/.cache/hostname` on new installs. Does some cleanup too.

Resolves https://forum.libreelec.tv/thread/27162-system-name-always-reverts-to-libreelec-after-reboot/