### PR TITLE
Rework RPi Revision Handling

### DIFF
--- a/resources/lib/config.py
+++ b/resources/lib/config.py
@@ -16,3 +16,5 @@ HOSTS_CONF = os.path.join(USER_CONFIG, 'hosts.conf')
 
 REGDOMAIN_CONF = os.path.join(CONFIG_CACHE, 'regdomain.conf')
 SETREGDOMAIN = '/usr/lib/iw/setregdomain'
+
+RPI_DEVICE_TYPE = os_tools.get_rpi_device_type() if PROJECT == 'RPi' else None

--- a/resources/lib/modules/updates.py
+++ b/resources/lib/modules/updates.py
@@ -307,8 +307,8 @@ class updates(modules.Module):
         self.struct['update']['settings']['Channel']['values'] = self.get_channels()
         self.struct['update']['settings']['Build']['values'] = self.get_available_builds()
 
-        # RPi4 EEPROM updating
-        if oe.RPI_CPU_VER == '3':
+        # RPi4/RPi400 EEPROM updating
+        if config.RPI_DEVICE_TYPE in ['11', '13']:
             self.rpi_flashing_state = self.get_rpi_flashing_state()
             if self.rpi_flashing_state['incompatible']:
                 self.struct['rpieeprom']['hidden'] = 'true'

--- a/resources/lib/oe.py
+++ b/resources/lib/oe.py
@@ -816,14 +816,6 @@ if os.path.exists('/etc/machine-id'):
 else:
     SYSTEMID = os.environ.get('SYSTEMID', '')
 
-try:
-    if PROJECT == 'RPi':
-        RPI_CPU_VER = os_tools.execute('vcgencmd otp_dump 2>/dev/null | grep 30: | cut -c8', get_result=True).replace('\n','')
-    else:
-        RPI_CPU_VER = None
-except Exception:
-    RPI_CPU_VER = None
-
 BOOT_STATUS = load_file('/storage/.config/boot.status')
 
 ############################################################################################

--- a/resources/lib/os_tools.py
+++ b/resources/lib/os_tools.py
@@ -50,3 +50,19 @@ def execute(command, get_result=False, output_err_msg=True):
         return '' if get_result else None
     # return output if requested, otherwise return None
     return cmd_status.stdout.decode() if get_result else None
+
+
+def get_rpi_device_type():
+    '''Ask kernel for RPi revision to get device type'''
+    if os.path.isfile('/proc/device-tree/system/linux,revision'):
+        with open('/proc/device-tree/system/linux,revision', mode='rb') as data:
+            revision = int(data.read().hex(), 16)
+        new_revision_format = (revision >> 23) & 0x1
+        if new_revision_format:
+            device_type = str((revision >> 4) & 0xff)
+            return device_type
+        else:
+            # old style revision format means older than RPi2; noop for now as no firmware for this hardware
+            # if needed in future, see: https://github.com/raspberrypi/documentation/blob/develop/documentation/asciidoc/computers/raspberry-pi/revision-codes.adoc
+            return None
+    return None


### PR DESCRIPTION
This replaces RPI_CPU_VER, which checked the RPI's processor (BCM283#...), with RPI_DEVICE_TYPE, which checks board type (RPi4B). This avoids trying to update firmware on CM4, which has different steps from my understanding. See: https://www.raspberrypi.com/documentation/computers/compute-module.html#cm4bootloader

Python to check this change from the CLI:

```
#!/usr/bin/env python3

with open('/proc/device-tree/system/linux,revision', mode='rb') as data:
    revision = int(data.read().hex(), 16)
new_rev_format = (revision >> 23) & 0x1

if new_rev_format:
    type = str((revision >> 4) & 0xff)
    print(f'{type=}')
```

Type='X' gets printed and 'X' should correspond to the "New style revision code" chart, under Type: https://github.com/raspberrypi/documentation/blob/develop/documentation/asciidoc/computers/raspberry-pi/revision-codes.adoc

The code for parsing the revision code from the kernel comes from the same document in the example section.

RPi3B is 8. RPi3B+ is d. RPi4B is 11. RPi5 is 17. If you're on an alpha board, it should be 5. Devices with only an 'old style' of revision code (old RPi1) just return None because there's no reason for the addon to care at this time. Above document has the codes for that if needed later.