### PR TITLE
Replace filter used in backup selection and add hostname to default backup file name

### DIFF
--- a/resources/language/resource.language.af_za/strings.po
+++ b/resources/language/resource.language.af_za/strings.po
@@ -962,6 +962,10 @@ msgctxt "#32373"
 msgid "Restore Backup"
 msgstr ""
 
+msgctxt "#32374"
+msgid "Error: Invalid backup file. Filename must end in: .tar, .tar.gz, .tar.bz2, or .tar.xz"
+msgstr ""
+
 msgctxt "#32375"
 msgid "Backup Progress"
 msgstr ""

--- a/resources/language/resource.language.am_et/strings.po
+++ b/resources/language/resource.language.am_et/strings.po
@@ -962,6 +962,10 @@ msgctxt "#32373"
 msgid "Restore Backup"
 msgstr ""
 
+msgctxt "#32374"
+msgid "Error: Invalid backup file. Filename must end in: .tar, .tar.gz, .tar.bz2, or .tar.xz"
+msgstr ""
+
 msgctxt "#32375"
 msgid "Backup Progress"
 msgstr ""

--- a/resources/language/resource.language.ar_sa/strings.po
+++ b/resources/language/resource.language.ar_sa/strings.po
@@ -962,6 +962,10 @@ msgctxt "#32373"
 msgid "Restore Backup"
 msgstr ""
 
+msgctxt "#32374"
+msgid "Error: Invalid backup file. Filename must end in: .tar, .tar.gz, .tar.bz2, or .tar.xz"
+msgstr ""
+
 msgctxt "#32375"
 msgid "Backup Progress"
 msgstr ""

--- a/resources/language/resource.language.ast_es/strings.po
+++ b/resources/language/resource.language.ast_es/strings.po
@@ -967,6 +967,10 @@ msgctxt "#32373"
 msgid "Restore Backup"
 msgstr ""
 
+msgctxt "#32374"
+msgid "Error: Invalid backup file. Filename must end in: .tar, .tar.gz, .tar.bz2, or .tar.xz"
+msgstr ""
+
 msgctxt "#32375"
 msgid "Backup Progress"
 msgstr "Progresu del respaldu"

--- a/resources/language/resource.language.az_az/strings.po
+++ b/resources/language/resource.language.az_az/strings.po
@@ -957,6 +957,10 @@ msgctxt "#32373"
 msgid "Restore Backup"
 msgstr ""
 
+msgctxt "#32374"
+msgid "Error: Invalid backup file. Filename must end in: .tar, .tar.gz, .tar.bz2, or .tar.xz"
+msgstr ""
+
 msgctxt "#32375"
 msgid "Backup Progress"
 msgstr ""

--- a/resources/language/resource.language.be_by/strings.po
+++ b/resources/language/resource.language.be_by/strings.po
@@ -957,6 +957,10 @@ msgctxt "#32373"
 msgid "Restore Backup"
 msgstr ""
 
+msgctxt "#32374"
+msgid "Error: Invalid backup file. Filename must end in: .tar, .tar.gz, .tar.bz2, or .tar.xz"
+msgstr ""
+
 msgctxt "#32375"
 msgid "Backup Progress"
 msgstr ""

--- a/resources/language/resource.language.bg_bg/strings.po
+++ b/resources/language/resource.language.bg_bg/strings.po
@@ -970,6 +970,10 @@ msgctxt "#32373"
 msgid "Restore Backup"
 msgstr "Възстановяване от резервно копие"
 
+msgctxt "#32374"
+msgid "Error: Invalid backup file. Filename must end in: .tar, .tar.gz, .tar.bz2, or .tar.xz"
+msgstr ""
+
 msgctxt "#32375"
 msgid "Backup Progress"
 msgstr "Прогрес за създаване на резервното копие"

--- a/resources/language/resource.language.bs_ba/strings.po
+++ b/resources/language/resource.language.bs_ba/strings.po
@@ -957,6 +957,10 @@ msgctxt "#32373"
 msgid "Restore Backup"
 msgstr ""
 
+msgctxt "#32374"
+msgid "Error: Invalid backup file. Filename must end in: .tar, .tar.gz, .tar.bz2, or .tar.xz"
+msgstr ""
+
 msgctxt "#32375"
 msgid "Backup Progress"
 msgstr ""

--- a/resources/language/resource.language.ca_es/strings.po
+++ b/resources/language/resource.language.ca_es/strings.po
@@ -966,6 +966,10 @@ msgctxt "#32373"
 msgid "Restore Backup"
 msgstr ""
 
+msgctxt "#32374"
+msgid "Error: Invalid backup file. Filename must end in: .tar, .tar.gz, .tar.bz2, or .tar.xz"
+msgstr ""
+
 msgctxt "#32375"
 msgid "Backup Progress"
 msgstr ""

--- a/resources/language/resource.language.cs_cz/strings.po
+++ b/resources/language/resource.language.cs_cz/strings.po
@@ -980,6 +980,10 @@ msgctxt "#32373"
 msgid "Restore Backup"
 msgstr "Obnovit zálohu"
 
+msgctxt "#32374"
+msgid "Error: Invalid backup file. Filename must end in: .tar, .tar.gz, .tar.bz2, or .tar.xz"
+msgstr ""
+
 msgctxt "#32375"
 msgid "Backup Progress"
 msgstr "Průběh zálohování"

--- a/resources/language/resource.language.cy_gb/strings.po
+++ b/resources/language/resource.language.cy_gb/strings.po
@@ -957,6 +957,10 @@ msgctxt "#32373"
 msgid "Restore Backup"
 msgstr ""
 
+msgctxt "#32374"
+msgid "Error: Invalid backup file. Filename must end in: .tar, .tar.gz, .tar.bz2, or .tar.xz"
+msgstr ""
+
 msgctxt "#32375"
 msgid "Backup Progress"
 msgstr ""

--- a/resources/language/resource.language.da_dk/strings.po
+++ b/resources/language/resource.language.da_dk/strings.po
@@ -963,6 +963,10 @@ msgctxt "#32373"
 msgid "Restore Backup"
 msgstr ""
 
+msgctxt "#32374"
+msgid "Error: Invalid backup file. Filename must end in: .tar, .tar.gz, .tar.bz2, or .tar.xz"
+msgstr ""
+
 msgctxt "#32375"
 msgid "Backup Progress"
 msgstr ""

--- a/resources/language/resource.language.de_de/strings.po
+++ b/resources/language/resource.language.de_de/strings.po
@@ -975,6 +975,10 @@ msgctxt "#32373"
 msgid "Restore Backup"
 msgstr "Datensicherung wiederherstellen"
 
+msgctxt "#32374"
+msgid "Error: Invalid backup file. Filename must end in: .tar, .tar.gz, .tar.bz2, or .tar.xz"
+msgstr ""
+
 msgctxt "#32375"
 msgid "Backup Progress"
 msgstr "Fortschritt der Datensicherung"

--- a/resources/language/resource.language.el_gr/strings.po
+++ b/resources/language/resource.language.el_gr/strings.po
@@ -967,6 +967,10 @@ msgctxt "#32373"
 msgid "Restore Backup"
 msgstr ""
 
+msgctxt "#32374"
+msgid "Error: Invalid backup file. Filename must end in: .tar, .tar.gz, .tar.bz2, or .tar.xz"
+msgstr ""
+
 msgctxt "#32375"
 msgid "Backup Progress"
 msgstr ""

--- a/resources/language/resource.language.en_au/strings.po
+++ b/resources/language/resource.language.en_au/strings.po
@@ -965,6 +965,10 @@ msgctxt "#32373"
 msgid "Restore Backup"
 msgstr ""
 
+msgctxt "#32374"
+msgid "Error: Invalid backup file. Filename must end in: .tar, .tar.gz, .tar.bz2, or .tar.xz"
+msgstr ""
+
 msgctxt "#32375"
 msgid "Backup Progress"
 msgstr ""

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -952,6 +952,10 @@ msgctxt "#32373"
 msgid "Restore Backup"
 msgstr ""
 
+msgctxt "#32374"
+msgid "Error: Invalid backup file. Filename must end in: .tar, .tar.gz, .tar.bz2, or .tar.xz"
+msgstr ""
+
 msgctxt "#32375"
 msgid "Backup Progress"
 msgstr ""

--- a/resources/language/resource.language.en_nz/strings.po
+++ b/resources/language/resource.language.en_nz/strings.po
@@ -965,6 +965,10 @@ msgctxt "#32373"
 msgid "Restore Backup"
 msgstr ""
 
+msgctxt "#32374"
+msgid "Error: Invalid backup file. Filename must end in: .tar, .tar.gz, .tar.bz2, or .tar.xz"
+msgstr ""
+
 msgctxt "#32375"
 msgid "Backup Progress"
 msgstr ""

--- a/resources/language/resource.language.en_us/strings.po
+++ b/resources/language/resource.language.en_us/strings.po
@@ -965,6 +965,10 @@ msgctxt "#32373"
 msgid "Restore Backup"
 msgstr ""
 
+msgctxt "#32374"
+msgid "Error: Invalid backup file. Filename must end in: .tar, .tar.gz, .tar.bz2, or .tar.xz"
+msgstr ""
+
 msgctxt "#32375"
 msgid "Backup Progress"
 msgstr ""

--- a/resources/language/resource.language.eo/strings.po
+++ b/resources/language/resource.language.eo/strings.po
@@ -957,6 +957,10 @@ msgctxt "#32373"
 msgid "Restore Backup"
 msgstr ""
 
+msgctxt "#32374"
+msgid "Error: Invalid backup file. Filename must end in: .tar, .tar.gz, .tar.bz2, or .tar.xz"
+msgstr ""
+
 msgctxt "#32375"
 msgid "Backup Progress"
 msgstr ""

--- a/resources/language/resource.language.es_ar/strings.po
+++ b/resources/language/resource.language.es_ar/strings.po
@@ -970,6 +970,10 @@ msgctxt "#32373"
 msgid "Restore Backup"
 msgstr ""
 
+msgctxt "#32374"
+msgid "Error: Invalid backup file. Filename must end in: .tar, .tar.gz, .tar.bz2, or .tar.xz"
+msgstr ""
+
 msgctxt "#32375"
 msgid "Backup Progress"
 msgstr ""

--- a/resources/language/resource.language.es_es/strings.po
+++ b/resources/language/resource.language.es_es/strings.po
@@ -978,6 +978,10 @@ msgctxt "#32373"
 msgid "Restore Backup"
 msgstr "Restaurar respaldo"
 
+msgctxt "#32374"
+msgid "Error: Invalid backup file. Filename must end in: .tar, .tar.gz, .tar.bz2, or .tar.xz"
+msgstr ""
+
 msgctxt "#32375"
 msgid "Backup Progress"
 msgstr "Progreso del respaldo"

--- a/resources/language/resource.language.es_mx/strings.po
+++ b/resources/language/resource.language.es_mx/strings.po
@@ -974,6 +974,10 @@ msgctxt "#32373"
 msgid "Restore Backup"
 msgstr "Restaurar respaldo"
 
+msgctxt "#32374"
+msgid "Error: Invalid backup file. Filename must end in: .tar, .tar.gz, .tar.bz2, or .tar.xz"
+msgstr ""
+
 msgctxt "#32375"
 msgid "Backup Progress"
 msgstr "Progreso de respaldo"

--- a/resources/language/resource.language.et_ee/strings.po
+++ b/resources/language/resource.language.et_ee/strings.po
@@ -957,6 +957,10 @@ msgctxt "#32373"
 msgid "Restore Backup"
 msgstr ""
 
+msgctxt "#32374"
+msgid "Error: Invalid backup file. Filename must end in: .tar, .tar.gz, .tar.bz2, or .tar.xz"
+msgstr ""
+
 msgctxt "#32375"
 msgid "Backup Progress"
 msgstr ""

--- a/resources/language/resource.language.eu_es/strings.po
+++ b/resources/language/resource.language.eu_es/strings.po
@@ -970,6 +970,10 @@ msgctxt "#32373"
 msgid "Restore Backup"
 msgstr "Berreskuratu Segurtasun-Kopia"
 
+msgctxt "#32374"
+msgid "Error: Invalid backup file. Filename must end in: .tar, .tar.gz, .tar.bz2, or .tar.xz"
+msgstr ""
+
 msgctxt "#32375"
 msgid "Backup Progress"
 msgstr "Segurtasun-Kopiaren Aurrerapena"

--- a/resources/language/resource.language.fa_af/strings.po
+++ b/resources/language/resource.language.fa_af/strings.po
@@ -957,6 +957,10 @@ msgctxt "#32373"
 msgid "Restore Backup"
 msgstr ""
 
+msgctxt "#32374"
+msgid "Error: Invalid backup file. Filename must end in: .tar, .tar.gz, .tar.bz2, or .tar.xz"
+msgstr ""
+
 msgctxt "#32375"
 msgid "Backup Progress"
 msgstr ""

--- a/resources/language/resource.language.fa_ir/strings.po
+++ b/resources/language/resource.language.fa_ir/strings.po
@@ -957,6 +957,10 @@ msgctxt "#32373"
 msgid "Restore Backup"
 msgstr ""
 
+msgctxt "#32374"
+msgid "Error: Invalid backup file. Filename must end in: .tar, .tar.gz, .tar.bz2, or .tar.xz"
+msgstr ""
+
 msgctxt "#32375"
 msgid "Backup Progress"
 msgstr ""

--- a/resources/language/resource.language.fi_fi/strings.po
+++ b/resources/language/resource.language.fi_fi/strings.po
@@ -973,6 +973,10 @@ msgctxt "#32373"
 msgid "Restore Backup"
 msgstr "Palauta varmuuskopio"
 
+msgctxt "#32374"
+msgid "Error: Invalid backup file. Filename must end in: .tar, .tar.gz, .tar.bz2, or .tar.xz"
+msgstr ""
+
 msgctxt "#32375"
 msgid "Backup Progress"
 msgstr "Varmuuskopiointi"

--- a/resources/language/resource.language.fo_fo/strings.po
+++ b/resources/language/resource.language.fo_fo/strings.po
@@ -957,6 +957,10 @@ msgctxt "#32373"
 msgid "Restore Backup"
 msgstr ""
 
+msgctxt "#32374"
+msgid "Error: Invalid backup file. Filename must end in: .tar, .tar.gz, .tar.bz2, or .tar.xz"
+msgstr ""
+
 msgctxt "#32375"
 msgid "Backup Progress"
 msgstr ""

--- a/resources/language/resource.language.fr_ca/strings.po
+++ b/resources/language/resource.language.fr_ca/strings.po
@@ -985,6 +985,10 @@ msgctxt "#32373"
 msgid "Restore Backup"
 msgstr "Restaurer une sauvegarde"
 
+msgctxt "#32374"
+msgid "Error: Invalid backup file. Filename must end in: .tar, .tar.gz, .tar.bz2, or .tar.xz"
+msgstr ""
+
 msgctxt "#32375"
 msgid "Backup Progress"
 msgstr "Progression de la sauvegarde"

--- a/resources/language/resource.language.fr_fr/strings.po
+++ b/resources/language/resource.language.fr_fr/strings.po
@@ -980,6 +980,10 @@ msgctxt "#32373"
 msgid "Restore Backup"
 msgstr "Restaurer une sauvegarde"
 
+msgctxt "#32374"
+msgid "Error: Invalid backup file. Filename must end in: .tar, .tar.gz, .tar.bz2, or .tar.xz"
+msgstr ""
+
 msgctxt "#32375"
 msgid "Backup Progress"
 msgstr "Progression de la sauvegarde"

--- a/resources/language/resource.language.gl_es/strings.po
+++ b/resources/language/resource.language.gl_es/strings.po
@@ -962,6 +962,10 @@ msgctxt "#32373"
 msgid "Restore Backup"
 msgstr ""
 
+msgctxt "#32374"
+msgid "Error: Invalid backup file. Filename must end in: .tar, .tar.gz, .tar.bz2, or .tar.xz"
+msgstr ""
+
 msgctxt "#32375"
 msgid "Backup Progress"
 msgstr ""

--- a/resources/language/resource.language.he_il/strings.po
+++ b/resources/language/resource.language.he_il/strings.po
@@ -964,6 +964,10 @@ msgctxt "#32373"
 msgid "Restore Backup"
 msgstr ""
 
+msgctxt "#32374"
+msgid "Error: Invalid backup file. Filename must end in: .tar, .tar.gz, .tar.bz2, or .tar.xz"
+msgstr ""
+
 msgctxt "#32375"
 msgid "Backup Progress"
 msgstr ""

--- a/resources/language/resource.language.hi_in/strings.po
+++ b/resources/language/resource.language.hi_in/strings.po
@@ -957,6 +957,10 @@ msgctxt "#32373"
 msgid "Restore Backup"
 msgstr ""
 
+msgctxt "#32374"
+msgid "Error: Invalid backup file. Filename must end in: .tar, .tar.gz, .tar.bz2, or .tar.xz"
+msgstr ""
+
 msgctxt "#32375"
 msgid "Backup Progress"
 msgstr ""

--- a/resources/language/resource.language.hr_hr/strings.po
+++ b/resources/language/resource.language.hr_hr/strings.po
@@ -969,6 +969,10 @@ msgctxt "#32373"
 msgid "Restore Backup"
 msgstr "Obnovi sigurnosno kopiranje"
 
+msgctxt "#32374"
+msgid "Error: Invalid backup file. Filename must end in: .tar, .tar.gz, .tar.bz2, or .tar.xz"
+msgstr ""
+
 msgctxt "#32375"
 msgid "Backup Progress"
 msgstr "Napredak sigurnosnog kopiranja"

--- a/resources/language/resource.language.hu_hu/strings.po
+++ b/resources/language/resource.language.hu_hu/strings.po
@@ -976,6 +976,10 @@ msgctxt "#32373"
 msgid "Restore Backup"
 msgstr "Biztonsági mentés visszaállítása"
 
+msgctxt "#32374"
+msgid "Error: Invalid backup file. Filename must end in: .tar, .tar.gz, .tar.bz2, or .tar.xz"
+msgstr ""
+
 msgctxt "#32375"
 msgid "Backup Progress"
 msgstr "Biztonsági mentés állapota"

--- a/resources/language/resource.language.hy_am/strings.po
+++ b/resources/language/resource.language.hy_am/strings.po
@@ -957,6 +957,10 @@ msgctxt "#32373"
 msgid "Restore Backup"
 msgstr ""
 
+msgctxt "#32374"
+msgid "Error: Invalid backup file. Filename must end in: .tar, .tar.gz, .tar.bz2, or .tar.xz"
+msgstr ""
+
 msgctxt "#32375"
 msgid "Backup Progress"
 msgstr ""

--- a/resources/language/resource.language.id_id/strings.po
+++ b/resources/language/resource.language.id_id/strings.po
@@ -962,6 +962,10 @@ msgctxt "#32373"
 msgid "Restore Backup"
 msgstr ""
 
+msgctxt "#32374"
+msgid "Error: Invalid backup file. Filename must end in: .tar, .tar.gz, .tar.bz2, or .tar.xz"
+msgstr ""
+
 msgctxt "#32375"
 msgid "Backup Progress"
 msgstr ""

--- a/resources/language/resource.language.is_is/strings.po
+++ b/resources/language/resource.language.is_is/strings.po
@@ -957,6 +957,10 @@ msgctxt "#32373"
 msgid "Restore Backup"
 msgstr ""
 
+msgctxt "#32374"
+msgid "Error: Invalid backup file. Filename must end in: .tar, .tar.gz, .tar.bz2, or .tar.xz"
+msgstr ""
+
 msgctxt "#32375"
 msgid "Backup Progress"
 msgstr ""

--- a/resources/language/resource.language.it_it/strings.po
+++ b/resources/language/resource.language.it_it/strings.po
@@ -973,6 +973,10 @@ msgctxt "#32373"
 msgid "Restore Backup"
 msgstr "Ripristina backup"
 
+msgctxt "#32374"
+msgid "Error: Invalid backup file. Filename must end in: .tar, .tar.gz, .tar.bz2, or .tar.xz"
+msgstr ""
+
 msgctxt "#32375"
 msgid "Backup Progress"
 msgstr "Avanzamento del backup"

--- a/resources/language/resource.language.ja_jp/strings.po
+++ b/resources/language/resource.language.ja_jp/strings.po
@@ -971,6 +971,10 @@ msgctxt "#32373"
 msgid "Restore Backup"
 msgstr "バックアップを復元します"
 
+msgctxt "#32374"
+msgid "Error: Invalid backup file. Filename must end in: .tar, .tar.gz, .tar.bz2, or .tar.xz"
+msgstr ""
+
 msgctxt "#32375"
 msgid "Backup Progress"
 msgstr "バックアップ実効中です"

--- a/resources/language/resource.language.kn_in/strings.po
+++ b/resources/language/resource.language.kn_in/strings.po
@@ -953,6 +953,10 @@ msgctxt "#32373"
 msgid "Restore Backup"
 msgstr ""
 
+msgctxt "#32374"
+msgid "Error: Invalid backup file. Filename must end in: .tar, .tar.gz, .tar.bz2, or .tar.xz"
+msgstr ""
+
 msgctxt "#32375"
 msgid "Backup Progress"
 msgstr ""

--- a/resources/language/resource.language.ko_kr/strings.po
+++ b/resources/language/resource.language.ko_kr/strings.po
@@ -973,6 +973,10 @@ msgctxt "#32373"
 msgid "Restore Backup"
 msgstr "복원"
 
+msgctxt "#32374"
+msgid "Error: Invalid backup file. Filename must end in: .tar, .tar.gz, .tar.bz2, or .tar.xz"
+msgstr ""
+
 msgctxt "#32375"
 msgid "Backup Progress"
 msgstr "백업 진행"

--- a/resources/language/resource.language.lt_lt/strings.po
+++ b/resources/language/resource.language.lt_lt/strings.po
@@ -973,6 +973,10 @@ msgctxt "#32373"
 msgid "Restore Backup"
 msgstr "Atkurti iš atsarginės kopijos"
 
+msgctxt "#32374"
+msgid "Error: Invalid backup file. Filename must end in: .tar, .tar.gz, .tar.bz2, or .tar.xz"
+msgstr ""
+
 msgctxt "#32375"
 msgid "Backup Progress"
 msgstr "Atsarginio kopijavimo progresas"

--- a/resources/language/resource.language.lv_lv/strings.po
+++ b/resources/language/resource.language.lv_lv/strings.po
@@ -970,6 +970,10 @@ msgctxt "#32373"
 msgid "Restore Backup"
 msgstr "Atjaunot no dublējumkopijas"
 
+msgctxt "#32374"
+msgid "Error: Invalid backup file. Filename must end in: .tar, .tar.gz, .tar.bz2, or .tar.xz"
+msgstr ""
+
 msgctxt "#32375"
 msgid "Backup Progress"
 msgstr "Dublējumkopijas izveides norise"

--- a/resources/language/resource.language.mi/strings.po
+++ b/resources/language/resource.language.mi/strings.po
@@ -953,6 +953,10 @@ msgctxt "#32373"
 msgid "Restore Backup"
 msgstr ""
 
+msgctxt "#32374"
+msgid "Error: Invalid backup file. Filename must end in: .tar, .tar.gz, .tar.bz2, or .tar.xz"
+msgstr ""
+
 msgctxt "#32375"
 msgid "Backup Progress"
 msgstr ""

--- a/resources/language/resource.language.mk_mk/strings.po
+++ b/resources/language/resource.language.mk_mk/strings.po
@@ -957,6 +957,10 @@ msgctxt "#32373"
 msgid "Restore Backup"
 msgstr ""
 
+msgctxt "#32374"
+msgid "Error: Invalid backup file. Filename must end in: .tar, .tar.gz, .tar.bz2, or .tar.xz"
+msgstr ""
+
 msgctxt "#32375"
 msgid "Backup Progress"
 msgstr ""

--- a/resources/language/resource.language.ml_in/strings.po
+++ b/resources/language/resource.language.ml_in/strings.po
@@ -957,6 +957,10 @@ msgctxt "#32373"
 msgid "Restore Backup"
 msgstr ""
 
+msgctxt "#32374"
+msgid "Error: Invalid backup file. Filename must end in: .tar, .tar.gz, .tar.bz2, or .tar.xz"
+msgstr ""
+
 msgctxt "#32375"
 msgid "Backup Progress"
 msgstr ""

--- a/resources/language/resource.language.mn_mn/strings.po
+++ b/resources/language/resource.language.mn_mn/strings.po
@@ -957,6 +957,10 @@ msgctxt "#32373"
 msgid "Restore Backup"
 msgstr ""
 
+msgctxt "#32374"
+msgid "Error: Invalid backup file. Filename must end in: .tar, .tar.gz, .tar.bz2, or .tar.xz"
+msgstr ""
+
 msgctxt "#32375"
 msgid "Backup Progress"
 msgstr ""

--- a/resources/language/resource.language.ms_my/strings.po
+++ b/resources/language/resource.language.ms_my/strings.po
@@ -957,6 +957,10 @@ msgctxt "#32373"
 msgid "Restore Backup"
 msgstr ""
 
+msgctxt "#32374"
+msgid "Error: Invalid backup file. Filename must end in: .tar, .tar.gz, .tar.bz2, or .tar.xz"
+msgstr ""
+
 msgctxt "#32375"
 msgid "Backup Progress"
 msgstr ""

--- a/resources/language/resource.language.mt_mt/strings.po
+++ b/resources/language/resource.language.mt_mt/strings.po
@@ -957,6 +957,10 @@ msgctxt "#32373"
 msgid "Restore Backup"
 msgstr ""
 
+msgctxt "#32374"
+msgid "Error: Invalid backup file. Filename must end in: .tar, .tar.gz, .tar.bz2, or .tar.xz"
+msgstr ""
+
 msgctxt "#32375"
 msgid "Backup Progress"
 msgstr ""

--- a/resources/language/resource.language.my_mm/strings.po
+++ b/resources/language/resource.language.my_mm/strings.po
@@ -957,6 +957,10 @@ msgctxt "#32373"
 msgid "Restore Backup"
 msgstr ""
 
+msgctxt "#32374"
+msgid "Error: Invalid backup file. Filename must end in: .tar, .tar.gz, .tar.bz2, or .tar.xz"
+msgstr ""
+
 msgctxt "#32375"
 msgid "Backup Progress"
 msgstr ""

--- a/resources/language/resource.language.nb_no/strings.po
+++ b/resources/language/resource.language.nb_no/strings.po
@@ -973,6 +973,10 @@ msgctxt "#32373"
 msgid "Restore Backup"
 msgstr "Gjenopprett Sikkerhetskopi"
 
+msgctxt "#32374"
+msgid "Error: Invalid backup file. Filename must end in: .tar, .tar.gz, .tar.bz2, or .tar.xz"
+msgstr ""
+
 msgctxt "#32375"
 msgid "Backup Progress"
 msgstr "Sikkerhetskopiering Fremgang"

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -975,6 +975,10 @@ msgctxt "#32373"
 msgid "Restore Backup"
 msgstr "Terugzetten backup"
 
+msgctxt "#32374"
+msgid "Error: Invalid backup file. Filename must end in: .tar, .tar.gz, .tar.bz2, or .tar.xz"
+msgstr ""
+
 msgctxt "#32375"
 msgid "Backup Progress"
 msgstr "Backupvoortgang"

--- a/resources/language/resource.language.os_os/strings.po
+++ b/resources/language/resource.language.os_os/strings.po
@@ -953,6 +953,10 @@ msgctxt "#32373"
 msgid "Restore Backup"
 msgstr ""
 
+msgctxt "#32374"
+msgid "Error: Invalid backup file. Filename must end in: .tar, .tar.gz, .tar.bz2, or .tar.xz"
+msgstr ""
+
 msgctxt "#32375"
 msgid "Backup Progress"
 msgstr ""

--- a/resources/language/resource.language.pl_pl/strings.po
+++ b/resources/language/resource.language.pl_pl/strings.po
@@ -973,6 +973,10 @@ msgctxt "#32373"
 msgid "Restore Backup"
 msgstr "Przywróć kopię zapasową"
 
+msgctxt "#32374"
+msgid "Error: Invalid backup file. Filename must end in: .tar, .tar.gz, .tar.bz2, or .tar.xz"
+msgstr ""
+
 msgctxt "#32375"
 msgid "Backup Progress"
 msgstr "Postęp kopii zapasowej"

--- a/resources/language/resource.language.pt_br/strings.po
+++ b/resources/language/resource.language.pt_br/strings.po
@@ -981,6 +981,10 @@ msgctxt "#32373"
 msgid "Restore Backup"
 msgstr "Restaurar Backup"
 
+msgctxt "#32374"
+msgid "Error: Invalid backup file. Filename must end in: .tar, .tar.gz, .tar.bz2, or .tar.xz"
+msgstr ""
+
 msgctxt "#32375"
 msgid "Backup Progress"
 msgstr "Progresso do Backup"

--- a/resources/language/resource.language.pt_pt/strings.po
+++ b/resources/language/resource.language.pt_pt/strings.po
@@ -969,6 +969,10 @@ msgctxt "#32373"
 msgid "Restore Backup"
 msgstr ""
 
+msgctxt "#32374"
+msgid "Error: Invalid backup file. Filename must end in: .tar, .tar.gz, .tar.bz2, or .tar.xz"
+msgstr ""
+
 msgctxt "#32375"
 msgid "Backup Progress"
 msgstr ""

--- a/resources/language/resource.language.ro_ro/strings.po
+++ b/resources/language/resource.language.ro_ro/strings.po
@@ -966,6 +966,10 @@ msgctxt "#32373"
 msgid "Restore Backup"
 msgstr "Restaurează rezerva"
 
+msgctxt "#32374"
+msgid "Error: Invalid backup file. Filename must end in: .tar, .tar.gz, .tar.bz2, or .tar.xz"
+msgstr ""
+
 msgctxt "#32375"
 msgid "Backup Progress"
 msgstr "Progres rezervă"

--- a/resources/language/resource.language.ru_ru/strings.po
+++ b/resources/language/resource.language.ru_ru/strings.po
@@ -975,6 +975,10 @@ msgctxt "#32373"
 msgid "Restore Backup"
 msgstr "Восстановить из резервной копии"
 
+msgctxt "#32374"
+msgid "Error: Invalid backup file. Filename must end in: .tar, .tar.gz, .tar.bz2, or .tar.xz"
+msgstr ""
+
 msgctxt "#32375"
 msgid "Backup Progress"
 msgstr "Прогресс создания резервной копии"

--- a/resources/language/resource.language.si_lk/strings.po
+++ b/resources/language/resource.language.si_lk/strings.po
@@ -953,6 +953,10 @@ msgctxt "#32373"
 msgid "Restore Backup"
 msgstr ""
 
+msgctxt "#32374"
+msgid "Error: Invalid backup file. Filename must end in: .tar, .tar.gz, .tar.bz2, or .tar.xz"
+msgstr ""
+
 msgctxt "#32375"
 msgid "Backup Progress"
 msgstr ""

--- a/resources/language/resource.language.sk_sk/strings.po
+++ b/resources/language/resource.language.sk_sk/strings.po
@@ -975,6 +975,10 @@ msgctxt "#32373"
 msgid "Restore Backup"
 msgstr "Obnoviť zálohu"
 
+msgctxt "#32374"
+msgid "Error: Invalid backup file. Filename must end in: .tar, .tar.gz, .tar.bz2, or .tar.xz"
+msgstr ""
+
 msgctxt "#32375"
 msgid "Backup Progress"
 msgstr "Priebeh zálohovania"

--- a/resources/language/resource.language.sl_si/strings.po
+++ b/resources/language/resource.language.sl_si/strings.po
@@ -957,6 +957,10 @@ msgctxt "#32373"
 msgid "Restore Backup"
 msgstr ""
 
+msgctxt "#32374"
+msgid "Error: Invalid backup file. Filename must end in: .tar, .tar.gz, .tar.bz2, or .tar.xz"
+msgstr ""
+
 msgctxt "#32375"
 msgid "Backup Progress"
 msgstr ""

--- a/resources/language/resource.language.sq_al/strings.po
+++ b/resources/language/resource.language.sq_al/strings.po
@@ -962,6 +962,10 @@ msgctxt "#32373"
 msgid "Restore Backup"
 msgstr ""
 
+msgctxt "#32374"
+msgid "Error: Invalid backup file. Filename must end in: .tar, .tar.gz, .tar.bz2, or .tar.xz"
+msgstr ""
+
 msgctxt "#32375"
 msgid "Backup Progress"
 msgstr ""

--- a/resources/language/resource.language.sr_rs/strings.po
+++ b/resources/language/resource.language.sr_rs/strings.po
@@ -957,6 +957,10 @@ msgctxt "#32373"
 msgid "Restore Backup"
 msgstr ""
 
+msgctxt "#32374"
+msgid "Error: Invalid backup file. Filename must end in: .tar, .tar.gz, .tar.bz2, or .tar.xz"
+msgstr ""
+
 msgctxt "#32375"
 msgid "Backup Progress"
 msgstr ""

--- a/resources/language/resource.language.sr_rs@latin/strings.po
+++ b/resources/language/resource.language.sr_rs@latin/strings.po
@@ -957,6 +957,10 @@ msgctxt "#32373"
 msgid "Restore Backup"
 msgstr ""
 
+msgctxt "#32374"
+msgid "Error: Invalid backup file. Filename must end in: .tar, .tar.gz, .tar.bz2, or .tar.xz"
+msgstr ""
+
 msgctxt "#32375"
 msgid "Backup Progress"
 msgstr ""

--- a/resources/language/resource.language.sv_se/strings.po
+++ b/resources/language/resource.language.sv_se/strings.po
@@ -973,6 +973,10 @@ msgctxt "#32373"
 msgid "Restore Backup"
 msgstr "Återställ backup"
 
+msgctxt "#32374"
+msgid "Error: Invalid backup file. Filename must end in: .tar, .tar.gz, .tar.bz2, or .tar.xz"
+msgstr ""
+
 msgctxt "#32375"
 msgid "Backup Progress"
 msgstr "Backup pågår"

--- a/resources/language/resource.language.szl/strings.po
+++ b/resources/language/resource.language.szl/strings.po
@@ -953,6 +953,10 @@ msgctxt "#32373"
 msgid "Restore Backup"
 msgstr ""
 
+msgctxt "#32374"
+msgid "Error: Invalid backup file. Filename must end in: .tar, .tar.gz, .tar.bz2, or .tar.xz"
+msgstr ""
+
 msgctxt "#32375"
 msgid "Backup Progress"
 msgstr ""

--- a/resources/language/resource.language.ta_in/strings.po
+++ b/resources/language/resource.language.ta_in/strings.po
@@ -957,6 +957,10 @@ msgctxt "#32373"
 msgid "Restore Backup"
 msgstr ""
 
+msgctxt "#32374"
+msgid "Error: Invalid backup file. Filename must end in: .tar, .tar.gz, .tar.bz2, or .tar.xz"
+msgstr ""
+
 msgctxt "#32375"
 msgid "Backup Progress"
 msgstr ""

--- a/resources/language/resource.language.tg_tj/strings.po
+++ b/resources/language/resource.language.tg_tj/strings.po
@@ -953,6 +953,10 @@ msgctxt "#32373"
 msgid "Restore Backup"
 msgstr ""
 
+msgctxt "#32374"
+msgid "Error: Invalid backup file. Filename must end in: .tar, .tar.gz, .tar.bz2, or .tar.xz"
+msgstr ""
+
 msgctxt "#32375"
 msgid "Backup Progress"
 msgstr ""

--- a/resources/language/resource.language.th_th/strings.po
+++ b/resources/language/resource.language.th_th/strings.po
@@ -957,6 +957,10 @@ msgctxt "#32373"
 msgid "Restore Backup"
 msgstr ""
 
+msgctxt "#32374"
+msgid "Error: Invalid backup file. Filename must end in: .tar, .tar.gz, .tar.bz2, or .tar.xz"
+msgstr ""
+
 msgctxt "#32375"
 msgid "Backup Progress"
 msgstr ""

--- a/resources/language/resource.language.tr_tr/strings.po
+++ b/resources/language/resource.language.tr_tr/strings.po
@@ -975,6 +975,10 @@ msgctxt "#32373"
 msgid "Restore Backup"
 msgstr "Yedeklemeyi Geri Yükle"
 
+msgctxt "#32374"
+msgid "Error: Invalid backup file. Filename must end in: .tar, .tar.gz, .tar.bz2, or .tar.xz"
+msgstr ""
+
 msgctxt "#32375"
 msgid "Backup Progress"
 msgstr "Yedekleme İşlemi İlerleme Durumu"

--- a/resources/language/resource.language.uk_ua/strings.po
+++ b/resources/language/resource.language.uk_ua/strings.po
@@ -964,6 +964,10 @@ msgctxt "#32373"
 msgid "Restore Backup"
 msgstr ""
 
+msgctxt "#32374"
+msgid "Error: Invalid backup file. Filename must end in: .tar, .tar.gz, .tar.bz2, or .tar.xz"
+msgstr ""
+
 msgctxt "#32375"
 msgid "Backup Progress"
 msgstr ""

--- a/resources/language/resource.language.uz_uz/strings.po
+++ b/resources/language/resource.language.uz_uz/strings.po
@@ -957,6 +957,10 @@ msgctxt "#32373"
 msgid "Restore Backup"
 msgstr ""
 
+msgctxt "#32374"
+msgid "Error: Invalid backup file. Filename must end in: .tar, .tar.gz, .tar.bz2, or .tar.xz"
+msgstr ""
+
 msgctxt "#32375"
 msgid "Backup Progress"
 msgstr ""

--- a/resources/language/resource.language.vi_vn/strings.po
+++ b/resources/language/resource.language.vi_vn/strings.po
@@ -957,6 +957,10 @@ msgctxt "#32373"
 msgid "Restore Backup"
 msgstr ""
 
+msgctxt "#32374"
+msgid "Error: Invalid backup file. Filename must end in: .tar, .tar.gz, .tar.bz2, or .tar.xz"
+msgstr ""
+
 msgctxt "#32375"
 msgid "Backup Progress"
 msgstr ""

--- a/resources/language/resource.language.zh_cn/strings.po
+++ b/resources/language/resource.language.zh_cn/strings.po
@@ -973,6 +973,10 @@ msgctxt "#32373"
 msgid "Restore Backup"
 msgstr "恢复备份"
 
+msgctxt "#32374"
+msgid "Error: Invalid backup file. Filename must end in: .tar, .tar.gz, .tar.bz2, or .tar.xz"
+msgstr ""
+
 msgctxt "#32375"
 msgid "Backup Progress"
 msgstr "备份进度"

--- a/resources/language/resource.language.zh_tw/strings.po
+++ b/resources/language/resource.language.zh_tw/strings.po
@@ -963,6 +963,10 @@ msgctxt "#32373"
 msgid "Restore Backup"
 msgstr ""
 
+msgctxt "#32374"
+msgid "Error: Invalid backup file. Filename must end in: .tar, .tar.gz, .tar.bz2, or .tar.xz"
+msgstr ""
+
 msgctxt "#32375"
 msgid "Backup Progress"
 msgstr ""

--- a/resources/lib/modules/system.py
+++ b/resources/lib/modules/system.py
@@ -556,13 +556,19 @@ class system(modules.Module):
             restore_file_path = xbmcDialog.browse( 1,
                                                    oe._(32373),
                                                    'files',
-                                                   '??????????????.tar',
+                                                   '',
                                                    False,
                                                    False,
                                                    self.BACKUP_DESTINATION )
             # Do nothing if the dialog is cancelled - path will be the backup destination
             if not os.path.isfile(restore_file_path):
                 return
+            # file selected that won't trigger busybox's backup restoration
+            if not restore_file_path.endswith(('.tar', '.tar.gz', '.tar.bz2', '.tar.xz')):
+                log.log(f'Error: Invalid restore file: {restore_file_path}', log.ERROR)
+                xbmcDialog.ok(oe._(32373), 'Error: Invalid selection. Filename must end in: .tar, .tar.gz, .tar.bz2, or .tar.xz')
+                return
+
             log.log(f'Restore file: {restore_file_path}', log.INFO)
             restore_file_name = restore_file_path.split('/')[-1]
             if os.path.exists(self.RESTORE_DIR):

--- a/resources/lib/modules/system.py
+++ b/resources/lib/modules/system.py
@@ -526,7 +526,7 @@ class system(modules.Module):
                 self.backup_dlg.create('LibreELEC', oe._(32375))
                 if not os.path.exists(self.BACKUP_DESTINATION):
                     os.makedirs(self.BACKUP_DESTINATION)
-                self.backup_file = f'{oe.timestamp()}.tar'
+                self.backup_file = f'{hostname.get_hostname()}-{oe.timestamp()}.tar'
                 log.log(f'Backup file: {bckDir + self.backup_file}', log.INFO)
                 tar = tarfile.open(bckDir + self.backup_file, 'w', format=tarfile.GNU_FORMAT)
                 for directory in self.BACKUP_DIRS:

--- a/resources/lib/modules/system.py
+++ b/resources/lib/modules/system.py
@@ -565,8 +565,8 @@ class system(modules.Module):
                 return
             # file selected that won't trigger busybox's backup restoration
             if not restore_file_path.endswith(('.tar', '.tar.gz', '.tar.bz2', '.tar.xz')):
-                log.log(f'Error: Invalid restore file: {restore_file_path}', log.ERROR)
-                xbmcDialog.ok(oe._(32373), 'Error: Invalid selection. Filename must end in: .tar, .tar.gz, .tar.bz2, or .tar.xz')
+                log.log(f'Error: Invalid backup file: {restore_file_path}', log.ERROR)
+                xbmcDialog.ok(oe._(32373), oe._(32374))
                 return
 
             log.log(f'Restore file: {restore_file_path}', log.INFO)


### PR DESCRIPTION
xbmcgui.dialog.browse (https://alwinesch.github.io/group__python___dialog.html#ga2ece1ca620087a97233713710eac1b83) is used to select the backup file to be restored. `'??????????????.tar'` serves as the "mask" to filter the selected file to an acceptable format. In short, if a user selects a file that isn't 14 characters followed by .tar, it gets rejected and silently replaced with the default value of the backup directory, which the addon then rejects and does nothing.

This removes the "mask" altogether, and instead does a post-selection check to see if the chosen file ends in one of: .tar, .tar.gz, .tar.bz2, or .tar.xz. This matches the busybox restore script (https://github.com/LibreELEC/LibreELEC.tv/blob/9ea3926457cf8b162b2e7f16faf7a8928270929b/packages/mediacenter/LibreELEC-settings/scripts/backup-restore#L11-L15). If the file doesn't match, it tells the user they made an invalid choice.

No image-side changes are needed for the above; the busybox script was changed pre-LE10 to accommodate #162 

With relaxed backup file selection, change the default backup naming from $DATESTAMP.tar to $HOSTNAME-$DATESTAMP.tar. My hope is that this will be clearer when looking at these files later, even if leaving at the default hostname. Additionally, if a user has multiple LE boxes, hopefully they have unique hostnames (ex: LE-LivingRoom or LE-RPi5).

~~TODO localization~~