### PR TITLE
Set timezone via addon

### DIFF
--- a/resources/language/resource.language.af_za/strings.po
+++ b/resources/language/resource.language.af_za/strings.po
@@ -591,7 +591,7 @@ msgid "Current Version"
 msgstr ""
 
 msgctxt "#32189"
-msgid "Identification"
+msgid "OS Configuration"
 msgstr ""
 
 msgctxt "#32190"

--- a/resources/language/resource.language.af_za/strings.po
+++ b/resources/language/resource.language.af_za/strings.po
@@ -86,6 +86,10 @@ msgctxt "#707"
 msgid "Configure updates"
 msgstr ""
 
+msgctxt "#709"
+msgid "Select the timezone for this device."
+msgstr ""
+
 msgctxt "#710"
 msgid "Configure the Hostname of your @DISTRONAME@ system. This will be used for the HTPC \\\\hostname in Windows and SMB server name in the Mac OS Finder"
 msgstr ""
@@ -1104,4 +1108,8 @@ msgstr ""
 
 msgctxt "#32419"
 msgid "Error sending log files. Please try again."
+msgstr ""
+
+msgctxt "#32420"
+msgid "Timezone"
 msgstr ""

--- a/resources/language/resource.language.am_et/strings.po
+++ b/resources/language/resource.language.am_et/strings.po
@@ -591,7 +591,7 @@ msgid "Current Version"
 msgstr ""
 
 msgctxt "#32189"
-msgid "Identification"
+msgid "OS Configuration"
 msgstr ""
 
 msgctxt "#32190"

--- a/resources/language/resource.language.am_et/strings.po
+++ b/resources/language/resource.language.am_et/strings.po
@@ -86,6 +86,10 @@ msgctxt "#707"
 msgid "Configure updates"
 msgstr ""
 
+msgctxt "#709"
+msgid "Select the timezone for this device."
+msgstr ""
+
 msgctxt "#710"
 msgid "Configure the Hostname of your @DISTRONAME@ system. This will be used for the HTPC \\\\hostname in Windows and SMB server name in the Mac OS Finder"
 msgstr ""
@@ -1104,4 +1108,8 @@ msgstr ""
 
 msgctxt "#32419"
 msgid "Error sending log files. Please try again."
+msgstr ""
+
+msgctxt "#32420"
+msgid "Timezone"
 msgstr ""

--- a/resources/language/resource.language.ar_sa/strings.po
+++ b/resources/language/resource.language.ar_sa/strings.po
@@ -591,7 +591,7 @@ msgid "Current Version"
 msgstr ""
 
 msgctxt "#32189"
-msgid "Identification"
+msgid "OS Configuration"
 msgstr ""
 
 msgctxt "#32190"

--- a/resources/language/resource.language.ar_sa/strings.po
+++ b/resources/language/resource.language.ar_sa/strings.po
@@ -86,6 +86,10 @@ msgctxt "#707"
 msgid "Configure updates"
 msgstr ""
 
+msgctxt "#709"
+msgid "Select the timezone for this device."
+msgstr ""
+
 msgctxt "#710"
 msgid "Configure the Hostname of your @DISTRONAME@ system. This will be used for the HTPC \\\\hostname in Windows and SMB server name in the Mac OS Finder"
 msgstr ""
@@ -1104,4 +1108,8 @@ msgstr ""
 
 msgctxt "#32419"
 msgid "Error sending log files. Please try again."
+msgstr ""
+
+msgctxt "#32420"
+msgid "Timezone"
 msgstr ""

--- a/resources/language/resource.language.ast_es/strings.po
+++ b/resources/language/resource.language.ast_es/strings.po
@@ -596,7 +596,7 @@ msgid "Current Version"
 msgstr "Versión actual"
 
 msgctxt "#32189"
-msgid "Identification"
+msgid "OS Configuration"
 msgstr "Identificación"
 
 msgctxt "#32190"

--- a/resources/language/resource.language.ast_es/strings.po
+++ b/resources/language/resource.language.ast_es/strings.po
@@ -91,6 +91,10 @@ msgctxt "#707"
 msgid "Configure updates"
 msgstr ""
 
+msgctxt "#709"
+msgid "Select the timezone for this device."
+msgstr ""
+
 msgctxt "#710"
 msgid "Configure the Hostname of your @DISTRONAME@ system. This will be used for the HTPC \\\\hostname in Windows and SMB server name in the Mac OS Finder"
 msgstr "Configura'l nome d'agospiu del to sistema d'@DISTRONAME@. Esto usaráse pal \\\\nome_agospiu del HTPC en Windows y el nome del sirvidor SMB nel Finder de MacOS"
@@ -1109,4 +1113,8 @@ msgstr ""
 
 msgctxt "#32419"
 msgid "Error sending log files. Please try again."
+msgstr ""
+
+msgctxt "#32420"
+msgid "Timezone"
 msgstr ""

--- a/resources/language/resource.language.az_az/strings.po
+++ b/resources/language/resource.language.az_az/strings.po
@@ -586,7 +586,7 @@ msgid "Current Version"
 msgstr ""
 
 msgctxt "#32189"
-msgid "Identification"
+msgid "OS Configuration"
 msgstr ""
 
 msgctxt "#32190"

--- a/resources/language/resource.language.az_az/strings.po
+++ b/resources/language/resource.language.az_az/strings.po
@@ -81,6 +81,10 @@ msgctxt "#707"
 msgid "Configure updates"
 msgstr ""
 
+msgctxt "#709"
+msgid "Select the timezone for this device."
+msgstr ""
+
 msgctxt "#710"
 msgid "Configure the Hostname of your @DISTRONAME@ system. This will be used for the HTPC \\\\hostname in Windows and SMB server name in the Mac OS Finder"
 msgstr ""
@@ -1099,4 +1103,8 @@ msgstr ""
 
 msgctxt "#32419"
 msgid "Error sending log files. Please try again."
+msgstr ""
+
+msgctxt "#32420"
+msgid "Timezone"
 msgstr ""

--- a/resources/language/resource.language.be_by/strings.po
+++ b/resources/language/resource.language.be_by/strings.po
@@ -586,7 +586,7 @@ msgid "Current Version"
 msgstr ""
 
 msgctxt "#32189"
-msgid "Identification"
+msgid "OS Configuration"
 msgstr ""
 
 msgctxt "#32190"

--- a/resources/language/resource.language.be_by/strings.po
+++ b/resources/language/resource.language.be_by/strings.po
@@ -81,6 +81,10 @@ msgctxt "#707"
 msgid "Configure updates"
 msgstr ""
 
+msgctxt "#709"
+msgid "Select the timezone for this device."
+msgstr ""
+
 msgctxt "#710"
 msgid "Configure the Hostname of your @DISTRONAME@ system. This will be used for the HTPC \\\\hostname in Windows and SMB server name in the Mac OS Finder"
 msgstr ""
@@ -1099,4 +1103,8 @@ msgstr ""
 
 msgctxt "#32419"
 msgid "Error sending log files. Please try again."
+msgstr ""
+
+msgctxt "#32420"
+msgid "Timezone"
 msgstr ""

--- a/resources/language/resource.language.bg_bg/strings.po
+++ b/resources/language/resource.language.bg_bg/strings.po
@@ -599,7 +599,7 @@ msgid "Current Version"
 msgstr "Текуща версия"
 
 msgctxt "#32189"
-msgid "Identification"
+msgid "OS Configuration"
 msgstr "Идентификация"
 
 msgctxt "#32190"

--- a/resources/language/resource.language.bg_bg/strings.po
+++ b/resources/language/resource.language.bg_bg/strings.po
@@ -90,6 +90,10 @@ msgctxt "#707"
 msgid "Configure updates"
 msgstr "Конфигуриране на актуализации"
 
+msgctxt "#709"
+msgid "Select the timezone for this device."
+msgstr ""
+
 msgctxt "#710"
 msgid "Configure the Hostname of your @DISTRONAME@ system. This will be used for the HTPC \\\\hostname in Windows and SMB server name in the Mac OS Finder"
 msgstr "Задайте име на устройството за Вашата @DISTRONAME@ система. Името ще се ползва в Windows и SMB мрежи (\\\\име–на–устройството), както и в Mac OS Finder"
@@ -1114,4 +1118,8 @@ msgstr ""
 
 msgctxt "#32419"
 msgid "Error sending log files. Please try again."
+msgstr ""
+
+msgctxt "#32420"
+msgid "Timezone"
 msgstr ""

--- a/resources/language/resource.language.bs_ba/strings.po
+++ b/resources/language/resource.language.bs_ba/strings.po
@@ -586,7 +586,7 @@ msgid "Current Version"
 msgstr ""
 
 msgctxt "#32189"
-msgid "Identification"
+msgid "OS Configuration"
 msgstr ""
 
 msgctxt "#32190"

--- a/resources/language/resource.language.bs_ba/strings.po
+++ b/resources/language/resource.language.bs_ba/strings.po
@@ -81,6 +81,10 @@ msgctxt "#707"
 msgid "Configure updates"
 msgstr ""
 
+msgctxt "#709"
+msgid "Select the timezone for this device."
+msgstr ""
+
 msgctxt "#710"
 msgid "Configure the Hostname of your @DISTRONAME@ system. This will be used for the HTPC \\\\hostname in Windows and SMB server name in the Mac OS Finder"
 msgstr ""
@@ -1099,4 +1103,8 @@ msgstr ""
 
 msgctxt "#32419"
 msgid "Error sending log files. Please try again."
+msgstr ""
+
+msgctxt "#32420"
+msgid "Timezone"
 msgstr ""

--- a/resources/language/resource.language.ca_es/strings.po
+++ b/resources/language/resource.language.ca_es/strings.po
@@ -595,7 +595,7 @@ msgid "Current Version"
 msgstr ""
 
 msgctxt "#32189"
-msgid "Identification"
+msgid "OS Configuration"
 msgstr ""
 
 msgctxt "#32190"

--- a/resources/language/resource.language.ca_es/strings.po
+++ b/resources/language/resource.language.ca_es/strings.po
@@ -86,6 +86,10 @@ msgctxt "#707"
 msgid "Configure updates"
 msgstr "Configura les actualitzacions"
 
+msgctxt "#709"
+msgid "Select the timezone for this device."
+msgstr ""
+
 msgctxt "#710"
 msgid "Configure the Hostname of your @DISTRONAME@ system. This will be used for the HTPC \\\\hostname in Windows and SMB server name in the Mac OS Finder"
 msgstr "Configura el Hostname del vostre sistema @DISTRONAME@. S'utilitzarà per a l'HTPC \\\\hostname a Windows i el nom del servidor SMB al Finder de Mac OS"
@@ -1108,4 +1112,8 @@ msgstr ""
 
 msgctxt "#32419"
 msgid "Error sending log files. Please try again."
+msgstr ""
+
+msgctxt "#32420"
+msgid "Timezone"
 msgstr ""

--- a/resources/language/resource.language.cs_cz/strings.po
+++ b/resources/language/resource.language.cs_cz/strings.po
@@ -609,7 +609,7 @@ msgid "Current Version"
 msgstr "Stávající verze"
 
 msgctxt "#32189"
-msgid "Identification"
+msgid "OS Configuration"
 msgstr "Identifikace"
 
 msgctxt "#32190"

--- a/resources/language/resource.language.cs_cz/strings.po
+++ b/resources/language/resource.language.cs_cz/strings.po
@@ -100,6 +100,10 @@ msgctxt "#707"
 msgid "Configure updates"
 msgstr "Konfigurace aktualizací"
 
+msgctxt "#709"
+msgid "Select the timezone for this device."
+msgstr ""
+
 msgctxt "#710"
 msgid "Configure the Hostname of your @DISTRONAME@ system. This will be used for the HTPC \\\\hostname in Windows and SMB server name in the Mac OS Finder"
 msgstr "Nastavení názvu systému @DISTRONAME@. Tento název bude použit v adresním řádku průzkumníku Windows a také jako název SMB serveru v Mac OS Finderu"
@@ -1122,4 +1126,8 @@ msgstr ""
 
 msgctxt "#32419"
 msgid "Error sending log files. Please try again."
+msgstr ""
+
+msgctxt "#32420"
+msgid "Timezone"
 msgstr ""

--- a/resources/language/resource.language.cy_gb/strings.po
+++ b/resources/language/resource.language.cy_gb/strings.po
@@ -586,7 +586,7 @@ msgid "Current Version"
 msgstr ""
 
 msgctxt "#32189"
-msgid "Identification"
+msgid "OS Configuration"
 msgstr ""
 
 msgctxt "#32190"

--- a/resources/language/resource.language.cy_gb/strings.po
+++ b/resources/language/resource.language.cy_gb/strings.po
@@ -81,6 +81,10 @@ msgctxt "#707"
 msgid "Configure updates"
 msgstr ""
 
+msgctxt "#709"
+msgid "Select the timezone for this device."
+msgstr ""
+
 msgctxt "#710"
 msgid "Configure the Hostname of your @DISTRONAME@ system. This will be used for the HTPC \\\\hostname in Windows and SMB server name in the Mac OS Finder"
 msgstr ""
@@ -1099,4 +1103,8 @@ msgstr ""
 
 msgctxt "#32419"
 msgid "Error sending log files. Please try again."
+msgstr ""
+
+msgctxt "#32420"
+msgid "Timezone"
 msgstr ""

--- a/resources/language/resource.language.da_dk/strings.po
+++ b/resources/language/resource.language.da_dk/strings.po
@@ -592,7 +592,7 @@ msgid "Current Version"
 msgstr ""
 
 msgctxt "#32189"
-msgid "Identification"
+msgid "OS Configuration"
 msgstr ""
 
 msgctxt "#32190"

--- a/resources/language/resource.language.da_dk/strings.po
+++ b/resources/language/resource.language.da_dk/strings.po
@@ -87,6 +87,10 @@ msgctxt "#707"
 msgid "Configure updates"
 msgstr "Konfigurer opdateringer"
 
+msgctxt "#709"
+msgid "Select the timezone for this device."
+msgstr ""
+
 msgctxt "#710"
 msgid "Configure the Hostname of your @DISTRONAME@ system. This will be used for the HTPC \\\\hostname in Windows and SMB server name in the Mac OS Finder"
 msgstr "Konfigurer værtsnavnet på dit @DISTRONAME@-system. Dette vil blive brugt til HTPC \\\\værtsnavnet i Windows og SMB-servernavnet i Mac OS Finder"
@@ -1105,4 +1109,8 @@ msgstr ""
 
 msgctxt "#32419"
 msgid "Error sending log files. Please try again."
+msgstr ""
+
+msgctxt "#32420"
+msgid "Timezone"
 msgstr ""

--- a/resources/language/resource.language.de_de/strings.po
+++ b/resources/language/resource.language.de_de/strings.po
@@ -95,6 +95,10 @@ msgctxt "#707"
 msgid "Configure updates"
 msgstr "Aktualisierungen konfigurieren"
 
+msgctxt "#709"
+msgid "Select the timezone for this device."
+msgstr ""
+
 msgctxt "#710"
 msgid "Configure the Hostname of your @DISTRONAME@ system. This will be used for the HTPC \\\\hostname in Windows and SMB server name in the Mac OS Finder"
 msgstr "Den Hostnamen des @DISTRONAME@-Systems konfigurieren. Dieser wird für den HTPC \\\\\\\\Hostnamen in Windows und für den SMB-Servernamen im macOS Finder verwendet werden"
@@ -1117,4 +1121,8 @@ msgstr ""
 
 msgctxt "#32419"
 msgid "Error sending log files. Please try again."
+msgstr ""
+
+msgctxt "#32420"
+msgid "Timezone"
 msgstr ""

--- a/resources/language/resource.language.de_de/strings.po
+++ b/resources/language/resource.language.de_de/strings.po
@@ -604,7 +604,7 @@ msgid "Current Version"
 msgstr "Aktuelle Version"
 
 msgctxt "#32189"
-msgid "Identification"
+msgid "OS Configuration"
 msgstr "Identifikation"
 
 msgctxt "#32190"

--- a/resources/language/resource.language.el_gr/strings.po
+++ b/resources/language/resource.language.el_gr/strings.po
@@ -87,6 +87,10 @@ msgctxt "#707"
 msgid "Configure updates"
 msgstr "Ρύθμιση ενημερώσεων"
 
+msgctxt "#709"
+msgid "Select the timezone for this device."
+msgstr ""
+
 msgctxt "#710"
 msgid "Configure the Hostname of your @DISTRONAME@ system. This will be used for the HTPC \\\\hostname in Windows and SMB server name in the Mac OS Finder"
 msgstr ""
@@ -1109,4 +1113,8 @@ msgstr ""
 
 msgctxt "#32419"
 msgid "Error sending log files. Please try again."
+msgstr ""
+
+msgctxt "#32420"
+msgid "Timezone"
 msgstr ""

--- a/resources/language/resource.language.el_gr/strings.po
+++ b/resources/language/resource.language.el_gr/strings.po
@@ -596,7 +596,7 @@ msgid "Current Version"
 msgstr ""
 
 msgctxt "#32189"
-msgid "Identification"
+msgid "OS Configuration"
 msgstr ""
 
 msgctxt "#32190"

--- a/resources/language/resource.language.en_au/strings.po
+++ b/resources/language/resource.language.en_au/strings.po
@@ -594,7 +594,7 @@ msgid "Current Version"
 msgstr ""
 
 msgctxt "#32189"
-msgid "Identification"
+msgid "OS Configuration"
 msgstr ""
 
 msgctxt "#32190"

--- a/resources/language/resource.language.en_au/strings.po
+++ b/resources/language/resource.language.en_au/strings.po
@@ -89,6 +89,10 @@ msgctxt "#707"
 msgid "Configure updates"
 msgstr ""
 
+msgctxt "#709"
+msgid "Select the timezone for this device."
+msgstr ""
+
 msgctxt "#710"
 msgid "Configure the Hostname of your @DISTRONAME@ system. This will be used for the HTPC \\\\hostname in Windows and SMB server name in the Mac OS Finder"
 msgstr ""
@@ -1107,4 +1111,8 @@ msgstr ""
 
 msgctxt "#32419"
 msgid "Error sending log files. Please try again."
+msgstr ""
+
+msgctxt "#32420"
+msgid "Timezone"
 msgstr ""

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -581,7 +581,7 @@ msgid "Current Version"
 msgstr ""
 
 msgctxt "#32189"
-msgid "Identification"
+msgid "OS Configuration"
 msgstr ""
 
 msgctxt "#32190"

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -80,6 +80,10 @@ msgctxt "#707"
 msgid "Configure updates"
 msgstr ""
 
+msgctxt "#709"
+msgid "Select the timezone for this device."
+msgstr ""
+
 msgctxt "#710"
 msgid "Configure the Hostname of your @DISTRONAME@ system. This will be used for the HTPC \\\\hostname in Windows and SMB server name in the Mac OS Finder"
 msgstr ""
@@ -1094,4 +1098,8 @@ msgstr ""
 
 msgctxt "#32419"
 msgid "Error sending log files. Please try again."
+msgstr ""
+
+msgctxt "#32420"
+msgid "Timezone"
 msgstr ""

--- a/resources/language/resource.language.en_nz/strings.po
+++ b/resources/language/resource.language.en_nz/strings.po
@@ -594,7 +594,7 @@ msgid "Current Version"
 msgstr ""
 
 msgctxt "#32189"
-msgid "Identification"
+msgid "OS Configuration"
 msgstr ""
 
 msgctxt "#32190"

--- a/resources/language/resource.language.en_nz/strings.po
+++ b/resources/language/resource.language.en_nz/strings.po
@@ -89,6 +89,10 @@ msgctxt "#707"
 msgid "Configure updates"
 msgstr ""
 
+msgctxt "#709"
+msgid "Select the timezone for this device."
+msgstr ""
+
 msgctxt "#710"
 msgid "Configure the Hostname of your @DISTRONAME@ system. This will be used for the HTPC \\\\hostname in Windows and SMB server name in the Mac OS Finder"
 msgstr ""
@@ -1107,4 +1111,8 @@ msgstr ""
 
 msgctxt "#32419"
 msgid "Error sending log files. Please try again."
+msgstr ""
+
+msgctxt "#32420"
+msgid "Timezone"
 msgstr ""

--- a/resources/language/resource.language.en_us/strings.po
+++ b/resources/language/resource.language.en_us/strings.po
@@ -594,7 +594,7 @@ msgid "Current Version"
 msgstr ""
 
 msgctxt "#32189"
-msgid "Identification"
+msgid "OS Configuration"
 msgstr ""
 
 msgctxt "#32190"

--- a/resources/language/resource.language.en_us/strings.po
+++ b/resources/language/resource.language.en_us/strings.po
@@ -89,6 +89,10 @@ msgctxt "#707"
 msgid "Configure updates"
 msgstr ""
 
+msgctxt "#709"
+msgid "Select the timezone for this device."
+msgstr ""
+
 msgctxt "#710"
 msgid "Configure the Hostname of your @DISTRONAME@ system. This will be used for the HTPC \\\\hostname in Windows and SMB server name in the Mac OS Finder"
 msgstr ""
@@ -1107,4 +1111,8 @@ msgstr ""
 
 msgctxt "#32419"
 msgid "Error sending log files. Please try again."
+msgstr ""
+
+msgctxt "#32420"
+msgid "Timezone"
 msgstr ""

--- a/resources/language/resource.language.eo/strings.po
+++ b/resources/language/resource.language.eo/strings.po
@@ -586,7 +586,7 @@ msgid "Current Version"
 msgstr ""
 
 msgctxt "#32189"
-msgid "Identification"
+msgid "OS Configuration"
 msgstr ""
 
 msgctxt "#32190"

--- a/resources/language/resource.language.eo/strings.po
+++ b/resources/language/resource.language.eo/strings.po
@@ -81,6 +81,10 @@ msgctxt "#707"
 msgid "Configure updates"
 msgstr ""
 
+msgctxt "#709"
+msgid "Select the timezone for this device."
+msgstr ""
+
 msgctxt "#710"
 msgid "Configure the Hostname of your @DISTRONAME@ system. This will be used for the HTPC \\\\hostname in Windows and SMB server name in the Mac OS Finder"
 msgstr ""
@@ -1099,4 +1103,8 @@ msgstr ""
 
 msgctxt "#32419"
 msgid "Error sending log files. Please try again."
+msgstr ""
+
+msgctxt "#32420"
+msgid "Timezone"
 msgstr ""

--- a/resources/language/resource.language.es_ar/strings.po
+++ b/resources/language/resource.language.es_ar/strings.po
@@ -599,7 +599,7 @@ msgid "Current Version"
 msgstr ""
 
 msgctxt "#32189"
-msgid "Identification"
+msgid "OS Configuration"
 msgstr ""
 
 msgctxt "#32190"

--- a/resources/language/resource.language.es_ar/strings.po
+++ b/resources/language/resource.language.es_ar/strings.po
@@ -94,6 +94,10 @@ msgctxt "#707"
 msgid "Configure updates"
 msgstr ""
 
+msgctxt "#709"
+msgid "Select the timezone for this device."
+msgstr ""
+
 msgctxt "#710"
 msgid "Configure the Hostname of your @DISTRONAME@ system. This will be used for the HTPC \\\\hostname in Windows and SMB server name in the Mac OS Finder"
 msgstr ""
@@ -1112,4 +1116,8 @@ msgstr ""
 
 msgctxt "#32419"
 msgid "Error sending log files. Please try again."
+msgstr ""
+
+msgctxt "#32420"
+msgid "Timezone"
 msgstr ""

--- a/resources/language/resource.language.es_es/strings.po
+++ b/resources/language/resource.language.es_es/strings.po
@@ -98,6 +98,10 @@ msgctxt "#707"
 msgid "Configure updates"
 msgstr "Configurar actualizaciones"
 
+msgctxt "#709"
+msgid "Select the timezone for this device."
+msgstr ""
+
 msgctxt "#710"
 msgid "Configure the Hostname of your @DISTRONAME@ system. This will be used for the HTPC \\\\hostname in Windows and SMB server name in the Mac OS Finder"
 msgstr "Configura el nombre de host de tu sistema @DISTRONAME@. Este será utilizado para el \\\\hostname del HTPC en Windows y el nombre del servidor SMB en el Finder de Mac OS"
@@ -1120,4 +1124,8 @@ msgstr ""
 
 msgctxt "#32419"
 msgid "Error sending log files. Please try again."
+msgstr ""
+
+msgctxt "#32420"
+msgid "Timezone"
 msgstr ""

--- a/resources/language/resource.language.es_es/strings.po
+++ b/resources/language/resource.language.es_es/strings.po
@@ -607,7 +607,7 @@ msgid "Current Version"
 msgstr "Versión actual"
 
 msgctxt "#32189"
-msgid "Identification"
+msgid "OS Configuration"
 msgstr "Identificación"
 
 msgctxt "#32190"

--- a/resources/language/resource.language.es_mx/strings.po
+++ b/resources/language/resource.language.es_mx/strings.po
@@ -94,6 +94,10 @@ msgctxt "#707"
 msgid "Configure updates"
 msgstr "Configurar actualizaciones"
 
+msgctxt "#709"
+msgid "Select the timezone for this device."
+msgstr ""
+
 msgctxt "#710"
 msgid "Configure the Hostname of your @DISTRONAME@ system. This will be used for the HTPC \\\\hostname in Windows and SMB server name in the Mac OS Finder"
 msgstr "Configura el nombre de host de tu sistema @DISTRONAME@. Este mismo será utilizado para el \\\\hostname del HTPC en Windows y para el nombre del servidor SMB en el Finder de Mac OS"
@@ -1116,4 +1120,8 @@ msgstr ""
 
 msgctxt "#32419"
 msgid "Error sending log files. Please try again."
+msgstr ""
+
+msgctxt "#32420"
+msgid "Timezone"
 msgstr ""

--- a/resources/language/resource.language.es_mx/strings.po
+++ b/resources/language/resource.language.es_mx/strings.po
@@ -603,7 +603,7 @@ msgid "Current Version"
 msgstr "Versión actual"
 
 msgctxt "#32189"
-msgid "Identification"
+msgid "OS Configuration"
 msgstr "Identificación"
 
 msgctxt "#32190"

--- a/resources/language/resource.language.et_ee/strings.po
+++ b/resources/language/resource.language.et_ee/strings.po
@@ -586,7 +586,7 @@ msgid "Current Version"
 msgstr ""
 
 msgctxt "#32189"
-msgid "Identification"
+msgid "OS Configuration"
 msgstr ""
 
 msgctxt "#32190"

--- a/resources/language/resource.language.et_ee/strings.po
+++ b/resources/language/resource.language.et_ee/strings.po
@@ -81,6 +81,10 @@ msgctxt "#707"
 msgid "Configure updates"
 msgstr ""
 
+msgctxt "#709"
+msgid "Select the timezone for this device."
+msgstr ""
+
 msgctxt "#710"
 msgid "Configure the Hostname of your @DISTRONAME@ system. This will be used for the HTPC \\\\hostname in Windows and SMB server name in the Mac OS Finder"
 msgstr ""
@@ -1099,4 +1103,8 @@ msgstr ""
 
 msgctxt "#32419"
 msgid "Error sending log files. Please try again."
+msgstr ""
+
+msgctxt "#32420"
+msgid "Timezone"
 msgstr ""

--- a/resources/language/resource.language.eu_es/strings.po
+++ b/resources/language/resource.language.eu_es/strings.po
@@ -599,7 +599,7 @@ msgid "Current Version"
 msgstr "Oraingo bertsioa"
 
 msgctxt "#32189"
-msgid "Identification"
+msgid "OS Configuration"
 msgstr "Identifikazioa"
 
 msgctxt "#32190"

--- a/resources/language/resource.language.eu_es/strings.po
+++ b/resources/language/resource.language.eu_es/strings.po
@@ -90,6 +90,10 @@ msgctxt "#707"
 msgid "Configure updates"
 msgstr ""
 
+msgctxt "#709"
+msgid "Select the timezone for this device."
+msgstr ""
+
 msgctxt "#710"
 msgid "Configure the Hostname of your @DISTRONAME@ system. This will be used for the HTPC \\\\hostname in Windows and SMB server name in the Mac OS Finder"
 msgstr "Konfiguratu Ostalari-izena zure @DISTRONAME@ sisteman. Ezarpen hau izango da zure HTPCaren \\\\ostalariizena Windows-en eta zerbitzariaren izena SMB eta Mac OS Finder-en."
@@ -1112,4 +1116,8 @@ msgstr ""
 
 msgctxt "#32419"
 msgid "Error sending log files. Please try again."
+msgstr ""
+
+msgctxt "#32420"
+msgid "Timezone"
 msgstr ""

--- a/resources/language/resource.language.fa_af/strings.po
+++ b/resources/language/resource.language.fa_af/strings.po
@@ -586,7 +586,7 @@ msgid "Current Version"
 msgstr ""
 
 msgctxt "#32189"
-msgid "Identification"
+msgid "OS Configuration"
 msgstr ""
 
 msgctxt "#32190"

--- a/resources/language/resource.language.fa_af/strings.po
+++ b/resources/language/resource.language.fa_af/strings.po
@@ -81,6 +81,10 @@ msgctxt "#707"
 msgid "Configure updates"
 msgstr ""
 
+msgctxt "#709"
+msgid "Select the timezone for this device."
+msgstr ""
+
 msgctxt "#710"
 msgid "Configure the Hostname of your @DISTRONAME@ system. This will be used for the HTPC \\\\hostname in Windows and SMB server name in the Mac OS Finder"
 msgstr ""
@@ -1099,4 +1103,8 @@ msgstr ""
 
 msgctxt "#32419"
 msgid "Error sending log files. Please try again."
+msgstr ""
+
+msgctxt "#32420"
+msgid "Timezone"
 msgstr ""

--- a/resources/language/resource.language.fa_ir/strings.po
+++ b/resources/language/resource.language.fa_ir/strings.po
@@ -586,7 +586,7 @@ msgid "Current Version"
 msgstr ""
 
 msgctxt "#32189"
-msgid "Identification"
+msgid "OS Configuration"
 msgstr ""
 
 msgctxt "#32190"

--- a/resources/language/resource.language.fa_ir/strings.po
+++ b/resources/language/resource.language.fa_ir/strings.po
@@ -81,6 +81,10 @@ msgctxt "#707"
 msgid "Configure updates"
 msgstr ""
 
+msgctxt "#709"
+msgid "Select the timezone for this device."
+msgstr ""
+
 msgctxt "#710"
 msgid "Configure the Hostname of your @DISTRONAME@ system. This will be used for the HTPC \\\\hostname in Windows and SMB server name in the Mac OS Finder"
 msgstr ""
@@ -1099,4 +1103,8 @@ msgstr ""
 
 msgctxt "#32419"
 msgid "Error sending log files. Please try again."
+msgstr ""
+
+msgctxt "#32420"
+msgid "Timezone"
 msgstr ""

--- a/resources/language/resource.language.fi_fi/strings.po
+++ b/resources/language/resource.language.fi_fi/strings.po
@@ -602,7 +602,7 @@ msgid "Current Version"
 msgstr "Nykyinen versio"
 
 msgctxt "#32189"
-msgid "Identification"
+msgid "OS Configuration"
 msgstr "Tunniste"
 
 msgctxt "#32190"

--- a/resources/language/resource.language.fi_fi/strings.po
+++ b/resources/language/resource.language.fi_fi/strings.po
@@ -93,6 +93,10 @@ msgctxt "#707"
 msgid "Configure updates"
 msgstr "Määritä päivitysasetukset"
 
+msgctxt "#709"
+msgid "Select the timezone for this device."
+msgstr ""
+
 msgctxt "#710"
 msgid "Configure the Hostname of your @DISTRONAME@ system. This will be used for the HTPC \\\\hostname in Windows and SMB server name in the Mac OS Finder"
 msgstr "Määritä @DISTRONAME@-järjestelmäsi isäntänimi. Tätä toimii Windows-laitteissa tämän laitteen \\\\isäntänimenä ja macOS-laitteiden Finder-sovelluksessa SMB-palvelimen nimenä."
@@ -1115,4 +1119,8 @@ msgstr ""
 
 msgctxt "#32419"
 msgid "Error sending log files. Please try again."
+msgstr ""
+
+msgctxt "#32420"
+msgid "Timezone"
 msgstr ""

--- a/resources/language/resource.language.fo_fo/strings.po
+++ b/resources/language/resource.language.fo_fo/strings.po
@@ -586,7 +586,7 @@ msgid "Current Version"
 msgstr ""
 
 msgctxt "#32189"
-msgid "Identification"
+msgid "OS Configuration"
 msgstr ""
 
 msgctxt "#32190"

--- a/resources/language/resource.language.fo_fo/strings.po
+++ b/resources/language/resource.language.fo_fo/strings.po
@@ -81,6 +81,10 @@ msgctxt "#707"
 msgid "Configure updates"
 msgstr ""
 
+msgctxt "#709"
+msgid "Select the timezone for this device."
+msgstr ""
+
 msgctxt "#710"
 msgid "Configure the Hostname of your @DISTRONAME@ system. This will be used for the HTPC \\\\hostname in Windows and SMB server name in the Mac OS Finder"
 msgstr ""
@@ -1099,4 +1103,8 @@ msgstr ""
 
 msgctxt "#32419"
 msgid "Error sending log files. Please try again."
+msgstr ""
+
+msgctxt "#32420"
+msgid "Timezone"
 msgstr ""

--- a/resources/language/resource.language.fr_ca/strings.po
+++ b/resources/language/resource.language.fr_ca/strings.po
@@ -614,8 +614,8 @@ msgid "Current Version"
 msgstr "Version actuelle"
 
 msgctxt "#32189"
-msgid "Identification"
-msgstr "Identification"
+msgid "OS Configuration"
+msgstr ""
 
 msgctxt "#32190"
 msgid "System Name"

--- a/resources/language/resource.language.fr_ca/strings.po
+++ b/resources/language/resource.language.fr_ca/strings.po
@@ -105,6 +105,10 @@ msgctxt "#707"
 msgid "Configure updates"
 msgstr "Configurer les mises à jour"
 
+msgctxt "#709"
+msgid "Select the timezone for this device."
+msgstr ""
+
 msgctxt "#710"
 msgid "Configure the Hostname of your @DISTRONAME@ system. This will be used for the HTPC \\\\hostname in Windows and SMB server name in the Mac OS Finder"
 msgstr "Configuration du nom d'hôte de votre système @DISTRONAME@. Utilisé pour atteindre le HTPC par \\\\hostname dans Windows et nom du serveur SMB dans le Finder Mac OS"
@@ -1127,4 +1131,8 @@ msgstr ""
 
 msgctxt "#32419"
 msgid "Error sending log files. Please try again."
+msgstr ""
+
+msgctxt "#32420"
+msgid "Timezone"
 msgstr ""

--- a/resources/language/resource.language.fr_fr/strings.po
+++ b/resources/language/resource.language.fr_fr/strings.po
@@ -609,8 +609,8 @@ msgid "Current Version"
 msgstr "Version actuelle"
 
 msgctxt "#32189"
-msgid "Identification"
-msgstr "Identification"
+msgid "OS Configuration"
+msgstr ""
 
 msgctxt "#32190"
 msgid "System Name"

--- a/resources/language/resource.language.fr_fr/strings.po
+++ b/resources/language/resource.language.fr_fr/strings.po
@@ -100,6 +100,10 @@ msgctxt "#707"
 msgid "Configure updates"
 msgstr "Configurer les mises à jour"
 
+msgctxt "#709"
+msgid "Select the timezone for this device."
+msgstr ""
+
 msgctxt "#710"
 msgid "Configure the Hostname of your @DISTRONAME@ system. This will be used for the HTPC \\\\hostname in Windows and SMB server name in the Mac OS Finder"
 msgstr "Configuration du nom d'hôte de votre système @DISTRONAME@. Utilisé pour atteindre le HTPC par \\\\hostname dans Windows et nom du serveur SMB dans le Finder Mac OS"
@@ -1122,4 +1126,8 @@ msgstr ""
 
 msgctxt "#32419"
 msgid "Error sending log files. Please try again."
+msgstr ""
+
+msgctxt "#32420"
+msgid "Timezone"
 msgstr ""

--- a/resources/language/resource.language.gl_es/strings.po
+++ b/resources/language/resource.language.gl_es/strings.po
@@ -86,6 +86,10 @@ msgctxt "#707"
 msgid "Configure updates"
 msgstr "Configurar actualizacións"
 
+msgctxt "#709"
+msgid "Select the timezone for this device."
+msgstr ""
+
 msgctxt "#710"
 msgid "Configure the Hostname of your @DISTRONAME@ system. This will be used for the HTPC \\\\hostname in Windows and SMB server name in the Mac OS Finder"
 msgstr "Configurar o Hostname da túa @DISTRONAME@ do sistema. Isto empregarase para o HTPC \\\\hostname en Windows e o nome do servidor SMB no Finder de macOS"
@@ -1104,4 +1108,8 @@ msgstr ""
 
 msgctxt "#32419"
 msgid "Error sending log files. Please try again."
+msgstr ""
+
+msgctxt "#32420"
+msgid "Timezone"
 msgstr ""

--- a/resources/language/resource.language.gl_es/strings.po
+++ b/resources/language/resource.language.gl_es/strings.po
@@ -591,7 +591,7 @@ msgid "Current Version"
 msgstr ""
 
 msgctxt "#32189"
-msgid "Identification"
+msgid "OS Configuration"
 msgstr ""
 
 msgctxt "#32190"

--- a/resources/language/resource.language.he_il/strings.po
+++ b/resources/language/resource.language.he_il/strings.po
@@ -88,6 +88,10 @@ msgctxt "#707"
 msgid "Configure updates"
 msgstr ""
 
+msgctxt "#709"
+msgid "Select the timezone for this device."
+msgstr ""
+
 msgctxt "#710"
 msgid "Configure the Hostname of your @DISTRONAME@ system. This will be used for the HTPC \\\\hostname in Windows and SMB server name in the Mac OS Finder"
 msgstr ""
@@ -1106,4 +1110,8 @@ msgstr ""
 
 msgctxt "#32419"
 msgid "Error sending log files. Please try again."
+msgstr ""
+
+msgctxt "#32420"
+msgid "Timezone"
 msgstr ""

--- a/resources/language/resource.language.he_il/strings.po
+++ b/resources/language/resource.language.he_il/strings.po
@@ -593,7 +593,7 @@ msgid "Current Version"
 msgstr ""
 
 msgctxt "#32189"
-msgid "Identification"
+msgid "OS Configuration"
 msgstr ""
 
 msgctxt "#32190"

--- a/resources/language/resource.language.hi_in/strings.po
+++ b/resources/language/resource.language.hi_in/strings.po
@@ -586,7 +586,7 @@ msgid "Current Version"
 msgstr ""
 
 msgctxt "#32189"
-msgid "Identification"
+msgid "OS Configuration"
 msgstr ""
 
 msgctxt "#32190"

--- a/resources/language/resource.language.hi_in/strings.po
+++ b/resources/language/resource.language.hi_in/strings.po
@@ -81,6 +81,10 @@ msgctxt "#707"
 msgid "Configure updates"
 msgstr ""
 
+msgctxt "#709"
+msgid "Select the timezone for this device."
+msgstr ""
+
 msgctxt "#710"
 msgid "Configure the Hostname of your @DISTRONAME@ system. This will be used for the HTPC \\\\hostname in Windows and SMB server name in the Mac OS Finder"
 msgstr ""
@@ -1099,4 +1103,8 @@ msgstr ""
 
 msgctxt "#32419"
 msgid "Error sending log files. Please try again."
+msgstr ""
+
+msgctxt "#32420"
+msgid "Timezone"
 msgstr ""

--- a/resources/language/resource.language.hr_hr/strings.po
+++ b/resources/language/resource.language.hr_hr/strings.po
@@ -87,6 +87,10 @@ msgctxt "#707"
 msgid "Configure updates"
 msgstr "Podesi nadopune"
 
+msgctxt "#709"
+msgid "Select the timezone for this device."
+msgstr ""
+
 msgctxt "#710"
 msgid "Configure the Hostname of your @DISTRONAME@ system. This will be used for the HTPC \\\\hostname in Windows and SMB server name in the Mac OS Finder"
 msgstr ""
@@ -1111,4 +1115,8 @@ msgstr ""
 
 msgctxt "#32419"
 msgid "Error sending log files. Please try again."
+msgstr ""
+
+msgctxt "#32420"
+msgid "Timezone"
 msgstr ""

--- a/resources/language/resource.language.hr_hr/strings.po
+++ b/resources/language/resource.language.hr_hr/strings.po
@@ -598,7 +598,7 @@ msgid "Current Version"
 msgstr "Trenutna inačica"
 
 msgctxt "#32189"
-msgid "Identification"
+msgid "OS Configuration"
 msgstr "Identifikacija"
 
 msgctxt "#32190"

--- a/resources/language/resource.language.hu_hu/strings.po
+++ b/resources/language/resource.language.hu_hu/strings.po
@@ -96,6 +96,10 @@ msgctxt "#707"
 msgid "Configure updates"
 msgstr "Frissítések beállításai"
 
+msgctxt "#709"
+msgid "Select the timezone for this device."
+msgstr ""
+
 msgctxt "#710"
 msgid "Configure the Hostname of your @DISTRONAME@ system. This will be used for the HTPC \\\\hostname in Windows and SMB server name in the Mac OS Finder"
 msgstr "A(z) @DISTRONAME@ rendszeredhez tartozó hoszt nevének beállítása. A HTPC így lesz elérhető Windows alatt: \\\\hosztnév, valamint macOS Finder-en keresztül SMB szerverként"
@@ -1118,4 +1122,8 @@ msgstr ""
 
 msgctxt "#32419"
 msgid "Error sending log files. Please try again."
+msgstr ""
+
+msgctxt "#32420"
+msgid "Timezone"
 msgstr ""

--- a/resources/language/resource.language.hu_hu/strings.po
+++ b/resources/language/resource.language.hu_hu/strings.po
@@ -605,7 +605,7 @@ msgid "Current Version"
 msgstr "Jelenlegi verzió"
 
 msgctxt "#32189"
-msgid "Identification"
+msgid "OS Configuration"
 msgstr "Azonosítás"
 
 msgctxt "#32190"

--- a/resources/language/resource.language.hy_am/strings.po
+++ b/resources/language/resource.language.hy_am/strings.po
@@ -586,7 +586,7 @@ msgid "Current Version"
 msgstr ""
 
 msgctxt "#32189"
-msgid "Identification"
+msgid "OS Configuration"
 msgstr ""
 
 msgctxt "#32190"

--- a/resources/language/resource.language.hy_am/strings.po
+++ b/resources/language/resource.language.hy_am/strings.po
@@ -81,6 +81,10 @@ msgctxt "#707"
 msgid "Configure updates"
 msgstr ""
 
+msgctxt "#709"
+msgid "Select the timezone for this device."
+msgstr ""
+
 msgctxt "#710"
 msgid "Configure the Hostname of your @DISTRONAME@ system. This will be used for the HTPC \\\\hostname in Windows and SMB server name in the Mac OS Finder"
 msgstr ""
@@ -1099,4 +1103,8 @@ msgstr ""
 
 msgctxt "#32419"
 msgid "Error sending log files. Please try again."
+msgstr ""
+
+msgctxt "#32420"
+msgid "Timezone"
 msgstr ""

--- a/resources/language/resource.language.id_id/strings.po
+++ b/resources/language/resource.language.id_id/strings.po
@@ -591,7 +591,7 @@ msgid "Current Version"
 msgstr ""
 
 msgctxt "#32189"
-msgid "Identification"
+msgid "OS Configuration"
 msgstr ""
 
 msgctxt "#32190"

--- a/resources/language/resource.language.id_id/strings.po
+++ b/resources/language/resource.language.id_id/strings.po
@@ -86,6 +86,10 @@ msgctxt "#707"
 msgid "Configure updates"
 msgstr "Konfigurasi pembaruan"
 
+msgctxt "#709"
+msgid "Select the timezone for this device."
+msgstr ""
+
 msgctxt "#710"
 msgid "Configure the Hostname of your @DISTRONAME@ system. This will be used for the HTPC \\\\hostname in Windows and SMB server name in the Mac OS Finder"
 msgstr ""
@@ -1104,4 +1108,8 @@ msgstr ""
 
 msgctxt "#32419"
 msgid "Error sending log files. Please try again."
+msgstr ""
+
+msgctxt "#32420"
+msgid "Timezone"
 msgstr ""

--- a/resources/language/resource.language.is_is/strings.po
+++ b/resources/language/resource.language.is_is/strings.po
@@ -586,7 +586,7 @@ msgid "Current Version"
 msgstr ""
 
 msgctxt "#32189"
-msgid "Identification"
+msgid "OS Configuration"
 msgstr ""
 
 msgctxt "#32190"

--- a/resources/language/resource.language.is_is/strings.po
+++ b/resources/language/resource.language.is_is/strings.po
@@ -81,6 +81,10 @@ msgctxt "#707"
 msgid "Configure updates"
 msgstr ""
 
+msgctxt "#709"
+msgid "Select the timezone for this device."
+msgstr ""
+
 msgctxt "#710"
 msgid "Configure the Hostname of your @DISTRONAME@ system. This will be used for the HTPC \\\\hostname in Windows and SMB server name in the Mac OS Finder"
 msgstr ""
@@ -1099,4 +1103,8 @@ msgstr ""
 
 msgctxt "#32419"
 msgid "Error sending log files. Please try again."
+msgstr ""
+
+msgctxt "#32420"
+msgid "Timezone"
 msgstr ""

--- a/resources/language/resource.language.it_it/strings.po
+++ b/resources/language/resource.language.it_it/strings.po
@@ -602,7 +602,7 @@ msgid "Current Version"
 msgstr "Versione attuale"
 
 msgctxt "#32189"
-msgid "Identification"
+msgid "OS Configuration"
 msgstr "Identificazione"
 
 msgctxt "#32190"

--- a/resources/language/resource.language.it_it/strings.po
+++ b/resources/language/resource.language.it_it/strings.po
@@ -93,6 +93,10 @@ msgctxt "#707"
 msgid "Configure updates"
 msgstr "Configura gli aggiornamenti"
 
+msgctxt "#709"
+msgid "Select the timezone for this device."
+msgstr ""
+
 msgctxt "#710"
 msgid "Configure the Hostname of your @DISTRONAME@ system. This will be used for the HTPC \\\\hostname in Windows and SMB server name in the Mac OS Finder"
 msgstr "Configura il nome host del tuo sistema @DISTRONAME@. Verrà utilizzato per HTPC \\\\hostname in Windows e per il nome del server SMB nel Finder di MacOS"
@@ -1115,4 +1119,8 @@ msgstr ""
 
 msgctxt "#32419"
 msgid "Error sending log files. Please try again."
+msgstr ""
+
+msgctxt "#32420"
+msgid "Timezone"
 msgstr ""

--- a/resources/language/resource.language.ja_jp/strings.po
+++ b/resources/language/resource.language.ja_jp/strings.po
@@ -91,6 +91,10 @@ msgctxt "#707"
 msgid "Configure updates"
 msgstr "アップデートを設定する"
 
+msgctxt "#709"
+msgid "Select the timezone for this device."
+msgstr ""
+
 msgctxt "#710"
 msgid "Configure the Hostname of your @DISTRONAME@ system. This will be used for the HTPC \\\\hostname in Windows and SMB server name in the Mac OS Finder"
 msgstr "@DISTRONAME@ システムのホスト名を設定します。これは、WindowsでのHTPCの\\\\hostnameと、Mac OS FinderでのSMBサーバ名に使われます"
@@ -1113,4 +1117,8 @@ msgstr ""
 
 msgctxt "#32419"
 msgid "Error sending log files. Please try again."
+msgstr ""
+
+msgctxt "#32420"
+msgid "Timezone"
 msgstr ""

--- a/resources/language/resource.language.ja_jp/strings.po
+++ b/resources/language/resource.language.ja_jp/strings.po
@@ -600,7 +600,7 @@ msgid "Current Version"
 msgstr "現バージョン"
 
 msgctxt "#32189"
-msgid "Identification"
+msgid "OS Configuration"
 msgstr "証明書"
 
 msgctxt "#32190"

--- a/resources/language/resource.language.kn_in/strings.po
+++ b/resources/language/resource.language.kn_in/strings.po
@@ -582,7 +582,7 @@ msgid "Current Version"
 msgstr ""
 
 msgctxt "#32189"
-msgid "Identification"
+msgid "OS Configuration"
 msgstr ""
 
 msgctxt "#32190"

--- a/resources/language/resource.language.kn_in/strings.po
+++ b/resources/language/resource.language.kn_in/strings.po
@@ -81,6 +81,10 @@ msgctxt "#707"
 msgid "Configure updates"
 msgstr ""
 
+msgctxt "#709"
+msgid "Select the timezone for this device."
+msgstr ""
+
 msgctxt "#710"
 msgid "Configure the Hostname of your @DISTRONAME@ system. This will be used for the HTPC \\\\hostname in Windows and SMB server name in the Mac OS Finder"
 msgstr ""
@@ -1095,4 +1099,8 @@ msgstr ""
 
 msgctxt "#32419"
 msgid "Error sending log files. Please try again."
+msgstr ""
+
+msgctxt "#32420"
+msgid "Timezone"
 msgstr ""

--- a/resources/language/resource.language.ko_kr/strings.po
+++ b/resources/language/resource.language.ko_kr/strings.po
@@ -93,6 +93,10 @@ msgctxt "#707"
 msgid "Configure updates"
 msgstr "업데이트 설정"
 
+msgctxt "#709"
+msgid "Select the timezone for this device."
+msgstr ""
+
 msgctxt "#710"
 msgid "Configure the Hostname of your @DISTRONAME@ system. This will be used for the HTPC \\\\hostname in Windows and SMB server name in the Mac OS Finder"
 msgstr "사용자의 @DISTRONAME@ 시스템의 호스트이름을 설정합니다. 이것은 윈도의 HTPC \\\\호스트이름 그리고 맥 OS 파인더의 SMB 서버명에 쓰입니다"
@@ -1115,4 +1119,8 @@ msgstr ""
 
 msgctxt "#32419"
 msgid "Error sending log files. Please try again."
+msgstr ""
+
+msgctxt "#32420"
+msgid "Timezone"
 msgstr ""

--- a/resources/language/resource.language.ko_kr/strings.po
+++ b/resources/language/resource.language.ko_kr/strings.po
@@ -602,7 +602,7 @@ msgid "Current Version"
 msgstr "현재 버전"
 
 msgctxt "#32189"
-msgid "Identification"
+msgid "OS Configuration"
 msgstr "확인"
 
 msgctxt "#32190"

--- a/resources/language/resource.language.lt_lt/strings.po
+++ b/resources/language/resource.language.lt_lt/strings.po
@@ -93,6 +93,10 @@ msgctxt "#707"
 msgid "Configure updates"
 msgstr "Konfigūruokite naujinius"
 
+msgctxt "#709"
+msgid "Select the timezone for this device."
+msgstr ""
+
 msgctxt "#710"
 msgid "Configure the Hostname of your @DISTRONAME@ system. This will be used for the HTPC \\\\hostname in Windows and SMB server name in the Mac OS Finder"
 msgstr "Nustatykite savo @DISTRONAME@ sistemos įrenginio vardą. Jis bus naudojamas kaip HTPC įrenginio '\\\\hostname' Windows sistemoje ir SMB serverio vardas Mac OS Finder programoje"
@@ -1115,4 +1119,8 @@ msgstr ""
 
 msgctxt "#32419"
 msgid "Error sending log files. Please try again."
+msgstr ""
+
+msgctxt "#32420"
+msgid "Timezone"
 msgstr ""

--- a/resources/language/resource.language.lt_lt/strings.po
+++ b/resources/language/resource.language.lt_lt/strings.po
@@ -602,7 +602,7 @@ msgid "Current Version"
 msgstr "Dabartinė versija"
 
 msgctxt "#32189"
-msgid "Identification"
+msgid "OS Configuration"
 msgstr "Identifikacija"
 
 msgctxt "#32190"

--- a/resources/language/resource.language.lv_lv/strings.po
+++ b/resources/language/resource.language.lv_lv/strings.po
@@ -599,7 +599,7 @@ msgid "Current Version"
 msgstr "Pašreizējā versija"
 
 msgctxt "#32189"
-msgid "Identification"
+msgid "OS Configuration"
 msgstr "Identifikācija"
 
 msgctxt "#32190"

--- a/resources/language/resource.language.lv_lv/strings.po
+++ b/resources/language/resource.language.lv_lv/strings.po
@@ -90,6 +90,10 @@ msgctxt "#707"
 msgid "Configure updates"
 msgstr "Atjauninājumu konfigurēšana"
 
+msgctxt "#709"
+msgid "Select the timezone for this device."
+msgstr ""
+
 msgctxt "#710"
 msgid "Configure the Hostname of your @DISTRONAME@ system. This will be used for the HTPC \\\\hostname in Windows and SMB server name in the Mac OS Finder"
 msgstr "@DISTRONAME@ sistēmas resursdatora nosaukuma konfigurēšana. Tas tiks izmantots Windows HTPC \\\\hostname un Mac OS Finder SMB servera nosaukumā"
@@ -1112,4 +1116,8 @@ msgstr ""
 
 msgctxt "#32419"
 msgid "Error sending log files. Please try again."
+msgstr ""
+
+msgctxt "#32420"
+msgid "Timezone"
 msgstr ""

--- a/resources/language/resource.language.mi/strings.po
+++ b/resources/language/resource.language.mi/strings.po
@@ -582,7 +582,7 @@ msgid "Current Version"
 msgstr ""
 
 msgctxt "#32189"
-msgid "Identification"
+msgid "OS Configuration"
 msgstr ""
 
 msgctxt "#32190"

--- a/resources/language/resource.language.mi/strings.po
+++ b/resources/language/resource.language.mi/strings.po
@@ -81,6 +81,10 @@ msgctxt "#707"
 msgid "Configure updates"
 msgstr ""
 
+msgctxt "#709"
+msgid "Select the timezone for this device."
+msgstr ""
+
 msgctxt "#710"
 msgid "Configure the Hostname of your @DISTRONAME@ system. This will be used for the HTPC \\\\hostname in Windows and SMB server name in the Mac OS Finder"
 msgstr ""
@@ -1095,4 +1099,8 @@ msgstr ""
 
 msgctxt "#32419"
 msgid "Error sending log files. Please try again."
+msgstr ""
+
+msgctxt "#32420"
+msgid "Timezone"
 msgstr ""

--- a/resources/language/resource.language.mk_mk/strings.po
+++ b/resources/language/resource.language.mk_mk/strings.po
@@ -586,7 +586,7 @@ msgid "Current Version"
 msgstr ""
 
 msgctxt "#32189"
-msgid "Identification"
+msgid "OS Configuration"
 msgstr ""
 
 msgctxt "#32190"

--- a/resources/language/resource.language.mk_mk/strings.po
+++ b/resources/language/resource.language.mk_mk/strings.po
@@ -81,6 +81,10 @@ msgctxt "#707"
 msgid "Configure updates"
 msgstr ""
 
+msgctxt "#709"
+msgid "Select the timezone for this device."
+msgstr ""
+
 msgctxt "#710"
 msgid "Configure the Hostname of your @DISTRONAME@ system. This will be used for the HTPC \\\\hostname in Windows and SMB server name in the Mac OS Finder"
 msgstr ""
@@ -1099,4 +1103,8 @@ msgstr ""
 
 msgctxt "#32419"
 msgid "Error sending log files. Please try again."
+msgstr ""
+
+msgctxt "#32420"
+msgid "Timezone"
 msgstr ""

--- a/resources/language/resource.language.ml_in/strings.po
+++ b/resources/language/resource.language.ml_in/strings.po
@@ -586,7 +586,7 @@ msgid "Current Version"
 msgstr ""
 
 msgctxt "#32189"
-msgid "Identification"
+msgid "OS Configuration"
 msgstr ""
 
 msgctxt "#32190"

--- a/resources/language/resource.language.ml_in/strings.po
+++ b/resources/language/resource.language.ml_in/strings.po
@@ -81,6 +81,10 @@ msgctxt "#707"
 msgid "Configure updates"
 msgstr ""
 
+msgctxt "#709"
+msgid "Select the timezone for this device."
+msgstr ""
+
 msgctxt "#710"
 msgid "Configure the Hostname of your @DISTRONAME@ system. This will be used for the HTPC \\\\hostname in Windows and SMB server name in the Mac OS Finder"
 msgstr ""
@@ -1099,4 +1103,8 @@ msgstr ""
 
 msgctxt "#32419"
 msgid "Error sending log files. Please try again."
+msgstr ""
+
+msgctxt "#32420"
+msgid "Timezone"
 msgstr ""

--- a/resources/language/resource.language.mn_mn/strings.po
+++ b/resources/language/resource.language.mn_mn/strings.po
@@ -586,7 +586,7 @@ msgid "Current Version"
 msgstr ""
 
 msgctxt "#32189"
-msgid "Identification"
+msgid "OS Configuration"
 msgstr ""
 
 msgctxt "#32190"

--- a/resources/language/resource.language.mn_mn/strings.po
+++ b/resources/language/resource.language.mn_mn/strings.po
@@ -81,6 +81,10 @@ msgctxt "#707"
 msgid "Configure updates"
 msgstr ""
 
+msgctxt "#709"
+msgid "Select the timezone for this device."
+msgstr ""
+
 msgctxt "#710"
 msgid "Configure the Hostname of your @DISTRONAME@ system. This will be used for the HTPC \\\\hostname in Windows and SMB server name in the Mac OS Finder"
 msgstr ""
@@ -1099,4 +1103,8 @@ msgstr ""
 
 msgctxt "#32419"
 msgid "Error sending log files. Please try again."
+msgstr ""
+
+msgctxt "#32420"
+msgid "Timezone"
 msgstr ""

--- a/resources/language/resource.language.ms_my/strings.po
+++ b/resources/language/resource.language.ms_my/strings.po
@@ -586,7 +586,7 @@ msgid "Current Version"
 msgstr ""
 
 msgctxt "#32189"
-msgid "Identification"
+msgid "OS Configuration"
 msgstr ""
 
 msgctxt "#32190"

--- a/resources/language/resource.language.ms_my/strings.po
+++ b/resources/language/resource.language.ms_my/strings.po
@@ -81,6 +81,10 @@ msgctxt "#707"
 msgid "Configure updates"
 msgstr ""
 
+msgctxt "#709"
+msgid "Select the timezone for this device."
+msgstr ""
+
 msgctxt "#710"
 msgid "Configure the Hostname of your @DISTRONAME@ system. This will be used for the HTPC \\\\hostname in Windows and SMB server name in the Mac OS Finder"
 msgstr ""
@@ -1099,4 +1103,8 @@ msgstr ""
 
 msgctxt "#32419"
 msgid "Error sending log files. Please try again."
+msgstr ""
+
+msgctxt "#32420"
+msgid "Timezone"
 msgstr ""

--- a/resources/language/resource.language.mt_mt/strings.po
+++ b/resources/language/resource.language.mt_mt/strings.po
@@ -586,7 +586,7 @@ msgid "Current Version"
 msgstr ""
 
 msgctxt "#32189"
-msgid "Identification"
+msgid "OS Configuration"
 msgstr ""
 
 msgctxt "#32190"

--- a/resources/language/resource.language.mt_mt/strings.po
+++ b/resources/language/resource.language.mt_mt/strings.po
@@ -81,6 +81,10 @@ msgctxt "#707"
 msgid "Configure updates"
 msgstr ""
 
+msgctxt "#709"
+msgid "Select the timezone for this device."
+msgstr ""
+
 msgctxt "#710"
 msgid "Configure the Hostname of your @DISTRONAME@ system. This will be used for the HTPC \\\\hostname in Windows and SMB server name in the Mac OS Finder"
 msgstr ""
@@ -1099,4 +1103,8 @@ msgstr ""
 
 msgctxt "#32419"
 msgid "Error sending log files. Please try again."
+msgstr ""
+
+msgctxt "#32420"
+msgid "Timezone"
 msgstr ""

--- a/resources/language/resource.language.my_mm/strings.po
+++ b/resources/language/resource.language.my_mm/strings.po
@@ -586,7 +586,7 @@ msgid "Current Version"
 msgstr ""
 
 msgctxt "#32189"
-msgid "Identification"
+msgid "OS Configuration"
 msgstr ""
 
 msgctxt "#32190"

--- a/resources/language/resource.language.my_mm/strings.po
+++ b/resources/language/resource.language.my_mm/strings.po
@@ -81,6 +81,10 @@ msgctxt "#707"
 msgid "Configure updates"
 msgstr ""
 
+msgctxt "#709"
+msgid "Select the timezone for this device."
+msgstr ""
+
 msgctxt "#710"
 msgid "Configure the Hostname of your @DISTRONAME@ system. This will be used for the HTPC \\\\hostname in Windows and SMB server name in the Mac OS Finder"
 msgstr ""
@@ -1099,4 +1103,8 @@ msgstr ""
 
 msgctxt "#32419"
 msgid "Error sending log files. Please try again."
+msgstr ""
+
+msgctxt "#32420"
+msgid "Timezone"
 msgstr ""

--- a/resources/language/resource.language.nb_no/strings.po
+++ b/resources/language/resource.language.nb_no/strings.po
@@ -602,7 +602,7 @@ msgid "Current Version"
 msgstr "Gjeldende versjon"
 
 msgctxt "#32189"
-msgid "Identification"
+msgid "OS Configuration"
 msgstr "Identifikasjon"
 
 msgctxt "#32190"

--- a/resources/language/resource.language.nb_no/strings.po
+++ b/resources/language/resource.language.nb_no/strings.po
@@ -93,6 +93,10 @@ msgctxt "#707"
 msgid "Configure updates"
 msgstr "Konfigurer oppdateringer"
 
+msgctxt "#709"
+msgid "Select the timezone for this device."
+msgstr ""
+
 msgctxt "#710"
 msgid "Configure the Hostname of your @DISTRONAME@ system. This will be used for the HTPC \\\\hostname in Windows and SMB server name in the Mac OS Finder"
 msgstr "Konfigurer vertsnavn på @DISTRONAME@ systemet. Dette vil bli brukt til HTPC \\\\ vertsnavnet i Windows og SMB-server navnet i Mac OS Finder"
@@ -1115,4 +1119,8 @@ msgstr ""
 
 msgctxt "#32419"
 msgid "Error sending log files. Please try again."
+msgstr ""
+
+msgctxt "#32420"
+msgid "Timezone"
 msgstr ""

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -604,7 +604,7 @@ msgid "Current Version"
 msgstr "Huidige versie"
 
 msgctxt "#32189"
-msgid "Identification"
+msgid "OS Configuration"
 msgstr "Identificatie"
 
 msgctxt "#32190"

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -95,6 +95,10 @@ msgctxt "#707"
 msgid "Configure updates"
 msgstr "Updates configureren"
 
+msgctxt "#709"
+msgid "Select the timezone for this device."
+msgstr ""
+
 msgctxt "#710"
 msgid "Configure the Hostname of your @DISTRONAME@ system. This will be used for the HTPC \\\\hostname in Windows and SMB server name in the Mac OS Finder"
 msgstr "Configureer de hostnaam van je @DISTRONAME@-systeem. Dit zal gebruikt worden als HTPC \\\\hostnaam in Windows en SMB-servernaam in de Mac OS Finder"
@@ -1117,4 +1121,8 @@ msgstr ""
 
 msgctxt "#32419"
 msgid "Error sending log files. Please try again."
+msgstr ""
+
+msgctxt "#32420"
+msgid "Timezone"
 msgstr ""

--- a/resources/language/resource.language.os_os/strings.po
+++ b/resources/language/resource.language.os_os/strings.po
@@ -582,7 +582,7 @@ msgid "Current Version"
 msgstr ""
 
 msgctxt "#32189"
-msgid "Identification"
+msgid "OS Configuration"
 msgstr ""
 
 msgctxt "#32190"

--- a/resources/language/resource.language.os_os/strings.po
+++ b/resources/language/resource.language.os_os/strings.po
@@ -81,6 +81,10 @@ msgctxt "#707"
 msgid "Configure updates"
 msgstr ""
 
+msgctxt "#709"
+msgid "Select the timezone for this device."
+msgstr ""
+
 msgctxt "#710"
 msgid "Configure the Hostname of your @DISTRONAME@ system. This will be used for the HTPC \\\\hostname in Windows and SMB server name in the Mac OS Finder"
 msgstr ""
@@ -1095,4 +1099,8 @@ msgstr ""
 
 msgctxt "#32419"
 msgid "Error sending log files. Please try again."
+msgstr ""
+
+msgctxt "#32420"
+msgid "Timezone"
 msgstr ""

--- a/resources/language/resource.language.pl_pl/strings.po
+++ b/resources/language/resource.language.pl_pl/strings.po
@@ -602,7 +602,7 @@ msgid "Current Version"
 msgstr "Aktualna wersja"
 
 msgctxt "#32189"
-msgid "Identification"
+msgid "OS Configuration"
 msgstr "Identyfikacja"
 
 msgctxt "#32190"

--- a/resources/language/resource.language.pl_pl/strings.po
+++ b/resources/language/resource.language.pl_pl/strings.po
@@ -93,6 +93,10 @@ msgctxt "#707"
 msgid "Configure updates"
 msgstr "Konfiguruj aktualizacje"
 
+msgctxt "#709"
+msgid "Select the timezone for this device."
+msgstr ""
+
 msgctxt "#710"
 msgid "Configure the Hostname of your @DISTRONAME@ system. This will be used for the HTPC \\\\hostname in Windows and SMB server name in the Mac OS Finder"
 msgstr "Skonfiguruj nazwę hosta systemu @DISTRONAME@ . Będzie to używane dla nazwy \\\\hosta HTPC w systemie Windows i nazwy serwera SMB w Finderze Mac OS"
@@ -1115,4 +1119,8 @@ msgstr ""
 
 msgctxt "#32419"
 msgid "Error sending log files. Please try again."
+msgstr ""
+
+msgctxt "#32420"
+msgid "Timezone"
 msgstr ""

--- a/resources/language/resource.language.pt_br/strings.po
+++ b/resources/language/resource.language.pt_br/strings.po
@@ -101,6 +101,10 @@ msgctxt "#707"
 msgid "Configure updates"
 msgstr "Configurar atualizações"
 
+msgctxt "#709"
+msgid "Select the timezone for this device."
+msgstr ""
+
 msgctxt "#710"
 msgid "Configure the Hostname of your @DISTRONAME@ system. This will be used for the HTPC \\\\hostname in Windows and SMB server name in the Mac OS Finder"
 msgstr "Configure o Hostname do seu @DISTRONAME@ sistema. Isso será usado para o HTPC \\\\hostname no nome do servidor Windows e SMB no MacOS Finder"
@@ -1123,4 +1127,8 @@ msgstr ""
 
 msgctxt "#32419"
 msgid "Error sending log files. Please try again."
+msgstr ""
+
+msgctxt "#32420"
+msgid "Timezone"
 msgstr ""

--- a/resources/language/resource.language.pt_br/strings.po
+++ b/resources/language/resource.language.pt_br/strings.po
@@ -610,7 +610,7 @@ msgid "Current Version"
 msgstr "Versão Atual"
 
 msgctxt "#32189"
-msgid "Identification"
+msgid "OS Configuration"
 msgstr "Identificação"
 
 msgctxt "#32190"

--- a/resources/language/resource.language.pt_pt/strings.po
+++ b/resources/language/resource.language.pt_pt/strings.po
@@ -93,6 +93,10 @@ msgctxt "#707"
 msgid "Configure updates"
 msgstr "Configurar atualizações"
 
+msgctxt "#709"
+msgid "Select the timezone for this device."
+msgstr ""
+
 msgctxt "#710"
 msgid "Configure the Hostname of your @DISTRONAME@ system. This will be used for the HTPC \\\\hostname in Windows and SMB server name in the Mac OS Finder"
 msgstr "Configure o Hostname do seu sistema @DISTRONAME@. Ele será usado para o HTPC \\\\hostename no Windows e nome do servidor Samba no Mac OS Finder"
@@ -1111,4 +1115,8 @@ msgstr ""
 
 msgctxt "#32419"
 msgid "Error sending log files. Please try again."
+msgstr ""
+
+msgctxt "#32420"
+msgid "Timezone"
 msgstr ""

--- a/resources/language/resource.language.pt_pt/strings.po
+++ b/resources/language/resource.language.pt_pt/strings.po
@@ -598,7 +598,7 @@ msgid "Current Version"
 msgstr "Versão Atual"
 
 msgctxt "#32189"
-msgid "Identification"
+msgid "OS Configuration"
 msgstr "Identificação"
 
 msgctxt "#32190"

--- a/resources/language/resource.language.ro_ro/strings.po
+++ b/resources/language/resource.language.ro_ro/strings.po
@@ -90,6 +90,10 @@ msgctxt "#707"
 msgid "Configure updates"
 msgstr "Configurează actualizările."
 
+msgctxt "#709"
+msgid "Select the timezone for this device."
+msgstr ""
+
 msgctxt "#710"
 msgid "Configure the Hostname of your @DISTRONAME@ system. This will be used for the HTPC \\\\hostname in Windows and SMB server name in the Mac OS Finder"
 msgstr ""
@@ -1108,4 +1112,8 @@ msgstr ""
 
 msgctxt "#32419"
 msgid "Error sending log files. Please try again."
+msgstr ""
+
+msgctxt "#32420"
+msgid "Timezone"
 msgstr ""

--- a/resources/language/resource.language.ro_ro/strings.po
+++ b/resources/language/resource.language.ro_ro/strings.po
@@ -595,7 +595,7 @@ msgid "Current Version"
 msgstr "Versiune curentă"
 
 msgctxt "#32189"
-msgid "Identification"
+msgid "OS Configuration"
 msgstr "Identificare"
 
 msgctxt "#32190"

--- a/resources/language/resource.language.ru_ru/strings.po
+++ b/resources/language/resource.language.ru_ru/strings.po
@@ -604,7 +604,7 @@ msgid "Current Version"
 msgstr "Текущая версия"
 
 msgctxt "#32189"
-msgid "Identification"
+msgid "OS Configuration"
 msgstr "Идентификация"
 
 msgctxt "#32190"

--- a/resources/language/resource.language.ru_ru/strings.po
+++ b/resources/language/resource.language.ru_ru/strings.po
@@ -95,6 +95,10 @@ msgctxt "#707"
 msgid "Configure updates"
 msgstr "Настроить обновления"
 
+msgctxt "#709"
+msgid "Select the timezone for this device."
+msgstr ""
+
 msgctxt "#710"
 msgid "Configure the Hostname of your @DISTRONAME@ system. This will be used for the HTPC \\\\hostname in Windows and SMB server name in the Mac OS Finder"
 msgstr "Настройка имени хоста вашей системы @DISTRONAME@. Под этим именем Ваш HTPC будет виден, как \\\\имя_хоста в сети Windows и SMB сервер проводнике Mac OS"
@@ -1117,4 +1121,8 @@ msgstr ""
 
 msgctxt "#32419"
 msgid "Error sending log files. Please try again."
+msgstr ""
+
+msgctxt "#32420"
+msgid "Timezone"
 msgstr ""

--- a/resources/language/resource.language.si_lk/strings.po
+++ b/resources/language/resource.language.si_lk/strings.po
@@ -582,7 +582,7 @@ msgid "Current Version"
 msgstr ""
 
 msgctxt "#32189"
-msgid "Identification"
+msgid "OS Configuration"
 msgstr ""
 
 msgctxt "#32190"

--- a/resources/language/resource.language.si_lk/strings.po
+++ b/resources/language/resource.language.si_lk/strings.po
@@ -81,6 +81,10 @@ msgctxt "#707"
 msgid "Configure updates"
 msgstr ""
 
+msgctxt "#709"
+msgid "Select the timezone for this device."
+msgstr ""
+
 msgctxt "#710"
 msgid "Configure the Hostname of your @DISTRONAME@ system. This will be used for the HTPC \\\\hostname in Windows and SMB server name in the Mac OS Finder"
 msgstr ""
@@ -1095,4 +1099,8 @@ msgstr ""
 
 msgctxt "#32419"
 msgid "Error sending log files. Please try again."
+msgstr ""
+
+msgctxt "#32420"
+msgid "Timezone"
 msgstr ""

--- a/resources/language/resource.language.sk_sk/strings.po
+++ b/resources/language/resource.language.sk_sk/strings.po
@@ -604,7 +604,7 @@ msgid "Current Version"
 msgstr "Aktuálna verzia"
 
 msgctxt "#32189"
-msgid "Identification"
+msgid "OS Configuration"
 msgstr "Identifikácia"
 
 msgctxt "#32190"

--- a/resources/language/resource.language.sk_sk/strings.po
+++ b/resources/language/resource.language.sk_sk/strings.po
@@ -95,6 +95,10 @@ msgctxt "#707"
 msgid "Configure updates"
 msgstr "Konfugirovať aktualizácie"
 
+msgctxt "#709"
+msgid "Select the timezone for this device."
+msgstr ""
+
 msgctxt "#710"
 msgid "Configure the Hostname of your @DISTRONAME@ system. This will be used for the HTPC \\\\hostname in Windows and SMB server name in the Mac OS Finder"
 msgstr "Nakonfigurujte meno hostiteľa vášho systému @DISTRONAME@. Toto sa bude používať pre HTPC \\\\meno hostiteľa v systéme Windows a SMB server name v Mac OS Finder"
@@ -1117,4 +1121,8 @@ msgstr ""
 
 msgctxt "#32419"
 msgid "Error sending log files. Please try again."
+msgstr ""
+
+msgctxt "#32420"
+msgid "Timezone"
 msgstr ""

--- a/resources/language/resource.language.sl_si/strings.po
+++ b/resources/language/resource.language.sl_si/strings.po
@@ -586,7 +586,7 @@ msgid "Current Version"
 msgstr ""
 
 msgctxt "#32189"
-msgid "Identification"
+msgid "OS Configuration"
 msgstr ""
 
 msgctxt "#32190"

--- a/resources/language/resource.language.sl_si/strings.po
+++ b/resources/language/resource.language.sl_si/strings.po
@@ -81,6 +81,10 @@ msgctxt "#707"
 msgid "Configure updates"
 msgstr ""
 
+msgctxt "#709"
+msgid "Select the timezone for this device."
+msgstr ""
+
 msgctxt "#710"
 msgid "Configure the Hostname of your @DISTRONAME@ system. This will be used for the HTPC \\\\hostname in Windows and SMB server name in the Mac OS Finder"
 msgstr ""
@@ -1099,4 +1103,8 @@ msgstr ""
 
 msgctxt "#32419"
 msgid "Error sending log files. Please try again."
+msgstr ""
+
+msgctxt "#32420"
+msgid "Timezone"
 msgstr ""

--- a/resources/language/resource.language.sq_al/strings.po
+++ b/resources/language/resource.language.sq_al/strings.po
@@ -591,7 +591,7 @@ msgid "Current Version"
 msgstr ""
 
 msgctxt "#32189"
-msgid "Identification"
+msgid "OS Configuration"
 msgstr ""
 
 msgctxt "#32190"

--- a/resources/language/resource.language.sq_al/strings.po
+++ b/resources/language/resource.language.sq_al/strings.po
@@ -86,6 +86,10 @@ msgctxt "#707"
 msgid "Configure updates"
 msgstr ""
 
+msgctxt "#709"
+msgid "Select the timezone for this device."
+msgstr ""
+
 msgctxt "#710"
 msgid "Configure the Hostname of your @DISTRONAME@ system. This will be used for the HTPC \\\\hostname in Windows and SMB server name in the Mac OS Finder"
 msgstr ""
@@ -1104,4 +1108,8 @@ msgstr ""
 
 msgctxt "#32419"
 msgid "Error sending log files. Please try again."
+msgstr ""
+
+msgctxt "#32420"
+msgid "Timezone"
 msgstr ""

--- a/resources/language/resource.language.sr_rs/strings.po
+++ b/resources/language/resource.language.sr_rs/strings.po
@@ -586,7 +586,7 @@ msgid "Current Version"
 msgstr ""
 
 msgctxt "#32189"
-msgid "Identification"
+msgid "OS Configuration"
 msgstr ""
 
 msgctxt "#32190"

--- a/resources/language/resource.language.sr_rs/strings.po
+++ b/resources/language/resource.language.sr_rs/strings.po
@@ -81,6 +81,10 @@ msgctxt "#707"
 msgid "Configure updates"
 msgstr ""
 
+msgctxt "#709"
+msgid "Select the timezone for this device."
+msgstr ""
+
 msgctxt "#710"
 msgid "Configure the Hostname of your @DISTRONAME@ system. This will be used for the HTPC \\\\hostname in Windows and SMB server name in the Mac OS Finder"
 msgstr ""
@@ -1099,4 +1103,8 @@ msgstr ""
 
 msgctxt "#32419"
 msgid "Error sending log files. Please try again."
+msgstr ""
+
+msgctxt "#32420"
+msgid "Timezone"
 msgstr ""

--- a/resources/language/resource.language.sr_rs@latin/strings.po
+++ b/resources/language/resource.language.sr_rs@latin/strings.po
@@ -586,7 +586,7 @@ msgid "Current Version"
 msgstr ""
 
 msgctxt "#32189"
-msgid "Identification"
+msgid "OS Configuration"
 msgstr ""
 
 msgctxt "#32190"

--- a/resources/language/resource.language.sr_rs@latin/strings.po
+++ b/resources/language/resource.language.sr_rs@latin/strings.po
@@ -81,6 +81,10 @@ msgctxt "#707"
 msgid "Configure updates"
 msgstr ""
 
+msgctxt "#709"
+msgid "Select the timezone for this device."
+msgstr ""
+
 msgctxt "#710"
 msgid "Configure the Hostname of your @DISTRONAME@ system. This will be used for the HTPC \\\\hostname in Windows and SMB server name in the Mac OS Finder"
 msgstr ""
@@ -1099,4 +1103,8 @@ msgstr ""
 
 msgctxt "#32419"
 msgid "Error sending log files. Please try again."
+msgstr ""
+
+msgctxt "#32420"
+msgid "Timezone"
 msgstr ""

--- a/resources/language/resource.language.sv_se/strings.po
+++ b/resources/language/resource.language.sv_se/strings.po
@@ -600,7 +600,7 @@ msgid "Current Version"
 msgstr "Nuvarande version"
 
 msgctxt "#32189"
-msgid "Identification"
+msgid "OS Configuration"
 msgstr "Identifikation"
 
 msgctxt "#32190"

--- a/resources/language/resource.language.sv_se/strings.po
+++ b/resources/language/resource.language.sv_se/strings.po
@@ -91,6 +91,10 @@ msgctxt "#707"
 msgid "Configure updates"
 msgstr "Konfigurera uppdateringar"
 
+msgctxt "#709"
+msgid "Select the timezone for this device."
+msgstr ""
+
 msgctxt "#710"
 msgid "Configure the Hostname of your @DISTRONAME@ system. This will be used for the HTPC \\\\hostname in Windows and SMB server name in the Mac OS Finder"
 msgstr "Ange värdnamnet för ditt @DISTRONAME@-system. Detta kommer användas för enhetems \\\\värnamn i Windows och SMB-servernamn i Mac OS Finder"
@@ -1115,4 +1119,8 @@ msgstr ""
 
 msgctxt "#32419"
 msgid "Error sending log files. Please try again."
+msgstr ""
+
+msgctxt "#32420"
+msgid "Timezone"
 msgstr ""

--- a/resources/language/resource.language.szl/strings.po
+++ b/resources/language/resource.language.szl/strings.po
@@ -582,7 +582,7 @@ msgid "Current Version"
 msgstr ""
 
 msgctxt "#32189"
-msgid "Identification"
+msgid "OS Configuration"
 msgstr ""
 
 msgctxt "#32190"

--- a/resources/language/resource.language.szl/strings.po
+++ b/resources/language/resource.language.szl/strings.po
@@ -81,6 +81,10 @@ msgctxt "#707"
 msgid "Configure updates"
 msgstr ""
 
+msgctxt "#709"
+msgid "Select the timezone for this device."
+msgstr ""
+
 msgctxt "#710"
 msgid "Configure the Hostname of your @DISTRONAME@ system. This will be used for the HTPC \\\\hostname in Windows and SMB server name in the Mac OS Finder"
 msgstr ""
@@ -1095,4 +1099,8 @@ msgstr ""
 
 msgctxt "#32419"
 msgid "Error sending log files. Please try again."
+msgstr ""
+
+msgctxt "#32420"
+msgid "Timezone"
 msgstr ""

--- a/resources/language/resource.language.ta_in/strings.po
+++ b/resources/language/resource.language.ta_in/strings.po
@@ -586,7 +586,7 @@ msgid "Current Version"
 msgstr ""
 
 msgctxt "#32189"
-msgid "Identification"
+msgid "OS Configuration"
 msgstr ""
 
 msgctxt "#32190"

--- a/resources/language/resource.language.ta_in/strings.po
+++ b/resources/language/resource.language.ta_in/strings.po
@@ -81,6 +81,10 @@ msgctxt "#707"
 msgid "Configure updates"
 msgstr ""
 
+msgctxt "#709"
+msgid "Select the timezone for this device."
+msgstr ""
+
 msgctxt "#710"
 msgid "Configure the Hostname of your @DISTRONAME@ system. This will be used for the HTPC \\\\hostname in Windows and SMB server name in the Mac OS Finder"
 msgstr ""
@@ -1099,4 +1103,8 @@ msgstr ""
 
 msgctxt "#32419"
 msgid "Error sending log files. Please try again."
+msgstr ""
+
+msgctxt "#32420"
+msgid "Timezone"
 msgstr ""

--- a/resources/language/resource.language.tg_tj/strings.po
+++ b/resources/language/resource.language.tg_tj/strings.po
@@ -582,7 +582,7 @@ msgid "Current Version"
 msgstr ""
 
 msgctxt "#32189"
-msgid "Identification"
+msgid "OS Configuration"
 msgstr ""
 
 msgctxt "#32190"

--- a/resources/language/resource.language.tg_tj/strings.po
+++ b/resources/language/resource.language.tg_tj/strings.po
@@ -81,6 +81,10 @@ msgctxt "#707"
 msgid "Configure updates"
 msgstr ""
 
+msgctxt "#709"
+msgid "Select the timezone for this device."
+msgstr ""
+
 msgctxt "#710"
 msgid "Configure the Hostname of your @DISTRONAME@ system. This will be used for the HTPC \\\\hostname in Windows and SMB server name in the Mac OS Finder"
 msgstr ""
@@ -1095,4 +1099,8 @@ msgstr ""
 
 msgctxt "#32419"
 msgid "Error sending log files. Please try again."
+msgstr ""
+
+msgctxt "#32420"
+msgid "Timezone"
 msgstr ""

--- a/resources/language/resource.language.th_th/strings.po
+++ b/resources/language/resource.language.th_th/strings.po
@@ -586,7 +586,7 @@ msgid "Current Version"
 msgstr ""
 
 msgctxt "#32189"
-msgid "Identification"
+msgid "OS Configuration"
 msgstr ""
 
 msgctxt "#32190"

--- a/resources/language/resource.language.th_th/strings.po
+++ b/resources/language/resource.language.th_th/strings.po
@@ -81,6 +81,10 @@ msgctxt "#707"
 msgid "Configure updates"
 msgstr ""
 
+msgctxt "#709"
+msgid "Select the timezone for this device."
+msgstr ""
+
 msgctxt "#710"
 msgid "Configure the Hostname of your @DISTRONAME@ system. This will be used for the HTPC \\\\hostname in Windows and SMB server name in the Mac OS Finder"
 msgstr ""
@@ -1099,4 +1103,8 @@ msgstr ""
 
 msgctxt "#32419"
 msgid "Error sending log files. Please try again."
+msgstr ""
+
+msgctxt "#32420"
+msgid "Timezone"
 msgstr ""

--- a/resources/language/resource.language.tr_tr/strings.po
+++ b/resources/language/resource.language.tr_tr/strings.po
@@ -604,7 +604,7 @@ msgid "Current Version"
 msgstr "Geçerli Sürüm"
 
 msgctxt "#32189"
-msgid "Identification"
+msgid "OS Configuration"
 msgstr "Kimlik"
 
 msgctxt "#32190"

--- a/resources/language/resource.language.tr_tr/strings.po
+++ b/resources/language/resource.language.tr_tr/strings.po
@@ -95,6 +95,10 @@ msgctxt "#707"
 msgid "Configure updates"
 msgstr "Güncellemeleri yapılandır"
 
+msgctxt "#709"
+msgid "Select the timezone for this device."
+msgstr ""
+
 msgctxt "#710"
 msgid "Configure the Hostname of your @DISTRONAME@ system. This will be used for the HTPC \\\\hostname in Windows and SMB server name in the Mac OS Finder"
 msgstr "@DISTRONAME@ sisteminizin Ana Bilgisayar adını (Hostname) yapılandırın. Bu, Windows'taki HTPC \\\\\\\\hostname (ana bilgisayar adı) ve Mac OS Finder'da SMB sunucusu adı için kullanılacaktır"
@@ -1117,4 +1121,8 @@ msgstr ""
 
 msgctxt "#32419"
 msgid "Error sending log files. Please try again."
+msgstr ""
+
+msgctxt "#32420"
+msgid "Timezone"
 msgstr ""

--- a/resources/language/resource.language.uk_ua/strings.po
+++ b/resources/language/resource.language.uk_ua/strings.po
@@ -88,6 +88,10 @@ msgctxt "#707"
 msgid "Configure updates"
 msgstr ""
 
+msgctxt "#709"
+msgid "Select the timezone for this device."
+msgstr ""
+
 msgctxt "#710"
 msgid "Configure the Hostname of your @DISTRONAME@ system. This will be used for the HTPC \\\\hostname in Windows and SMB server name in the Mac OS Finder"
 msgstr ""
@@ -1106,4 +1110,8 @@ msgstr ""
 
 msgctxt "#32419"
 msgid "Error sending log files. Please try again."
+msgstr ""
+
+msgctxt "#32420"
+msgid "Timezone"
 msgstr ""

--- a/resources/language/resource.language.uk_ua/strings.po
+++ b/resources/language/resource.language.uk_ua/strings.po
@@ -593,7 +593,7 @@ msgid "Current Version"
 msgstr ""
 
 msgctxt "#32189"
-msgid "Identification"
+msgid "OS Configuration"
 msgstr ""
 
 msgctxt "#32190"

--- a/resources/language/resource.language.uz_uz/strings.po
+++ b/resources/language/resource.language.uz_uz/strings.po
@@ -586,7 +586,7 @@ msgid "Current Version"
 msgstr ""
 
 msgctxt "#32189"
-msgid "Identification"
+msgid "OS Configuration"
 msgstr ""
 
 msgctxt "#32190"

--- a/resources/language/resource.language.uz_uz/strings.po
+++ b/resources/language/resource.language.uz_uz/strings.po
@@ -81,6 +81,10 @@ msgctxt "#707"
 msgid "Configure updates"
 msgstr ""
 
+msgctxt "#709"
+msgid "Select the timezone for this device."
+msgstr ""
+
 msgctxt "#710"
 msgid "Configure the Hostname of your @DISTRONAME@ system. This will be used for the HTPC \\\\hostname in Windows and SMB server name in the Mac OS Finder"
 msgstr ""
@@ -1099,4 +1103,8 @@ msgstr ""
 
 msgctxt "#32419"
 msgid "Error sending log files. Please try again."
+msgstr ""
+
+msgctxt "#32420"
+msgid "Timezone"
 msgstr ""

--- a/resources/language/resource.language.vi_vn/strings.po
+++ b/resources/language/resource.language.vi_vn/strings.po
@@ -586,7 +586,7 @@ msgid "Current Version"
 msgstr ""
 
 msgctxt "#32189"
-msgid "Identification"
+msgid "OS Configuration"
 msgstr ""
 
 msgctxt "#32190"

--- a/resources/language/resource.language.vi_vn/strings.po
+++ b/resources/language/resource.language.vi_vn/strings.po
@@ -81,6 +81,10 @@ msgctxt "#707"
 msgid "Configure updates"
 msgstr ""
 
+msgctxt "#709"
+msgid "Select the timezone for this device."
+msgstr ""
+
 msgctxt "#710"
 msgid "Configure the Hostname of your @DISTRONAME@ system. This will be used for the HTPC \\\\hostname in Windows and SMB server name in the Mac OS Finder"
 msgstr ""
@@ -1099,4 +1103,8 @@ msgstr ""
 
 msgctxt "#32419"
 msgid "Error sending log files. Please try again."
+msgstr ""
+
+msgctxt "#32420"
+msgid "Timezone"
 msgstr ""

--- a/resources/language/resource.language.zh_cn/strings.po
+++ b/resources/language/resource.language.zh_cn/strings.po
@@ -602,7 +602,7 @@ msgid "Current Version"
 msgstr "当前版本"
 
 msgctxt "#32189"
-msgid "Identification"
+msgid "OS Configuration"
 msgstr "鉴定"
 
 msgctxt "#32190"

--- a/resources/language/resource.language.zh_cn/strings.po
+++ b/resources/language/resource.language.zh_cn/strings.po
@@ -93,6 +93,10 @@ msgctxt "#707"
 msgid "Configure updates"
 msgstr "配置更新源"
 
+msgctxt "#709"
+msgid "Select the timezone for this device."
+msgstr ""
+
 msgctxt "#710"
 msgid "Configure the Hostname of your @DISTRONAME@ system. This will be used for the HTPC \\\\hostname in Windows and SMB server name in the Mac OS Finder"
 msgstr "配置@DISTRONAME@ 系统的主机名。 这将用于Windows中的HTPC \\\\主机名和Mac OS Finder中的SMB服务器名称"
@@ -1115,4 +1119,8 @@ msgstr ""
 
 msgctxt "#32419"
 msgid "Error sending log files. Please try again."
+msgstr ""
+
+msgctxt "#32420"
+msgid "Timezone"
 msgstr ""

--- a/resources/language/resource.language.zh_tw/strings.po
+++ b/resources/language/resource.language.zh_tw/strings.po
@@ -592,7 +592,7 @@ msgid "Current Version"
 msgstr ""
 
 msgctxt "#32189"
-msgid "Identification"
+msgid "OS Configuration"
 msgstr ""
 
 msgctxt "#32190"

--- a/resources/language/resource.language.zh_tw/strings.po
+++ b/resources/language/resource.language.zh_tw/strings.po
@@ -87,6 +87,10 @@ msgctxt "#707"
 msgid "Configure updates"
 msgstr ""
 
+msgctxt "#709"
+msgid "Select the timezone for this device."
+msgstr ""
+
 msgctxt "#710"
 msgid "Configure the Hostname of your @DISTRONAME@ system. This will be used for the HTPC \\\\hostname in Windows and SMB server name in the Mac OS Finder"
 msgstr ""
@@ -1105,4 +1109,8 @@ msgstr ""
 
 msgctxt "#32419"
 msgid "Error sending log files. Please try again."
+msgstr ""
+
+msgctxt "#32420"
+msgid "Timezone"
 msgstr ""

--- a/resources/lib/config.py
+++ b/resources/lib/config.py
@@ -16,3 +16,5 @@ HOSTS_CONF = os.path.join(USER_CONFIG, 'hosts.conf')
 
 REGDOMAIN_CONF = os.path.join(CONFIG_CACHE, 'regdomain.conf')
 SETREGDOMAIN = '/usr/lib/iw/setregdomain'
+
+TIMEZONE = os.path.join(CONFIG_CACHE, 'timezone')

--- a/resources/lib/hostname.py
+++ b/resources/lib/hostname.py
@@ -13,14 +13,8 @@ def get_hostname():
 
 def set_hostname(hostname):
     # network-base.service handles user created persistent settings
-    if os.path.isfile(config.HOSTNAME):
-        with open(config.HOSTNAME, mode='r', encoding='utf-8') as in_file:
-            current_hostname = in_file.read().strip()
-        if current_hostname != hostname:
-            with open(config.HOSTNAME, mode='w', encoding='utf-8') as out_file:
-                out_file.write(f'{hostname}\n')
-            os_tools.execute('systemctl restart network-base')
-    else:
+    current_hostname = get_hostname()
+    if current_hostname != hostname or not os.path.isfile(config.HOSTNAME):
         with open(config.HOSTNAME, mode='w', encoding='utf-8') as out_file:
             out_file.write(f'{hostname}\n')
         os_tools.execute('systemctl restart network-base')

--- a/resources/lib/modules/system.py
+++ b/resources/lib/modules/system.py
@@ -260,7 +260,6 @@ class system(modules.Module):
     def start_service(self):
         self.is_service = True
         self.load_values()
-        self.set_hostname()
         self.set_keyboard_layout()
         self.set_hw_clock()
         del self.is_service
@@ -388,8 +387,6 @@ class system(modules.Module):
 
     @log.log_function()
     def set_hostname(self, listItem=None):
-        if listItem is not None:
-            self.set_value(listItem)
         value = self.struct['ident']['settings']['hostname']['value']
         if value is not None and value != '':
             hostname.set_hostname(value)

--- a/resources/lib/modules/system.py
+++ b/resources/lib/modules/system.py
@@ -18,6 +18,7 @@ import log
 import modules
 import oe
 import os_tools
+import timezone
 
 
 xbmcDialog = xbmcgui.Dialog()
@@ -68,8 +69,22 @@ class system(modules.Module):
                     'InfoText': 710,
                     }},
                 },
-            'keyboard': {
+            'timezone': {
                 'order': 2,
+                'name': 32420,
+                'settings': {
+                    'timezone': {
+                        'order': 1,
+                        'name': 32420,
+                        'value': '',
+                        'action': 'set_timezone',
+                        'type': 'button',
+                        'InfoText': 709,
+                        },
+                    },
+                },
+            'keyboard': {
+                'order': 3,
                 'name': 32009,
                 'settings': {
                     'KeyboardLayout1': {
@@ -120,7 +135,7 @@ class system(modules.Module):
                     },
                 },
             'pinlock': {
-                'order': 3,
+                'order': 4,
                 'name': 32192,
                 'settings': {
                     'pinlock_enable': {
@@ -145,9 +160,8 @@ class system(modules.Module):
                         },
                     },
                 },
-
             'backup': {
-                'order': 7,
+                'order': 5,
                 'name': 32371,
                 'settings': {
                     'backup': {
@@ -169,7 +183,7 @@ class system(modules.Module):
                     },
                 },
             'reset': {
-                'order': 8,
+                'order': 6,
                 'name': 32323,
                 'settings': {
                     'xbmc_reset': {
@@ -191,7 +205,7 @@ class system(modules.Module):
                     },
                 },
             'debug': {
-                'order': 9,
+                'order': 7,
                 'name': 32376,
                 'settings': {
                     'paste_system': {
@@ -213,7 +227,7 @@ class system(modules.Module):
                     },
                 },
             'journal': {
-                'order': 10,
+                'order': 8,
                 'name': 32410,
                 'settings': {
                     'journal_persistent': {
@@ -307,6 +321,9 @@ class system(modules.Module):
             self.nox_keyboard_layouts = True
         # Hostname
         self.struct['ident']['settings']['hostname']['value'] = hostname.get_hostname()
+        # Timezone
+        self.struct['timezone']['settings']['timezone']['value'] = timezone.get_timezone()
+        self.struct['timezone']['settings']['timezone']['name'] = f"{oe._(32420)} ({self.struct['timezone']['settings']['timezone']['value']})"
         # PIN Lock
         self.struct['pinlock']['settings']['pinlock_enable']['value'] = '1' if oe.PIN.isEnabled() else '0'
 
@@ -390,6 +407,22 @@ class system(modules.Module):
         value = self.struct['ident']['settings']['hostname']['value']
         if value is not None and value != '':
             hostname.set_hostname(value)
+
+
+    @log.log_function()
+    def set_timezone(self, listItem=None):
+        timezones = timezone.list_timezones()
+        xbmcDialog = xbmcgui.Dialog()
+        timezone_select = xbmcDialog.select(oe._(32420), timezones)
+        if timezone_select > -1:
+            listItem = timezones[timezone_select]
+            self.struct['timezone']['settings']['timezone']['value'] = listItem
+            self.struct['timezone']['settings']['timezone']['name'] = f"{oe._(32420)} ({listItem})"
+            log.log(f'Setting timezone to: {timezone}', log.DEBUG)
+            timezone.set_timezone(listItem)
+        xbmcDialog = None
+        del xbmcDialog
+
 
     @log.log_function()
     def get_keyboard_layouts(self):

--- a/resources/lib/modules/system.py
+++ b/resources/lib/modules/system.py
@@ -59,22 +59,18 @@ class system(modules.Module):
             'ident': {
                 'order': 1,
                 'name': 32189,
-                'settings': {'hostname': {
-                    'order': 1,
-                    'name': 32190,
-                    'value': '',
-                    'action': 'set_hostname',
-                    'type': 'text',
-                    'validate': '^([a-zA-Z0-9](?:[a-zA-Z0-9-\.]*[a-zA-Z0-9]))$',
-                    'InfoText': 710,
-                    }},
-                },
-            'timezone': {
-                'order': 2,
-                'name': 32420,
                 'settings': {
-                    'timezone': {
+                    'hostname': {
                         'order': 1,
+                        'name': 32190,
+                        'value': '',
+                        'action': 'set_hostname',
+                        'type': 'text',
+                        'validate': '^([a-zA-Z0-9](?:[a-zA-Z0-9-\.]*[a-zA-Z0-9]))$',
+                        'InfoText': 710,
+                        },
+                    'timezone': {
+                        'order': 2,
                         'name': 32420,
                         'value': '',
                         'action': 'set_timezone',
@@ -84,7 +80,7 @@ class system(modules.Module):
                     },
                 },
             'keyboard': {
-                'order': 3,
+                'order': 2,
                 'name': 32009,
                 'settings': {
                     'KeyboardLayout1': {
@@ -135,7 +131,7 @@ class system(modules.Module):
                     },
                 },
             'pinlock': {
-                'order': 4,
+                'order': 3,
                 'name': 32192,
                 'settings': {
                     'pinlock_enable': {
@@ -161,7 +157,7 @@ class system(modules.Module):
                     },
                 },
             'backup': {
-                'order': 5,
+                'order': 4,
                 'name': 32371,
                 'settings': {
                     'backup': {
@@ -183,7 +179,7 @@ class system(modules.Module):
                     },
                 },
             'reset': {
-                'order': 6,
+                'order': 5,
                 'name': 32323,
                 'settings': {
                     'xbmc_reset': {
@@ -205,7 +201,7 @@ class system(modules.Module):
                     },
                 },
             'debug': {
-                'order': 7,
+                'order': 6,
                 'name': 32376,
                 'settings': {
                     'paste_system': {
@@ -227,7 +223,7 @@ class system(modules.Module):
                     },
                 },
             'journal': {
-                'order': 8,
+                'order': 7,
                 'name': 32410,
                 'settings': {
                     'journal_persistent': {
@@ -322,8 +318,8 @@ class system(modules.Module):
         # Hostname
         self.struct['ident']['settings']['hostname']['value'] = hostname.get_hostname()
         # Timezone
-        self.struct['timezone']['settings']['timezone']['value'] = timezone.get_timezone()
-        self.struct['timezone']['settings']['timezone']['name'] = f"{oe._(32420)} ({self.struct['timezone']['settings']['timezone']['value']})"
+        self.struct['ident']['settings']['timezone']['value'] = timezone.get_timezone()
+        self.struct['ident']['settings']['timezone']['name'] = f"{oe._(32420)} ({self.struct['ident']['settings']['timezone']['value']})"
         # PIN Lock
         self.struct['pinlock']['settings']['pinlock_enable']['value'] = '1' if oe.PIN.isEnabled() else '0'
 
@@ -416,8 +412,8 @@ class system(modules.Module):
         timezone_select = xbmcDialog.select(oe._(32420), timezones)
         if timezone_select > -1:
             listItem = timezones[timezone_select]
-            self.struct['timezone']['settings']['timezone']['value'] = listItem
-            self.struct['timezone']['settings']['timezone']['name'] = f"{oe._(32420)} ({listItem})"
+            self.struct['ident']['settings']['timezone']['value'] = listItem
+            self.struct['ident']['settings']['timezone']['name'] = f"{oe._(32420)} ({listItem})"
             log.log(f'Setting timezone to: {timezone}', log.DEBUG)
             timezone.set_timezone(listItem)
         xbmcDialog = None

--- a/resources/lib/timezone.py
+++ b/resources/lib/timezone.py
@@ -32,7 +32,7 @@ def list_timezones():
 
 
 def set_timezone(timezone):
-    '''Write new timezone info to .cache file.'''
+    '''Write new timezone info to .cache file and commit change to system.'''
     current_timezone = get_timezone()
     if current_timezone != timezone or not os.path.isfile(config.TIMEZONE):
         with open(config.TIMEZONE, mode='w', encoding='utf-8') as out_file:

--- a/resources/lib/timezone.py
+++ b/resources/lib/timezone.py
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2024-present Team LibreELEC (https://libreelec.tv)
+
+'''This module holds support functions for interacting with timezones.
+'''
+
+
+import config
+import os_tools
+
+
+def get_timezone():
+    '''Read timezone setting from file or return default of UTC timezone.'''
+    return os_tools.read_shell_setting(config.TIMEZONE, default='TIMEZONE=UTC').split('=', 1)[1]
+
+
+def list_timezones():
+    '''List timezones available from tzdata.'''
+    timezones = []
+    with open('/usr/share/zoneinfo/tzdata.zi', mode='r', encoding='utf-8') as tz_db:
+        content = tz_db.read()
+    for line in content.splitlines():
+        # if line starts with Z take second field
+        if line.startswith('Z'):
+            timezones.append(line.split(' ')[1])
+        # if line starts with L take third field
+        elif line.startswith('L'):
+            timezones.append(line.split(' ')[2])
+    # sort and return
+    timezones.sort()
+    return timezones
+
+
+def set_timezone(timezone):
+    '''Write new timezone info to .cache file.'''
+    current_timezone = get_timezone()
+    if current_timezone != timezone or not os.path.isfile(config.TIMEZONE):
+        with open(config.TIMEZONE, mode='w', encoding='utf-8') as out_file:
+            out_file.write(f'TIMEZONE={timezone}\n')
+        os_tools.execute('systemctl restart tz-data')

--- a/resources/lib/timezone.py
+++ b/resources/lib/timezone.py
@@ -23,9 +23,6 @@ def list_timezones():
         # if line starts with Z take second field
         if line.startswith('Z'):
             timezones.append(line.split(' ')[1])
-        # if line starts with L take third field
-        elif line.startswith('L'):
-            timezones.append(line.split(' ')[2])
     # sort and return
     timezones.sort()
     return timezones


### PR DESCRIPTION
Initial implementation for selecting the OS's timezone via the settings addon. While it won't cause harm today, it's not intended to be merged until LE13 / Kodi 22P. Kodi 21 doesn't pick up on the change in timezone until reboot.

Also has cleanup commits for setting the hostname to follow same format as setting the timezone, to not run everytime Kodi starts, and to not save the hostname to the addon's configuration file.

TODO:
~~Tell user their current timezone (I'd prefer a menuitem 'type' that combines 'text' and 'button' so that the button displays the current value instead of the gear, but I don't know what my choices are and 'button' works today.)
Localization for timezone entries and combined hostname + timezone menus~~

~~Open question:
The list of timezones is very long. This can be trimmed by dropping all of the deprecated timezones. For example, someone on the US east coast should be using "America/New_York" instead of "US/Eastern", so we could just omit "US/Eastern".~~

The timezone list doesn't include deprecated / repeat entries for the same timezone.