### PR TITLE
oe.py: make load_url network errors less noisy

### DIFF
--- a/resources/lib/modules/updates.py
+++ b/resources/lib/modules/updates.py
@@ -592,6 +592,8 @@ class updates(modules.Module):
                 if self.struct['update']['settings']['AutoUpdate']['value'] == 'auto' and force == False:
                     self.update_in_progress = True
                     self.do_autoupdate(None, True)
+        else:
+            log.log(f'Unable to load: {url}', log.ERROR)
 
     @log.log_function()
     def do_autoupdate(self, listItem=None, silent=False):

--- a/resources/lib/oe.py
+++ b/resources/lib/oe.py
@@ -383,10 +383,15 @@ def url_quote(var):
 
 @log.log_function()
 def load_url(url):
-    request = urllib.request.Request(url)
-    response = urllib.request.urlopen(request)
-    content = response.read()
-    return content.decode('utf-8').strip()
+    try:
+        request = urllib.request.Request(url)
+        response = urllib.request.urlopen(request)
+    except urllib.error.URLError as err:
+        log.log(f'Error loading url: {url}\nReason: {err.reason}', log.ERROR)
+        return None
+    else:
+        content = response.read()
+        return content.decode('utf-8').strip()
 
 
 @log.log_function()


### PR DESCRIPTION
oe.py's load_url is used solely to retrieve release.json files. The addon tries to do this even if there is no network connection, producing the full python crash state in kodi's log. This changes it to 2-3 lines, like so:

> 2023-09-20 07:23:54.171 T:747     error <general>: SETTINGS: load_url # Error loading url: http://releases.libreelec.tv/releases.json
>                                                    Reason: [Errno -3] Temporary failure in name resolution

Which tells us what the networking error was, if that's all it was. Other errors will still produce the python crash state.

Resolves what I believe is the issue in https://github.com/LibreELEC/LibreELEC.tv/issues/7987