### PR TITLE
Add localization strings for RPi firmware updates and pastebin service

### DIFF
--- a/resources/language/resource.language.af_za/strings.po
+++ b/resources/language/resource.language.af_za/strings.po
@@ -1093,3 +1093,15 @@ msgstr ""
 msgctxt "#32416"
 msgid "Reboot to apply changes."
 msgstr ""
+
+msgctxt "#32417"
+msgid "Sending..."
+msgstr ""
+
+msgctxt "#32418"
+msgid "Log files sent to:"
+msgstr ""
+
+msgctxt "#32419"
+msgid "Error sending log files. Please try again."
+msgstr ""

--- a/resources/language/resource.language.am_et/strings.po
+++ b/resources/language/resource.language.am_et/strings.po
@@ -1093,3 +1093,15 @@ msgstr ""
 msgctxt "#32416"
 msgid "Reboot to apply changes."
 msgstr ""
+
+msgctxt "#32417"
+msgid "Sending..."
+msgstr ""
+
+msgctxt "#32418"
+msgid "Log files sent to:"
+msgstr ""
+
+msgctxt "#32419"
+msgid "Error sending log files. Please try again."
+msgstr ""

--- a/resources/language/resource.language.ar_sa/strings.po
+++ b/resources/language/resource.language.ar_sa/strings.po
@@ -1093,3 +1093,15 @@ msgstr ""
 msgctxt "#32416"
 msgid "Reboot to apply changes."
 msgstr ""
+
+msgctxt "#32417"
+msgid "Sending..."
+msgstr ""
+
+msgctxt "#32418"
+msgid "Log files sent to:"
+msgstr ""
+
+msgctxt "#32419"
+msgid "Error sending log files. Please try again."
+msgstr ""

--- a/resources/language/resource.language.ast_es/strings.po
+++ b/resources/language/resource.language.ast_es/strings.po
@@ -1098,3 +1098,15 @@ msgstr ""
 msgctxt "#32416"
 msgid "Reboot to apply changes."
 msgstr ""
+
+msgctxt "#32417"
+msgid "Sending..."
+msgstr ""
+
+msgctxt "#32418"
+msgid "Log files sent to:"
+msgstr ""
+
+msgctxt "#32419"
+msgid "Error sending log files. Please try again."
+msgstr ""

--- a/resources/language/resource.language.az_az/strings.po
+++ b/resources/language/resource.language.az_az/strings.po
@@ -1088,3 +1088,15 @@ msgstr ""
 msgctxt "#32416"
 msgid "Reboot to apply changes."
 msgstr ""
+
+msgctxt "#32417"
+msgid "Sending..."
+msgstr ""
+
+msgctxt "#32418"
+msgid "Log files sent to:"
+msgstr ""
+
+msgctxt "#32419"
+msgid "Error sending log files. Please try again."
+msgstr ""

--- a/resources/language/resource.language.be_by/strings.po
+++ b/resources/language/resource.language.be_by/strings.po
@@ -1088,3 +1088,15 @@ msgstr ""
 msgctxt "#32416"
 msgid "Reboot to apply changes."
 msgstr ""
+
+msgctxt "#32417"
+msgid "Sending..."
+msgstr ""
+
+msgctxt "#32418"
+msgid "Log files sent to:"
+msgstr ""
+
+msgctxt "#32419"
+msgid "Error sending log files. Please try again."
+msgstr ""

--- a/resources/language/resource.language.bg_bg/strings.po
+++ b/resources/language/resource.language.bg_bg/strings.po
@@ -1103,3 +1103,15 @@ msgstr ""
 msgctxt "#32416"
 msgid "Reboot to apply changes."
 msgstr ""
+
+msgctxt "#32417"
+msgid "Sending..."
+msgstr ""
+
+msgctxt "#32418"
+msgid "Log files sent to:"
+msgstr ""
+
+msgctxt "#32419"
+msgid "Error sending log files. Please try again."
+msgstr ""

--- a/resources/language/resource.language.bs_ba/strings.po
+++ b/resources/language/resource.language.bs_ba/strings.po
@@ -1088,3 +1088,15 @@ msgstr ""
 msgctxt "#32416"
 msgid "Reboot to apply changes."
 msgstr ""
+
+msgctxt "#32417"
+msgid "Sending..."
+msgstr ""
+
+msgctxt "#32418"
+msgid "Log files sent to:"
+msgstr ""
+
+msgctxt "#32419"
+msgid "Error sending log files. Please try again."
+msgstr ""

--- a/resources/language/resource.language.ca_es/strings.po
+++ b/resources/language/resource.language.ca_es/strings.po
@@ -1097,3 +1097,15 @@ msgstr ""
 msgctxt "#32416"
 msgid "Reboot to apply changes."
 msgstr ""
+
+msgctxt "#32417"
+msgid "Sending..."
+msgstr ""
+
+msgctxt "#32418"
+msgid "Log files sent to:"
+msgstr ""
+
+msgctxt "#32419"
+msgid "Error sending log files. Please try again."
+msgstr ""

--- a/resources/language/resource.language.cs_cz/strings.po
+++ b/resources/language/resource.language.cs_cz/strings.po
@@ -1111,3 +1111,15 @@ msgstr "Zrušit journald Rate Limit"
 msgctxt "#32416"
 msgid "Reboot to apply changes."
 msgstr "Restartovat pro použití změny."
+
+msgctxt "#32417"
+msgid "Sending..."
+msgstr ""
+
+msgctxt "#32418"
+msgid "Log files sent to:"
+msgstr ""
+
+msgctxt "#32419"
+msgid "Error sending log files. Please try again."
+msgstr ""

--- a/resources/language/resource.language.cy_gb/strings.po
+++ b/resources/language/resource.language.cy_gb/strings.po
@@ -1088,3 +1088,15 @@ msgstr ""
 msgctxt "#32416"
 msgid "Reboot to apply changes."
 msgstr ""
+
+msgctxt "#32417"
+msgid "Sending..."
+msgstr ""
+
+msgctxt "#32418"
+msgid "Log files sent to:"
+msgstr ""
+
+msgctxt "#32419"
+msgid "Error sending log files. Please try again."
+msgstr ""

--- a/resources/language/resource.language.da_dk/strings.po
+++ b/resources/language/resource.language.da_dk/strings.po
@@ -1094,3 +1094,15 @@ msgstr ""
 msgctxt "#32416"
 msgid "Reboot to apply changes."
 msgstr ""
+
+msgctxt "#32417"
+msgid "Sending..."
+msgstr ""
+
+msgctxt "#32418"
+msgid "Log files sent to:"
+msgstr ""
+
+msgctxt "#32419"
+msgid "Error sending log files. Please try again."
+msgstr ""

--- a/resources/language/resource.language.de_de/strings.po
+++ b/resources/language/resource.language.de_de/strings.po
@@ -1106,3 +1106,15 @@ msgstr "Ratenbegrenzung des \"journald\" deaktivieren"
 msgctxt "#32416"
 msgid "Reboot to apply changes."
 msgstr "Um die Änderungen zu aktivieren, bitte das System neu starten."
+
+msgctxt "#32417"
+msgid "Sending..."
+msgstr ""
+
+msgctxt "#32418"
+msgid "Log files sent to:"
+msgstr ""
+
+msgctxt "#32419"
+msgid "Error sending log files. Please try again."
+msgstr ""

--- a/resources/language/resource.language.el_gr/strings.po
+++ b/resources/language/resource.language.el_gr/strings.po
@@ -1098,3 +1098,15 @@ msgstr ""
 msgctxt "#32416"
 msgid "Reboot to apply changes."
 msgstr "Επανεκκίνηση για την εφαρμογή των αλλαγών"
+
+msgctxt "#32417"
+msgid "Sending..."
+msgstr ""
+
+msgctxt "#32418"
+msgid "Log files sent to:"
+msgstr ""
+
+msgctxt "#32419"
+msgid "Error sending log files. Please try again."
+msgstr ""

--- a/resources/language/resource.language.en_au/strings.po
+++ b/resources/language/resource.language.en_au/strings.po
@@ -1096,3 +1096,15 @@ msgstr ""
 msgctxt "#32416"
 msgid "Reboot to apply changes."
 msgstr ""
+
+msgctxt "#32417"
+msgid "Sending..."
+msgstr ""
+
+msgctxt "#32418"
+msgid "Log files sent to:"
+msgstr ""
+
+msgctxt "#32419"
+msgid "Error sending log files. Please try again."
+msgstr ""

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -1083,3 +1083,15 @@ msgstr ""
 msgctxt "#32416"
 msgid "Reboot to apply changes."
 msgstr ""
+
+msgctxt "#32417"
+msgid "Sending..."
+msgstr ""
+
+msgctxt "#32418"
+msgid "Log files sent to:"
+msgstr ""
+
+msgctxt "#32419"
+msgid "Error sending log files. Please try again."
+msgstr ""

--- a/resources/language/resource.language.en_nz/strings.po
+++ b/resources/language/resource.language.en_nz/strings.po
@@ -1096,3 +1096,15 @@ msgstr ""
 msgctxt "#32416"
 msgid "Reboot to apply changes."
 msgstr ""
+
+msgctxt "#32417"
+msgid "Sending..."
+msgstr ""
+
+msgctxt "#32418"
+msgid "Log files sent to:"
+msgstr ""
+
+msgctxt "#32419"
+msgid "Error sending log files. Please try again."
+msgstr ""

--- a/resources/language/resource.language.en_us/strings.po
+++ b/resources/language/resource.language.en_us/strings.po
@@ -1096,3 +1096,15 @@ msgstr ""
 msgctxt "#32416"
 msgid "Reboot to apply changes."
 msgstr ""
+
+msgctxt "#32417"
+msgid "Sending..."
+msgstr ""
+
+msgctxt "#32418"
+msgid "Log files sent to:"
+msgstr ""
+
+msgctxt "#32419"
+msgid "Error sending log files. Please try again."
+msgstr ""

--- a/resources/language/resource.language.eo/strings.po
+++ b/resources/language/resource.language.eo/strings.po
@@ -1088,3 +1088,15 @@ msgstr ""
 msgctxt "#32416"
 msgid "Reboot to apply changes."
 msgstr ""
+
+msgctxt "#32417"
+msgid "Sending..."
+msgstr ""
+
+msgctxt "#32418"
+msgid "Log files sent to:"
+msgstr ""
+
+msgctxt "#32419"
+msgid "Error sending log files. Please try again."
+msgstr ""

--- a/resources/language/resource.language.es_ar/strings.po
+++ b/resources/language/resource.language.es_ar/strings.po
@@ -1101,3 +1101,15 @@ msgstr ""
 msgctxt "#32416"
 msgid "Reboot to apply changes."
 msgstr ""
+
+msgctxt "#32417"
+msgid "Sending..."
+msgstr ""
+
+msgctxt "#32418"
+msgid "Log files sent to:"
+msgstr ""
+
+msgctxt "#32419"
+msgid "Error sending log files. Please try again."
+msgstr ""

--- a/resources/language/resource.language.es_es/strings.po
+++ b/resources/language/resource.language.es_es/strings.po
@@ -1109,3 +1109,15 @@ msgstr "Desabilitar limitación de frecuencia de registro jourlad"
 msgctxt "#32416"
 msgid "Reboot to apply changes."
 msgstr "Reiniciar para aplicar cambios."
+
+msgctxt "#32417"
+msgid "Sending..."
+msgstr ""
+
+msgctxt "#32418"
+msgid "Log files sent to:"
+msgstr ""
+
+msgctxt "#32419"
+msgid "Error sending log files. Please try again."
+msgstr ""

--- a/resources/language/resource.language.es_mx/strings.po
+++ b/resources/language/resource.language.es_mx/strings.po
@@ -1105,3 +1105,15 @@ msgstr "Desactivar límite de journald"
 msgctxt "#32416"
 msgid "Reboot to apply changes."
 msgstr "Reiniciar para aplicar cambios."
+
+msgctxt "#32417"
+msgid "Sending..."
+msgstr ""
+
+msgctxt "#32418"
+msgid "Log files sent to:"
+msgstr ""
+
+msgctxt "#32419"
+msgid "Error sending log files. Please try again."
+msgstr ""

--- a/resources/language/resource.language.et_ee/strings.po
+++ b/resources/language/resource.language.et_ee/strings.po
@@ -1088,3 +1088,15 @@ msgstr ""
 msgctxt "#32416"
 msgid "Reboot to apply changes."
 msgstr ""
+
+msgctxt "#32417"
+msgid "Sending..."
+msgstr ""
+
+msgctxt "#32418"
+msgid "Log files sent to:"
+msgstr ""
+
+msgctxt "#32419"
+msgid "Error sending log files. Please try again."
+msgstr ""

--- a/resources/language/resource.language.eu_es/strings.po
+++ b/resources/language/resource.language.eu_es/strings.po
@@ -1101,3 +1101,15 @@ msgstr ""
 msgctxt "#32416"
 msgid "Reboot to apply changes."
 msgstr ""
+
+msgctxt "#32417"
+msgid "Sending..."
+msgstr ""
+
+msgctxt "#32418"
+msgid "Log files sent to:"
+msgstr ""
+
+msgctxt "#32419"
+msgid "Error sending log files. Please try again."
+msgstr ""

--- a/resources/language/resource.language.fa_af/strings.po
+++ b/resources/language/resource.language.fa_af/strings.po
@@ -1088,3 +1088,15 @@ msgstr ""
 msgctxt "#32416"
 msgid "Reboot to apply changes."
 msgstr ""
+
+msgctxt "#32417"
+msgid "Sending..."
+msgstr ""
+
+msgctxt "#32418"
+msgid "Log files sent to:"
+msgstr ""
+
+msgctxt "#32419"
+msgid "Error sending log files. Please try again."
+msgstr ""

--- a/resources/language/resource.language.fa_ir/strings.po
+++ b/resources/language/resource.language.fa_ir/strings.po
@@ -1088,3 +1088,15 @@ msgstr ""
 msgctxt "#32416"
 msgid "Reboot to apply changes."
 msgstr ""
+
+msgctxt "#32417"
+msgid "Sending..."
+msgstr ""
+
+msgctxt "#32418"
+msgid "Log files sent to:"
+msgstr ""
+
+msgctxt "#32419"
+msgid "Error sending log files. Please try again."
+msgstr ""

--- a/resources/language/resource.language.fi_fi/strings.po
+++ b/resources/language/resource.language.fi_fi/strings.po
@@ -1104,3 +1104,15 @@ msgstr "Poista journaloinnin nopeusrajoitus käytöstä"
 msgctxt "#32416"
 msgid "Reboot to apply changes."
 msgstr "Käynnistä uudelleen muutosten käyttööottamiseksi."
+
+msgctxt "#32417"
+msgid "Sending..."
+msgstr ""
+
+msgctxt "#32418"
+msgid "Log files sent to:"
+msgstr ""
+
+msgctxt "#32419"
+msgid "Error sending log files. Please try again."
+msgstr ""

--- a/resources/language/resource.language.fo_fo/strings.po
+++ b/resources/language/resource.language.fo_fo/strings.po
@@ -1088,3 +1088,15 @@ msgstr ""
 msgctxt "#32416"
 msgid "Reboot to apply changes."
 msgstr ""
+
+msgctxt "#32417"
+msgid "Sending..."
+msgstr ""
+
+msgctxt "#32418"
+msgid "Log files sent to:"
+msgstr ""
+
+msgctxt "#32419"
+msgid "Error sending log files. Please try again."
+msgstr ""

--- a/resources/language/resource.language.fr_ca/strings.po
+++ b/resources/language/resource.language.fr_ca/strings.po
@@ -1116,3 +1116,15 @@ msgstr ""
 msgctxt "#32416"
 msgid "Reboot to apply changes."
 msgstr ""
+
+msgctxt "#32417"
+msgid "Sending..."
+msgstr ""
+
+msgctxt "#32418"
+msgid "Log files sent to:"
+msgstr ""
+
+msgctxt "#32419"
+msgid "Error sending log files. Please try again."
+msgstr ""

--- a/resources/language/resource.language.fr_fr/strings.po
+++ b/resources/language/resource.language.fr_fr/strings.po
@@ -1111,3 +1111,15 @@ msgstr "Désactiver le débit limite de journald"
 msgctxt "#32416"
 msgid "Reboot to apply changes."
 msgstr "Redémarrer pour appliquer les modifications."
+
+msgctxt "#32417"
+msgid "Sending..."
+msgstr ""
+
+msgctxt "#32418"
+msgid "Log files sent to:"
+msgstr ""
+
+msgctxt "#32419"
+msgid "Error sending log files. Please try again."
+msgstr ""

--- a/resources/language/resource.language.gl_es/strings.po
+++ b/resources/language/resource.language.gl_es/strings.po
@@ -1093,3 +1093,15 @@ msgstr ""
 msgctxt "#32416"
 msgid "Reboot to apply changes."
 msgstr ""
+
+msgctxt "#32417"
+msgid "Sending..."
+msgstr ""
+
+msgctxt "#32418"
+msgid "Log files sent to:"
+msgstr ""
+
+msgctxt "#32419"
+msgid "Error sending log files. Please try again."
+msgstr ""

--- a/resources/language/resource.language.he_il/strings.po
+++ b/resources/language/resource.language.he_il/strings.po
@@ -1095,3 +1095,15 @@ msgstr ""
 msgctxt "#32416"
 msgid "Reboot to apply changes."
 msgstr ""
+
+msgctxt "#32417"
+msgid "Sending..."
+msgstr ""
+
+msgctxt "#32418"
+msgid "Log files sent to:"
+msgstr ""
+
+msgctxt "#32419"
+msgid "Error sending log files. Please try again."
+msgstr ""

--- a/resources/language/resource.language.hi_in/strings.po
+++ b/resources/language/resource.language.hi_in/strings.po
@@ -1088,3 +1088,15 @@ msgstr ""
 msgctxt "#32416"
 msgid "Reboot to apply changes."
 msgstr ""
+
+msgctxt "#32417"
+msgid "Sending..."
+msgstr ""
+
+msgctxt "#32418"
+msgid "Log files sent to:"
+msgstr ""
+
+msgctxt "#32419"
+msgid "Error sending log files. Please try again."
+msgstr ""

--- a/resources/language/resource.language.hr_hr/strings.po
+++ b/resources/language/resource.language.hr_hr/strings.po
@@ -1100,3 +1100,15 @@ msgstr "Onemogući ograničenje brzine dnevnika"
 msgctxt "#32416"
 msgid "Reboot to apply changes."
 msgstr "Ponovno pokrenite za primjenu promjena."
+
+msgctxt "#32417"
+msgid "Sending..."
+msgstr ""
+
+msgctxt "#32418"
+msgid "Log files sent to:"
+msgstr ""
+
+msgctxt "#32419"
+msgid "Error sending log files. Please try again."
+msgstr ""

--- a/resources/language/resource.language.hu_hu/strings.po
+++ b/resources/language/resource.language.hu_hu/strings.po
@@ -1107,3 +1107,15 @@ msgstr "A journald gyakorisági korlátjának letiltása"
 msgctxt "#32416"
 msgid "Reboot to apply changes."
 msgstr "A változtatáshoz újraindítást szükséges."
+
+msgctxt "#32417"
+msgid "Sending..."
+msgstr ""
+
+msgctxt "#32418"
+msgid "Log files sent to:"
+msgstr ""
+
+msgctxt "#32419"
+msgid "Error sending log files. Please try again."
+msgstr ""

--- a/resources/language/resource.language.hy_am/strings.po
+++ b/resources/language/resource.language.hy_am/strings.po
@@ -1088,3 +1088,15 @@ msgstr ""
 msgctxt "#32416"
 msgid "Reboot to apply changes."
 msgstr ""
+
+msgctxt "#32417"
+msgid "Sending..."
+msgstr ""
+
+msgctxt "#32418"
+msgid "Log files sent to:"
+msgstr ""
+
+msgctxt "#32419"
+msgid "Error sending log files. Please try again."
+msgstr ""

--- a/resources/language/resource.language.id_id/strings.po
+++ b/resources/language/resource.language.id_id/strings.po
@@ -1093,3 +1093,15 @@ msgstr ""
 msgctxt "#32416"
 msgid "Reboot to apply changes."
 msgstr ""
+
+msgctxt "#32417"
+msgid "Sending..."
+msgstr ""
+
+msgctxt "#32418"
+msgid "Log files sent to:"
+msgstr ""
+
+msgctxt "#32419"
+msgid "Error sending log files. Please try again."
+msgstr ""

--- a/resources/language/resource.language.is_is/strings.po
+++ b/resources/language/resource.language.is_is/strings.po
@@ -1088,3 +1088,15 @@ msgstr ""
 msgctxt "#32416"
 msgid "Reboot to apply changes."
 msgstr ""
+
+msgctxt "#32417"
+msgid "Sending..."
+msgstr ""
+
+msgctxt "#32418"
+msgid "Log files sent to:"
+msgstr ""
+
+msgctxt "#32419"
+msgid "Error sending log files. Please try again."
+msgstr ""

--- a/resources/language/resource.language.it_it/strings.po
+++ b/resources/language/resource.language.it_it/strings.po
@@ -1104,3 +1104,15 @@ msgstr "Disabilita il limite di frequenza di registrazione di journald"
 msgctxt "#32416"
 msgid "Reboot to apply changes."
 msgstr "Riavvia per applicare le modifiche."
+
+msgctxt "#32417"
+msgid "Sending..."
+msgstr ""
+
+msgctxt "#32418"
+msgid "Log files sent to:"
+msgstr ""
+
+msgctxt "#32419"
+msgid "Error sending log files. Please try again."
+msgstr ""

--- a/resources/language/resource.language.ja_jp/strings.po
+++ b/resources/language/resource.language.ja_jp/strings.po
@@ -1102,3 +1102,15 @@ msgstr ""
 msgctxt "#32416"
 msgid "Reboot to apply changes."
 msgstr ""
+
+msgctxt "#32417"
+msgid "Sending..."
+msgstr ""
+
+msgctxt "#32418"
+msgid "Log files sent to:"
+msgstr ""
+
+msgctxt "#32419"
+msgid "Error sending log files. Please try again."
+msgstr ""

--- a/resources/language/resource.language.kn_in/strings.po
+++ b/resources/language/resource.language.kn_in/strings.po
@@ -1084,3 +1084,15 @@ msgstr ""
 msgctxt "#32416"
 msgid "Reboot to apply changes."
 msgstr ""
+
+msgctxt "#32417"
+msgid "Sending..."
+msgstr ""
+
+msgctxt "#32418"
+msgid "Log files sent to:"
+msgstr ""
+
+msgctxt "#32419"
+msgid "Error sending log files. Please try again."
+msgstr ""

--- a/resources/language/resource.language.ko_kr/strings.po
+++ b/resources/language/resource.language.ko_kr/strings.po
@@ -1104,3 +1104,15 @@ msgstr "저널 속도 제한 사용 안 함"
 msgctxt "#32416"
 msgid "Reboot to apply changes."
 msgstr "다시 시작하면 변경 사항을 적용합니다."
+
+msgctxt "#32417"
+msgid "Sending..."
+msgstr ""
+
+msgctxt "#32418"
+msgid "Log files sent to:"
+msgstr ""
+
+msgctxt "#32419"
+msgid "Error sending log files. Please try again."
+msgstr ""

--- a/resources/language/resource.language.lt_lt/strings.po
+++ b/resources/language/resource.language.lt_lt/strings.po
@@ -1104,3 +1104,15 @@ msgstr ""
 msgctxt "#32416"
 msgid "Reboot to apply changes."
 msgstr ""
+
+msgctxt "#32417"
+msgid "Sending..."
+msgstr ""
+
+msgctxt "#32418"
+msgid "Log files sent to:"
+msgstr ""
+
+msgctxt "#32419"
+msgid "Error sending log files. Please try again."
+msgstr ""

--- a/resources/language/resource.language.lv_lv/strings.po
+++ b/resources/language/resource.language.lv_lv/strings.po
@@ -1101,3 +1101,15 @@ msgstr ""
 msgctxt "#32416"
 msgid "Reboot to apply changes."
 msgstr ""
+
+msgctxt "#32417"
+msgid "Sending..."
+msgstr ""
+
+msgctxt "#32418"
+msgid "Log files sent to:"
+msgstr ""
+
+msgctxt "#32419"
+msgid "Error sending log files. Please try again."
+msgstr ""

--- a/resources/language/resource.language.mi/strings.po
+++ b/resources/language/resource.language.mi/strings.po
@@ -1084,3 +1084,15 @@ msgstr ""
 msgctxt "#32416"
 msgid "Reboot to apply changes."
 msgstr ""
+
+msgctxt "#32417"
+msgid "Sending..."
+msgstr ""
+
+msgctxt "#32418"
+msgid "Log files sent to:"
+msgstr ""
+
+msgctxt "#32419"
+msgid "Error sending log files. Please try again."
+msgstr ""

--- a/resources/language/resource.language.mk_mk/strings.po
+++ b/resources/language/resource.language.mk_mk/strings.po
@@ -1088,3 +1088,15 @@ msgstr ""
 msgctxt "#32416"
 msgid "Reboot to apply changes."
 msgstr ""
+
+msgctxt "#32417"
+msgid "Sending..."
+msgstr ""
+
+msgctxt "#32418"
+msgid "Log files sent to:"
+msgstr ""
+
+msgctxt "#32419"
+msgid "Error sending log files. Please try again."
+msgstr ""

--- a/resources/language/resource.language.ml_in/strings.po
+++ b/resources/language/resource.language.ml_in/strings.po
@@ -1088,3 +1088,15 @@ msgstr ""
 msgctxt "#32416"
 msgid "Reboot to apply changes."
 msgstr ""
+
+msgctxt "#32417"
+msgid "Sending..."
+msgstr ""
+
+msgctxt "#32418"
+msgid "Log files sent to:"
+msgstr ""
+
+msgctxt "#32419"
+msgid "Error sending log files. Please try again."
+msgstr ""

--- a/resources/language/resource.language.mn_mn/strings.po
+++ b/resources/language/resource.language.mn_mn/strings.po
@@ -1088,3 +1088,15 @@ msgstr ""
 msgctxt "#32416"
 msgid "Reboot to apply changes."
 msgstr ""
+
+msgctxt "#32417"
+msgid "Sending..."
+msgstr ""
+
+msgctxt "#32418"
+msgid "Log files sent to:"
+msgstr ""
+
+msgctxt "#32419"
+msgid "Error sending log files. Please try again."
+msgstr ""

--- a/resources/language/resource.language.ms_my/strings.po
+++ b/resources/language/resource.language.ms_my/strings.po
@@ -1088,3 +1088,15 @@ msgstr ""
 msgctxt "#32416"
 msgid "Reboot to apply changes."
 msgstr ""
+
+msgctxt "#32417"
+msgid "Sending..."
+msgstr ""
+
+msgctxt "#32418"
+msgid "Log files sent to:"
+msgstr ""
+
+msgctxt "#32419"
+msgid "Error sending log files. Please try again."
+msgstr ""

--- a/resources/language/resource.language.mt_mt/strings.po
+++ b/resources/language/resource.language.mt_mt/strings.po
@@ -1088,3 +1088,15 @@ msgstr ""
 msgctxt "#32416"
 msgid "Reboot to apply changes."
 msgstr ""
+
+msgctxt "#32417"
+msgid "Sending..."
+msgstr ""
+
+msgctxt "#32418"
+msgid "Log files sent to:"
+msgstr ""
+
+msgctxt "#32419"
+msgid "Error sending log files. Please try again."
+msgstr ""

--- a/resources/language/resource.language.my_mm/strings.po
+++ b/resources/language/resource.language.my_mm/strings.po
@@ -1088,3 +1088,15 @@ msgstr ""
 msgctxt "#32416"
 msgid "Reboot to apply changes."
 msgstr ""
+
+msgctxt "#32417"
+msgid "Sending..."
+msgstr ""
+
+msgctxt "#32418"
+msgid "Log files sent to:"
+msgstr ""
+
+msgctxt "#32419"
+msgid "Error sending log files. Please try again."
+msgstr ""

--- a/resources/language/resource.language.nb_no/strings.po
+++ b/resources/language/resource.language.nb_no/strings.po
@@ -1104,3 +1104,15 @@ msgstr ""
 msgctxt "#32416"
 msgid "Reboot to apply changes."
 msgstr "Utfør omstart for å ta i bruk endringer."
+
+msgctxt "#32417"
+msgid "Sending..."
+msgstr ""
+
+msgctxt "#32418"
+msgid "Log files sent to:"
+msgstr ""
+
+msgctxt "#32419"
+msgid "Error sending log files. Please try again."
+msgstr ""

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -1106,3 +1106,15 @@ msgstr "Uitschakelen journald rate limit"
 msgctxt "#32416"
 msgid "Reboot to apply changes."
 msgstr "Herstart om wijzigingen door te voeren."
+
+msgctxt "#32417"
+msgid "Sending..."
+msgstr ""
+
+msgctxt "#32418"
+msgid "Log files sent to:"
+msgstr ""
+
+msgctxt "#32419"
+msgid "Error sending log files. Please try again."
+msgstr ""

--- a/resources/language/resource.language.os_os/strings.po
+++ b/resources/language/resource.language.os_os/strings.po
@@ -1084,3 +1084,15 @@ msgstr ""
 msgctxt "#32416"
 msgid "Reboot to apply changes."
 msgstr ""
+
+msgctxt "#32417"
+msgid "Sending..."
+msgstr ""
+
+msgctxt "#32418"
+msgid "Log files sent to:"
+msgstr ""
+
+msgctxt "#32419"
+msgid "Error sending log files. Please try again."
+msgstr ""

--- a/resources/language/resource.language.pl_pl/strings.po
+++ b/resources/language/resource.language.pl_pl/strings.po
@@ -1104,3 +1104,15 @@ msgstr "Wyłącz limitu prędkości journald"
 msgctxt "#32416"
 msgid "Reboot to apply changes."
 msgstr "Uruchom ponownie, aby zastosować zmiany."
+
+msgctxt "#32417"
+msgid "Sending..."
+msgstr ""
+
+msgctxt "#32418"
+msgid "Log files sent to:"
+msgstr ""
+
+msgctxt "#32419"
+msgid "Error sending log files. Please try again."
+msgstr ""

--- a/resources/language/resource.language.pt_br/strings.po
+++ b/resources/language/resource.language.pt_br/strings.po
@@ -1112,3 +1112,15 @@ msgstr "Desativa a taxa limite do journald"
 msgctxt "#32416"
 msgid "Reboot to apply changes."
 msgstr "Reinicialize para aplicar as alterações."
+
+msgctxt "#32417"
+msgid "Sending..."
+msgstr ""
+
+msgctxt "#32418"
+msgid "Log files sent to:"
+msgstr ""
+
+msgctxt "#32419"
+msgid "Error sending log files. Please try again."
+msgstr ""

--- a/resources/language/resource.language.pt_pt/strings.po
+++ b/resources/language/resource.language.pt_pt/strings.po
@@ -1100,3 +1100,15 @@ msgstr ""
 msgctxt "#32416"
 msgid "Reboot to apply changes."
 msgstr ""
+
+msgctxt "#32417"
+msgid "Sending..."
+msgstr ""
+
+msgctxt "#32418"
+msgid "Log files sent to:"
+msgstr ""
+
+msgctxt "#32419"
+msgid "Error sending log files. Please try again."
+msgstr ""

--- a/resources/language/resource.language.ro_ro/strings.po
+++ b/resources/language/resource.language.ro_ro/strings.po
@@ -1097,3 +1097,15 @@ msgstr ""
 msgctxt "#32416"
 msgid "Reboot to apply changes."
 msgstr ""
+
+msgctxt "#32417"
+msgid "Sending..."
+msgstr ""
+
+msgctxt "#32418"
+msgid "Log files sent to:"
+msgstr ""
+
+msgctxt "#32419"
+msgid "Error sending log files. Please try again."
+msgstr ""

--- a/resources/language/resource.language.ru_ru/strings.po
+++ b/resources/language/resource.language.ru_ru/strings.po
@@ -1106,3 +1106,15 @@ msgstr "Отключить ограничение скорости журнал�
 msgctxt "#32416"
 msgid "Reboot to apply changes."
 msgstr "Перезагрузите для применения изменений."
+
+msgctxt "#32417"
+msgid "Sending..."
+msgstr ""
+
+msgctxt "#32418"
+msgid "Log files sent to:"
+msgstr ""
+
+msgctxt "#32419"
+msgid "Error sending log files. Please try again."
+msgstr ""

--- a/resources/language/resource.language.si_lk/strings.po
+++ b/resources/language/resource.language.si_lk/strings.po
@@ -1084,3 +1084,15 @@ msgstr ""
 msgctxt "#32416"
 msgid "Reboot to apply changes."
 msgstr ""
+
+msgctxt "#32417"
+msgid "Sending..."
+msgstr ""
+
+msgctxt "#32418"
+msgid "Log files sent to:"
+msgstr ""
+
+msgctxt "#32419"
+msgid "Error sending log files. Please try again."
+msgstr ""

--- a/resources/language/resource.language.sk_sk/strings.po
+++ b/resources/language/resource.language.sk_sk/strings.po
@@ -1106,3 +1106,15 @@ msgstr ""
 msgctxt "#32416"
 msgid "Reboot to apply changes."
 msgstr ""
+
+msgctxt "#32417"
+msgid "Sending..."
+msgstr ""
+
+msgctxt "#32418"
+msgid "Log files sent to:"
+msgstr ""
+
+msgctxt "#32419"
+msgid "Error sending log files. Please try again."
+msgstr ""

--- a/resources/language/resource.language.sl_si/strings.po
+++ b/resources/language/resource.language.sl_si/strings.po
@@ -1088,3 +1088,15 @@ msgstr ""
 msgctxt "#32416"
 msgid "Reboot to apply changes."
 msgstr ""
+
+msgctxt "#32417"
+msgid "Sending..."
+msgstr ""
+
+msgctxt "#32418"
+msgid "Log files sent to:"
+msgstr ""
+
+msgctxt "#32419"
+msgid "Error sending log files. Please try again."
+msgstr ""

--- a/resources/language/resource.language.sq_al/strings.po
+++ b/resources/language/resource.language.sq_al/strings.po
@@ -1093,3 +1093,15 @@ msgstr ""
 msgctxt "#32416"
 msgid "Reboot to apply changes."
 msgstr ""
+
+msgctxt "#32417"
+msgid "Sending..."
+msgstr ""
+
+msgctxt "#32418"
+msgid "Log files sent to:"
+msgstr ""
+
+msgctxt "#32419"
+msgid "Error sending log files. Please try again."
+msgstr ""

--- a/resources/language/resource.language.sr_rs/strings.po
+++ b/resources/language/resource.language.sr_rs/strings.po
@@ -1088,3 +1088,15 @@ msgstr ""
 msgctxt "#32416"
 msgid "Reboot to apply changes."
 msgstr ""
+
+msgctxt "#32417"
+msgid "Sending..."
+msgstr ""
+
+msgctxt "#32418"
+msgid "Log files sent to:"
+msgstr ""
+
+msgctxt "#32419"
+msgid "Error sending log files. Please try again."
+msgstr ""

--- a/resources/language/resource.language.sr_rs@latin/strings.po
+++ b/resources/language/resource.language.sr_rs@latin/strings.po
@@ -1088,3 +1088,15 @@ msgstr ""
 msgctxt "#32416"
 msgid "Reboot to apply changes."
 msgstr ""
+
+msgctxt "#32417"
+msgid "Sending..."
+msgstr ""
+
+msgctxt "#32418"
+msgid "Log files sent to:"
+msgstr ""
+
+msgctxt "#32419"
+msgid "Error sending log files. Please try again."
+msgstr ""

--- a/resources/language/resource.language.sv_se/strings.po
+++ b/resources/language/resource.language.sv_se/strings.po
@@ -1104,3 +1104,15 @@ msgstr ""
 msgctxt "#32416"
 msgid "Reboot to apply changes."
 msgstr "Starta om för att tillämpa ändringar."
+
+msgctxt "#32417"
+msgid "Sending..."
+msgstr ""
+
+msgctxt "#32418"
+msgid "Log files sent to:"
+msgstr ""
+
+msgctxt "#32419"
+msgid "Error sending log files. Please try again."
+msgstr ""

--- a/resources/language/resource.language.szl/strings.po
+++ b/resources/language/resource.language.szl/strings.po
@@ -1084,3 +1084,15 @@ msgstr ""
 msgctxt "#32416"
 msgid "Reboot to apply changes."
 msgstr ""
+
+msgctxt "#32417"
+msgid "Sending..."
+msgstr ""
+
+msgctxt "#32418"
+msgid "Log files sent to:"
+msgstr ""
+
+msgctxt "#32419"
+msgid "Error sending log files. Please try again."
+msgstr ""

--- a/resources/language/resource.language.ta_in/strings.po
+++ b/resources/language/resource.language.ta_in/strings.po
@@ -1088,3 +1088,15 @@ msgstr ""
 msgctxt "#32416"
 msgid "Reboot to apply changes."
 msgstr ""
+
+msgctxt "#32417"
+msgid "Sending..."
+msgstr ""
+
+msgctxt "#32418"
+msgid "Log files sent to:"
+msgstr ""
+
+msgctxt "#32419"
+msgid "Error sending log files. Please try again."
+msgstr ""

--- a/resources/language/resource.language.tg_tj/strings.po
+++ b/resources/language/resource.language.tg_tj/strings.po
@@ -1084,3 +1084,15 @@ msgstr ""
 msgctxt "#32416"
 msgid "Reboot to apply changes."
 msgstr ""
+
+msgctxt "#32417"
+msgid "Sending..."
+msgstr ""
+
+msgctxt "#32418"
+msgid "Log files sent to:"
+msgstr ""
+
+msgctxt "#32419"
+msgid "Error sending log files. Please try again."
+msgstr ""

--- a/resources/language/resource.language.th_th/strings.po
+++ b/resources/language/resource.language.th_th/strings.po
@@ -1088,3 +1088,15 @@ msgstr ""
 msgctxt "#32416"
 msgid "Reboot to apply changes."
 msgstr ""
+
+msgctxt "#32417"
+msgid "Sending..."
+msgstr ""
+
+msgctxt "#32418"
+msgid "Log files sent to:"
+msgstr ""
+
+msgctxt "#32419"
+msgid "Error sending log files. Please try again."
+msgstr ""

--- a/resources/language/resource.language.tr_tr/strings.po
+++ b/resources/language/resource.language.tr_tr/strings.po
@@ -1106,3 +1106,15 @@ msgstr "Journald Hız Sınırını devre dışı bırak"
 msgctxt "#32416"
 msgid "Reboot to apply changes."
 msgstr "Değişiklikleri uygulamak için yeniden başlatın."
+
+msgctxt "#32417"
+msgid "Sending..."
+msgstr ""
+
+msgctxt "#32418"
+msgid "Log files sent to:"
+msgstr ""
+
+msgctxt "#32419"
+msgid "Error sending log files. Please try again."
+msgstr ""

--- a/resources/language/resource.language.uk_ua/strings.po
+++ b/resources/language/resource.language.uk_ua/strings.po
@@ -1095,3 +1095,15 @@ msgstr ""
 msgctxt "#32416"
 msgid "Reboot to apply changes."
 msgstr ""
+
+msgctxt "#32417"
+msgid "Sending..."
+msgstr ""
+
+msgctxt "#32418"
+msgid "Log files sent to:"
+msgstr ""
+
+msgctxt "#32419"
+msgid "Error sending log files. Please try again."
+msgstr ""

--- a/resources/language/resource.language.uz_uz/strings.po
+++ b/resources/language/resource.language.uz_uz/strings.po
@@ -1088,3 +1088,15 @@ msgstr ""
 msgctxt "#32416"
 msgid "Reboot to apply changes."
 msgstr ""
+
+msgctxt "#32417"
+msgid "Sending..."
+msgstr ""
+
+msgctxt "#32418"
+msgid "Log files sent to:"
+msgstr ""
+
+msgctxt "#32419"
+msgid "Error sending log files. Please try again."
+msgstr ""

--- a/resources/language/resource.language.vi_vn/strings.po
+++ b/resources/language/resource.language.vi_vn/strings.po
@@ -1088,3 +1088,15 @@ msgstr ""
 msgctxt "#32416"
 msgid "Reboot to apply changes."
 msgstr ""
+
+msgctxt "#32417"
+msgid "Sending..."
+msgstr ""
+
+msgctxt "#32418"
+msgid "Log files sent to:"
+msgstr ""
+
+msgctxt "#32419"
+msgid "Error sending log files. Please try again."
+msgstr ""

--- a/resources/language/resource.language.zh_cn/strings.po
+++ b/resources/language/resource.language.zh_cn/strings.po
@@ -1104,3 +1104,15 @@ msgstr "禁用日志速率限制"
 msgctxt "#32416"
 msgid "Reboot to apply changes."
 msgstr "重新启动以应用更改。"
+
+msgctxt "#32417"
+msgid "Sending..."
+msgstr ""
+
+msgctxt "#32418"
+msgid "Log files sent to:"
+msgstr ""
+
+msgctxt "#32419"
+msgid "Error sending log files. Please try again."
+msgstr ""

--- a/resources/language/resource.language.zh_tw/strings.po
+++ b/resources/language/resource.language.zh_tw/strings.po
@@ -1094,3 +1094,15 @@ msgstr ""
 msgctxt "#32416"
 msgid "Reboot to apply changes."
 msgstr ""
+
+msgctxt "#32417"
+msgid "Sending..."
+msgstr ""
+
+msgctxt "#32418"
+msgid "Log files sent to:"
+msgstr ""
+
+msgctxt "#32419"
+msgid "Error sending log files. Please try again."
+msgstr ""

--- a/resources/lib/modules/system.py
+++ b/resources/lib/modules/system.py
@@ -608,20 +608,19 @@ class system(modules.Module):
     @log.log_function()
     def do_send_logs(self, log_cmd):
         paste_dlg = xbmcgui.DialogProgress()
-        paste_dlg.create('Pasting log files', 'Pasting...')
+        paste_dlg.create(oe._(32376), oe._(32417))
         result = os_tools.execute(log_cmd, get_result=True)
         if not paste_dlg.iscanceled():
             paste_dlg.close()
             if result:
                 link = result.find('http')
-                # TODO Localization
                 if link != -1:
                     log.log(result[link:], log.WARNING)
-                    xbmcDialog.ok('Paste complete', f'Log files pasted to {result[link:]}')
+                    xbmcDialog.ok(oe._(32376), f'{oe._(32418)} {result[link:]}')
                 else:
-                    xbmcDialog.ok('Failed paste', 'Failed to paste log files. Please try again')
+                    xbmcDialog.ok(oe._(32376), oe._(32419))
             else:
-                xbmcDialog.ok('Failed paste', 'Failed to paste log files. Please try again.')
+                xbmcDialog.ok(oe._(32376), oe._(32419))
 
     @log.log_function()
     def tar_add_folder(self, tar, folder):

--- a/resources/lib/modules/updates.py
+++ b/resources/lib/modules/updates.py
@@ -657,13 +657,13 @@ class updates(modules.Module):
     @log.log_function()
     def update_rpi_firmware(self, listItem):
         value = 'false'
-        if xbmcgui.Dialog().yesno('Update RPi Firmware', f'{oe._(32023)}\n\n{oe._(32326)}'):
+        if xbmcgui.Dialog().yesno(oe._(32022), f'{oe._(32023)}\n\n{oe._(32326)}'):
             # available update is newer than installed version
             if self.rpi_flashing_state[listItem.getProperty('entry')]['current'] < self.rpi_flashing_state[listItem.getProperty('entry')]['latest']:
                 update_result = os_tools.execute(f'/usr/bin/rpi-eeprom-update -A {listItem.getProperty("entry")}', get_result=True)
                 log.log(f'rpi-eeprom-update result: {update_result}', log.DEBUG)
                 if update_result:
-                    xbmcgui.Dialog().ok('Update RPi Firmware', 'Please restart to complete the update.')
+                    xbmcgui.Dialog().ok(oe._(32022), oe._(32023))
                     value = 'true'
             else:
                 xbmcgui.Dialog().ok('Update RPi Firmware', 'Firmware is up to date.')


### PR DESCRIPTION
This uses existing strings for the RPi firmware update:

32022 is "Firmware Update"
32023 is "Updating will occur once the system is rebooted."

Adds new strings for the log submissions. 

32376 is "Submit Log"