### PR TITLE
dbus_utils.py: adjust use of get_event_loop for its deprecation

### DIFF
--- a/resources/lib/dbus_utils.py
+++ b/resources/lib/dbus_utils.py
@@ -128,7 +128,12 @@ def run_method(bus_name, path, interface, method_name, *args, **kwargs):
     return future.result()
 
 
-LOOP = asyncio.get_event_loop()
+try:
+    LOOP = asyncio.get_running_loop()
+except RuntimeError:
+    LOOP = asyncio.new_event_loop()
+asyncio.set_event_loop(LOOP)
+
 BUS = ravel.system_bus()
 BUS.attach_asyncio(LOOP)
 LOOP_THREAD = LoopThread(LOOP)


### PR DESCRIPTION
This is my understanding of what the addon needs for Python 3.13: https://github.com/LibreELEC/LibreELEC.tv/pull/9374

asyncio.get_event_loop() raises a RuntimeError if there isn't a loop running when it's called. This handles that error by creating a loop when it doesn't find one.

This is my best guess at the correct thing to do. I'm not familiar with asyncio. However, the addon Works For Me.