### PR TITLE
os_tools: execute: return empty string on failure

### DIFF
--- a/resources/lib/modules/system.py
+++ b/resources/lib/modules/system.py
@@ -612,12 +612,16 @@ class system(modules.Module):
         result = os_tools.execute(log_cmd, get_result=True)
         if not paste_dlg.iscanceled():
             paste_dlg.close()
-            link = result.find('http')
-            if link != -1:
-                log.log(result[link:], log.WARNING)
-                xbmcDialog.ok('Paste complete', f'Log files pasted to {result[link:]}')
+            if result:
+                link = result.find('http')
+                # TODO Localization
+                if link != -1:
+                    log.log(result[link:], log.WARNING)
+                    xbmcDialog.ok('Paste complete', f'Log files pasted to {result[link:]}')
+                else:
+                    xbmcDialog.ok('Failed paste', 'Failed to paste log files. Please try again')
             else:
-                xbmcDialog.ok('Failed paste', 'Failed to paste log files, try again')
+                xbmcDialog.ok('Failed paste', 'Failed to paste log files. Please try again.')
 
     @log.log_function()
     def tar_add_folder(self, tar, folder):

--- a/resources/lib/modules/updates.py
+++ b/resources/lib/modules/updates.py
@@ -572,8 +572,6 @@ class updates(modules.Module):
                 if self.struct['update']['settings']['AutoUpdate']['value'] == 'auto' and force == False:
                     self.update_in_progress = True
                     self.do_autoupdate(None, True)
-        else:
-            log.log(f'Unable to load: {url}', log.ERROR)
 
     @log.log_function()
     def do_autoupdate(self, listItem=None, silent=False):

--- a/resources/lib/modules/updates.py
+++ b/resources/lib/modules/updates.py
@@ -229,11 +229,11 @@ class updates(modules.Module):
         gpu_driver = ""
         gpu_card = self.get_gpu_card()
         log.log(f'Using card: {gpu_card}', log.DEBUG)
-        gpu_path = os_tools.execute(f'/usr/bin/udevadm info --name=/dev/dri/{gpu_card} --query path 2>/dev/null', get_result=True).replace('\n','')
+        gpu_path = os_tools.execute(f'/usr/bin/udevadm info --name=/dev/dri/{gpu_card} --query path 2>/dev/null', get_result=True, output_err_msg=False).replace('\n','')
         log.log(f'gpu path: {gpu_path}', log.DEBUG)
         if gpu_path:
             drv_path = os.path.dirname(os.path.dirname(gpu_path))
-            props = os_tools.execute(f'/usr/bin/udevadm info --path={drv_path} --query=property 2>/dev/null', get_result=True)
+            props = os_tools.execute(f'/usr/bin/udevadm info --path={drv_path} --query=property 2>/dev/null', get_result=True, output_err_msg=False)
             if props:
                 for key, value in [x.strip().split('=') for x in props.strip().split('\n')]:
                     gpu_props[key] = value

--- a/resources/lib/os_tools.py
+++ b/resources/lib/os_tools.py
@@ -36,23 +36,17 @@ def read_shell_settings(file, defaults={}):
 
 
 ### SYSTEM ACCESS ###
-def execute(command, get_result=False):
-    '''Run command, waiting for it to finish. Returns: command output or None'''
+def execute(command, get_result=False, output_err_msg=True):
+    '''Run command, waiting for it to finish. Returns: command output, empty string or None'''
     log.log(f'Executing command: {command}', log.DEBUG)
     try:
         cmd_status = subprocess.run(command, shell=True, check=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
     except subprocess.CalledProcessError as e:
-        log.log(f'Command failed: {command}', log.ERROR)
-        log.log(f'Executed command: {e.cmd}', log.DEBUG)
-        # with shell=True, this is the shell's exit code
-        log.log(f'shell exit code: {e.returncode}', log.ERROR)
-        log.log(f'START COMMAND OUTPUT:\n{e.stdout.decode()}\nEND COMMAND OUTPUT', log.ERROR)
-        # return None on failure. Commands that want output get nothing; remainder weren't expecting output
-        return None
-    except FileNotFoundError:
-        # this will be whether the shell is found while shell=True
-#        log.log(f'os_tools.execute: Command not found: {command.split(" ")[0]}', log.ERROR)
-        log.log('os_tools.execute: Failed to find shell.', log.ERROR)
-        return None
-    # return output if requested, otherwise None
+        if output_err_msg:
+            log.log(f'Command failed: {command}', log.ERROR)
+            log.log(f'Executed command: {e.cmd}', log.DEBUG)
+            log.log(f'\nSTART COMMAND OUTPUT:\n{e.stdout.decode()}\nEND COMMAND OUTPUT', log.ERROR)
+        # return empty string if result wanted to match old behaviour
+        return '' if get_result else None
+    # return output if requested, otherwise return None
     return cmd_status.stdout.decode() if get_result else None


### PR DESCRIPTION
This is to keep behavior of previous oe.execute()

Needs testing.