### PR TITLE
Fix broken hostname change / restart avahi and wsdd2 after change if running

### DIFF
--- a/resources/lib/hostname.py
+++ b/resources/lib/hostname.py
@@ -18,3 +18,4 @@ def set_hostname(hostname):
         with open(config.HOSTNAME, mode='w', encoding='utf-8') as out_file:
             out_file.write(f'{hostname}\n')
         os_tools.execute('systemctl restart network-base')
+        os_tools.execute('systemctl try-restart avahi-daemon wsdd2')

--- a/resources/lib/modules/system.py
+++ b/resources/lib/modules/system.py
@@ -400,6 +400,8 @@ class system(modules.Module):
 
     @log.log_function()
     def set_hostname(self, listItem=None):
+        if listItem is not None:
+            self.set_value(listItem)
         value = self.struct['ident']['settings']['hostname']['value']
         if value is not None and value != '':
             hostname.set_hostname(value)


### PR DESCRIPTION
Noticed impossibility to change hostname, the old one was always kept

In addition  avahi and wsdd2 do keep old hostname until restated.
