### PR TITLE
all: drop unused imports

### DIFF
--- a/resources/lib/modules.py
+++ b/resources/lib/modules.py
@@ -3,7 +3,6 @@
 
 import defaults
 import log
-import oe
 
 
 class Module(object):

--- a/resources/lib/modules/services.py
+++ b/resources/lib/modules/services.py
@@ -7,7 +7,6 @@ import os
 import shutil
 import subprocess
 
-import xbmc
 import xbmcgui
 
 import log

--- a/resources/lib/modules/system.py
+++ b/resources/lib/modules/system.py
@@ -17,7 +17,6 @@ import hostname
 import log
 import modules
 import oe
-import oeWindows
 import os_tools
 
 

--- a/resources/lib/modules/updates.py
+++ b/resources/lib/modules/updates.py
@@ -12,7 +12,6 @@ import threading
 import time
 from datetime import datetime
 from functools import cmp_to_key
-from xml.dom import minidom
 
 import xbmc
 import xbmcgui
@@ -20,7 +19,6 @@ import xbmcgui
 import log
 import modules
 import oe
-import oeWindows
 import os_tools
 
 

--- a/resources/lib/oe.py
+++ b/resources/lib/oe.py
@@ -13,8 +13,6 @@ import os
 import re
 import sys
 import time
-import tarfile
-import traceback
 import urllib.request
 import urllib.parse
 from xml.dom import minidom
@@ -22,7 +20,6 @@ from xml.dom import minidom
 import xbmc
 import xbmcaddon
 import xbmcgui
-import xbmcvfs
 
 import defaults
 import log

--- a/resources/lib/oeWindows.py
+++ b/resources/lib/oeWindows.py
@@ -3,11 +3,8 @@
 # Copyright (C) 2013 Lutz Fiebach (lufie@openelec.tv)
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
-import os
 import re
-import time
 from threading import Thread
-from xml.dom import minidom
 
 import xbmc
 import xbmcgui


### PR DESCRIPTION
This drops unused imports as reported by pylint.