### PR TITLE
Improvements to timezone selection

### DIFF
--- a/resources/lib/modules/system.py
+++ b/resources/lib/modules/system.py
@@ -416,8 +416,10 @@ class system(modules.Module):
             menu_position = 0
         xbmcDialog = xbmcgui.Dialog()
         timezone_select = xbmcDialog.select(heading=oe._(32420), list=timezones, preselect=menu_position)
+        log.log(f'timezone_select: {timezone_select}', log.DEBUG)
         if timezone_select > -1:
             listItem = timezones[timezone_select]
+            log.log(f'listItem: {listItem}', log.DEBUG)
             self.struct['ident']['settings']['timezone']['value'] = listItem
             self.struct['ident']['settings']['timezone']['name'] = f"{oe._(32420)} ({listItem})"
             log.log(f'Setting timezone to: {timezone}', log.DEBUG)

--- a/resources/lib/timezone.py
+++ b/resources/lib/timezone.py
@@ -7,6 +7,7 @@
 import os
 
 import config
+import log
 import os_tools
 
 

--- a/resources/lib/timezone.py
+++ b/resources/lib/timezone.py
@@ -4,6 +4,7 @@
 '''This module holds support functions for interacting with timezones.
 '''
 
+import os
 
 import config
 import os_tools
@@ -37,4 +38,8 @@ def set_timezone(timezone):
     if current_timezone != timezone or not os.path.isfile(config.TIMEZONE):
         with open(config.TIMEZONE, mode='w', encoding='utf-8') as out_file:
             out_file.write(f'TIMEZONE={timezone}\n')
-        os_tools.execute('systemctl restart tz-data')
+        if os.path.isfile(config.TIMEZONE):
+            os_tools.execute('systemctl restart tz-data')
+        else:
+            log.log(f'Failed to write: {config.TIMEZONE}', log.ERROR)
+            log.log(f'Desired timezone was: {timezone}', log.ERROR)

--- a/resources/lib/timezone.py
+++ b/resources/lib/timezone.py
@@ -23,6 +23,9 @@ def list_timezones():
         # if line starts with Z take second field
         if line.startswith('Z'):
             timezones.append(line.split(' ')[1])
+        # if line starts with L take third field
+        elif line.startswith('L'):
+            timezones.append(line.split(' ')[2])
     # sort and return
     timezones.sort()
     return timezones


### PR DESCRIPTION
This adds deprecated or repeated timezones in tzdata to the addon's timezone selection. The sheer number of timezones are less of an issue with the addon remembering placement now.

Also adds additional logging around selecting a timezone and writing the selection to file for an issue where selection fails for reasons I don't know and can't repeat. 

Both issues mentioned in https://forum.libreelec.tv/thread/29491-timezone-missing-from-today-s-libreelec-nightly/