### PR TITLE
Add support for RPi5 firmware updating

### DIFF
--- a/resources/lib/defaults.py
+++ b/resources/lib/defaults.py
@@ -90,8 +90,6 @@ updates = {
     'UPDATE_REQUEST_URL': 'https://update.libreelec.tv/updates.php',
     'UPDATE_DOWNLOAD_URL': 'http://%s.libreelec.tv/%s',
     'LOCAL_UPDATE_DIR': '/storage/.update/',
-
-    'RPI_FLASHING_TRIGGER': '/storage/.rpi_flash_firmware',
     }
 
 about = {'ENABLED': True}

--- a/resources/lib/modules/updates.py
+++ b/resources/lib/modules/updates.py
@@ -315,8 +315,11 @@ class updates(modules.Module):
             else:
                 self.struct['rpieeprom']['settings']['bootloader']['value'] = self.get_rpi_eeprom('BOOTLOADER')
                 self.struct['rpieeprom']['settings']['bootloader']['name'] = f"{oe._(32024)} ({self.rpi_flashing_state['bootloader']['state']})"
-                self.struct['rpieeprom']['settings']['vl805']['value'] = self.get_rpi_eeprom('VL805')
-                self.struct['rpieeprom']['settings']['vl805']['name'] = f"{oe._(32026)} ({self.rpi_flashing_state['vl805']['state']})"
+                if oe.DEVICE == 'RPi4':
+                    self.struct['rpieeprom']['settings']['vl805']['value'] = self.get_rpi_eeprom('VL805')
+                    self.struct['rpieeprom']['settings']['vl805']['name'] = f"{oe._(32026)} ({self.rpi_flashing_state['vl805']['state']})"
+                else:
+                    self.struct['rpieeprom']['settings']['vl805']['hidden'] = 'true'
         else:
             self.struct['rpieeprom']['hidden'] = 'true'
 

--- a/resources/lib/modules/updates.py
+++ b/resources/lib/modules/updates.py
@@ -615,7 +615,7 @@ class updates(modules.Module):
                     }
 
             with tempfile.NamedTemporaryFile(mode='r', delete=True) as machine_out:
-                console_output = os_tools.execute(f'/usr/bin/.rpi-eeprom-update.real -j -m "{machine_out.name}"', get_result=True).split('\n')
+                console_output = os_tools.execute(f'/usr/bin/.rpi-eeprom-update.real -j -m "{machine_out.name}"', get_result=True, output_err_msg=False).split('\n')
                 if os.path.getsize(machine_out.name) != 0:
                     state['incompatible'] = False
                     jdata = json.load(machine_out)

--- a/resources/lib/modules/updates.py
+++ b/resources/lib/modules/updates.py
@@ -147,7 +147,7 @@ class updates(modules.Module):
                 'bootloader': {
                     'name': 'dummy',
                     'value': '',
-                    'action': 'set_rpi_bootloader',
+                    'action': 'update_rpi_firmware',
                     'type': 'bool',
                     'InfoText': 32025,
                     'order': 1,
@@ -155,7 +155,7 @@ class updates(modules.Module):
                 'vl805': {
                     'name': 32026,
                     'value': '',
-                    'action': 'set_rpi_vl805',
+                    'action': 'update_rpi_firmware',
                     'type': 'bool',
                     'InfoText': 32027,
                     'order': 2,
@@ -310,13 +310,14 @@ class updates(modules.Module):
         # RPi4/RPi400/RPi5 EEPROM updating
         if os.path.isfile('/usr/bin/rpi-eeprom-update'):
             self.rpi_flashing_state = self.get_rpi_flashing_state()
+            log.log(f'RPi flashing state: {self.rpi_flashing_state}', log.DEBUG)
             if self.rpi_flashing_state['incompatible']:
                 self.struct['rpieeprom']['hidden'] = 'true'
             else:
-                self.struct['rpieeprom']['settings']['bootloader']['value'] = self.get_rpi_eeprom('BOOTLOADER')
+                self.struct['rpieeprom']['settings']['bootloader']['value'] = 'true' if os.path.isfile('/flash/pieeprom.upd') else 'false'
                 self.struct['rpieeprom']['settings']['bootloader']['name'] = f"{oe._(32024)} ({self.rpi_flashing_state['bootloader']['state']})"
                 if oe.DEVICE == 'RPi4':
-                    self.struct['rpieeprom']['settings']['vl805']['value'] = self.get_rpi_eeprom('VL805')
+                    self.struct['rpieeprom']['settings']['vl805']['value'] = 'true' if os.path.isfile('/flash/vl805.bin') else 'false'
                     self.struct['rpieeprom']['settings']['vl805']['name'] = f"{oe._(32026)} ({self.rpi_flashing_state['vl805']['state']})"
                 else:
                     self.struct['rpieeprom']['settings']['vl805']['hidden'] = 'true'
@@ -596,6 +597,7 @@ class updates(modules.Module):
             else:
                 delattr(self, 'update_in_progress')
 
+
     def get_rpi_flashing_state(self):
         try:
             log.log('enter_function', log.DEBUG)
@@ -651,47 +653,28 @@ class updates(modules.Module):
             log.log(f'ERROR: ({repr(e)})')
             return {'incompatible': True}
 
-    @log.log_function()
-    def get_rpi_eeprom(self, device):
-        values = []
-        if os.path.exists(self.RPI_FLASHING_TRIGGER):
-            with open(self.RPI_FLASHING_TRIGGER, 'r') as trigger:
-                values = trigger.read().split('\n')
-        log.log(f'values: {values}', log.DEBUG)
-        return 'true' if (f'{device}="yes"') in values else 'false'
 
     @log.log_function()
-    def set_rpi_eeprom(self):
-        bootloader = (self.struct['rpieeprom']['settings']['bootloader']['value'] == 'true')
-        vl805 = (self.struct['rpieeprom']['settings']['vl805']['value'] == 'true')
-        log.log(f'states: [{bootloader}], [{vl805}]', log.DEBUG)
-        if bootloader or vl805:
-            values = []
-            values.append('BOOTLOADER="%s"' % ('yes' if bootloader else 'no'))
-            values.append('VL805="%s"' % ('yes' if vl805 else 'no'))
-            with open(self.RPI_FLASHING_TRIGGER, 'w') as trigger:
-                trigger.write('\n'.join(values))
-        else:
-            if os.path.exists(self.RPI_FLASHING_TRIGGER):
-                os.remove(self.RPI_FLASHING_TRIGGER)
-
-    @log.log_function()
-    def set_rpi_bootloader(self, listItem):
+    def update_rpi_firmware(self, listItem):
         value = 'false'
-        if listItem.getProperty('value') == 'true':
-            if xbmcgui.Dialog().yesno('Update RPi Bootloader', f'{oe._(32023)}\n\n{oe._(32326)}'):
-                value = 'true'
+        if xbmcgui.Dialog().yesno('Update RPi Firmware', f'{oe._(32023)}\n\n{oe._(32326)}'):
+            # available update is newer than installed version
+            if self.rpi_flashing_state[listItem.getProperty('entry')]['current'] < self.rpi_flashing_state[listItem.getProperty('entry')]['latest']:
+                update_result = os_tools.execute(f'/usr/bin/rpi-eeprom-update -A {listItem.getProperty("entry")}', get_result=True)
+                log.log(f'rpi-eeprom-update result: {update_result}', log.DEBUG)
+                if update_result:
+                    xbmcgui.Dialog().ok('Update RPi Firmware', 'Please restart to complete the update.')
+                    value = 'true'
+            else:
+                xbmcgui.Dialog().ok('Update RPi Firmware', 'Firmware is up to date.')
+        # user chose no but bootloader update already queued
+        elif listItem.getProperty('entry') == 'bootloader' and os.path.isfile('/flash/pieeprom.upd'):
+            value = 'true'
+        # user chose no but vl805 update already queued
+        elif listItem.getProperty('entry') == 'vl805' and os.path.isfile('/flash/vl805.bin'):
+            value = 'true'
         self.struct[listItem.getProperty('category')]['settings'][listItem.getProperty('entry')]['value'] = value
-        self.set_rpi_eeprom()
 
-    @log.log_function()
-    def set_rpi_vl805(self, listItem):
-        value = 'false'
-        if listItem.getProperty('value') == 'true':
-            if xbmcgui.Dialog().yesno('Update RPi USB3 Firmware', f'{oe._(32023)}\n\n{oe._(32326)}'):
-                value = 'true'
-        self.struct[listItem.getProperty('category')]['settings'][listItem.getProperty('entry')]['value'] = value
-        self.set_rpi_eeprom()
 
 class updateThread(threading.Thread):
 

--- a/resources/lib/modules/updates.py
+++ b/resources/lib/modules/updates.py
@@ -307,8 +307,8 @@ class updates(modules.Module):
         self.struct['update']['settings']['Channel']['values'] = self.get_channels()
         self.struct['update']['settings']['Build']['values'] = self.get_available_builds()
 
-        # RPi4 EEPROM updating
-        if oe.RPI_CPU_VER == '3':
+        # RPi4/RPi400/RPi5 EEPROM updating
+        if os.path.isfile('/usr/bin/rpi-eeprom-update'):
             self.rpi_flashing_state = self.get_rpi_flashing_state()
             if self.rpi_flashing_state['incompatible']:
                 self.struct['rpieeprom']['hidden'] = 'true'

--- a/resources/lib/oe.py
+++ b/resources/lib/oe.py
@@ -816,14 +816,6 @@ if os.path.exists('/etc/machine-id'):
 else:
     SYSTEMID = os.environ.get('SYSTEMID', '')
 
-try:
-    if PROJECT == 'RPi':
-        RPI_CPU_VER = os_tools.execute('vcgencmd otp_dump 2>/dev/null | grep 30: | cut -c8', get_result=True).replace('\n','')
-    else:
-        RPI_CPU_VER = None
-except Exception:
-    RPI_CPU_VER = None
-
 BOOT_STATUS = load_file('/storage/.config/boot.status')
 
 ############################################################################################


### PR DESCRIPTION
This changes the RPi firmware update process to depend on the presence of `rpi-eeprom-update` instead of a specific model (vl805 firmware reporting is hidden if not on RPi4). If an update is available, it uses `-A` to update the bootloader or vl805 individually and directs the user to reboot. The flashing trigger / special bootup is no longer used.

Tested on RPi5; vl805 related changes are untested.

One bug found in `rpi-eeprom-update`. If an update is available, then `rpi-eeprom-update` has a non-zero return value when called either by itself, or with the `-j` and `-m` options. Python reported a Bad File Descriptor as the reason. `-A` did not have an issue. 

Toggling an update on/off quickly crashed Kodi. No investigation done (I was trying to break it and succeeded...)

TODO localization. If there's an objection to the approach, I'd rather change it before localization strings come into play.