### PR TITLE
Optimize refreshing the list of Bluetooth devices

### DIFF
--- a/resources/lib/modules/bluetooth.py
+++ b/resources/lib/modules/bluetooth.py
@@ -708,7 +708,7 @@ class discoveryThread(threading.Thread):
     def run(self):
         self._stop_event.clear()
         while not self.stopped and not oe.xbmcm.abortRequested():
-            current_time = time.time()
+            current_time = time.monotonic()
             if (self.main_menu.getSelectedItem().getProperty('modul') == 'bluetooth'
                     and current_time > self.last_run + BT_DEVICES_LIST_REFRESH_INTERVAL_SECONDS):
                 self.parent.discover_devices()
@@ -722,8 +722,8 @@ class pinkeyTimer(threading.Thread):
 
     def __init__(self, parent, runtime=60):
         self.parent = weakref.proxy(parent)
-        self.start_time = time.time()
-        self.last_run = time.time()
+        self.start_time = time.monotonic()
+        self.last_run = time.monotonic()
         self._stop_event = threading.Event()
         self.stopped = False
         self.runtime = runtime
@@ -749,7 +749,7 @@ class pinkeyTimer(threading.Thread):
         self._stop_event.clear()
         self.endtime = self.start_time + self.runtime
         while not self.stopped and not oe.xbmcm.abortRequested():
-            current_time = time.time()
+            current_time = time.monotonic()
             percent = round(100 / self.runtime * (self.endtime - current_time), 0)
             self.parent.pinkey_window.getControl(1704).setPercent(percent)
             if current_time >= self.endtime:

--- a/resources/lib/modules/bluetooth.py
+++ b/resources/lib/modules/bluetooth.py
@@ -19,6 +19,8 @@ import modules
 import oe
 import oeWindows
 
+BT_DEVICES_LIST_REFRESH_INTERVAL_SECONDS = 5
+
 
 class bluetooth(modules.Module):
 
@@ -708,7 +710,7 @@ class discoveryThread(threading.Thread):
         while not self.stopped and not oe.xbmcm.abortRequested():
             current_time = time.time()
             if (self.main_menu.getSelectedItem().getProperty('modul') == 'bluetooth'
-                    and current_time > self.last_run + 5):
+                    and current_time > self.last_run + BT_DEVICES_LIST_REFRESH_INTERVAL_SECONDS):
                 self.parent.discover_devices()
                 self.last_run = current_time
             elif self.main_menu.getSelectedItem().getProperty('modul') != 'bluetooth':


### PR DESCRIPTION
This PF fixes the following issues:
* When a device is added to/removed from the list of BT devices, the list fully is fully refreshed and the selection is reset to the first position in the list.
* When all BT devices in the vicinity of a LE instance have been turned off, they stay in the list while the label for the empty list is displayed.

Now devices are added to/removed from the list of BT devices without fully refreshing the list and the currently selected item is restored (it is actually reset even when the list is not fully refreshed but items are added/removed).

This PR is supposed to fix the problem that we had at this year FOSDEM when we couldn't connect a LE device to a wireless speaker because the list displayed dozens of devices (we had dozens and even hundreds of people around) that constantly appeared/disappeared so we could not navigate to our speaker to connect to it because the selection was constantly reset to the 1st position.