### PR TITLE
Add a timezone guess based on a device's IP

### DIFF
--- a/resources/lib/modules/system.py
+++ b/resources/lib/modules/system.py
@@ -410,8 +410,12 @@ class system(modules.Module):
     @log.log_function()
     def set_timezone(self, listItem=None):
         timezones = timezone.list_timezones()
-        if self.struct['ident']['settings']['timezone']['value'] in timezones:
-            menu_position = timezones.index(self.struct['ident']['settings']['timezone']['value'])
+        guessed_timezone = timezone.guess_timezone()
+        current_timezone = self.struct['ident']['settings']['timezone']['value']
+        if current_timezone != 'UTC' and current_timezone in timezones:
+            menu_position = timezones.index(current_timezone)
+        elif guessed_timezone in timezones:
+            menu_position = timezones.index(guessed_timezone)
         else:
             menu_position = 0
         xbmcDialog = xbmcgui.Dialog()

--- a/resources/lib/timezone.py
+++ b/resources/lib/timezone.py
@@ -5,6 +5,7 @@
 '''
 
 import os
+from urllib.request import urlopen
 
 import config
 import log
@@ -14,6 +15,22 @@ import os_tools
 def get_timezone():
     '''Read timezone setting from file or return default of UTC timezone.'''
     return os_tools.read_shell_setting(config.TIMEZONE, default='TIMEZONE=UTC').split('=', 1)[1]
+
+
+def guess_timezone():
+    '''Guess the device's timezone based on the public IP of the device.'''
+    def QueryWebServer(url):
+        '''Query a webserver for a response.'''
+        try:
+            response = urlopen(url)
+        except Exception as err:
+            log.log(f'Error querying: {url}', log.ERROR)
+            log.log(err, log.ERROR)
+            response = None
+        return response.read().decode('utf-8').strip() if response else None
+
+    my_ip = QueryWebServer('https://icanhazip.com')
+    return QueryWebServer(f'https://ipapi.co/{my_ip}/timezone') if my_ip else None
 
 
 def list_timezones():


### PR DESCRIPTION
Builds on #331. This should be complete. Draft until that is merged.

This adds a function to guess a device's timezone based on its public ip. Public IP and the geoip lookup are provided by two webservices, icanhazip.com and ipapi.co. If a user has selected a timezone other than the default 'UTC', then it performs a lookup of the timezone associated with the device's ip and preselects it if it's in the list of available timezones. If the query fails, or the timezone isn't there, then it doesn't preselect anything. Once a user selects something other than the default, then it no longer guesses when opening the menu.

I expect this to be as good as timezone selection within Kodi will get without having a mechanism to tell Kodi the system's time changed. The alternative is having a service that checks for network being up and the timezone being the default still before Kodi runs. Maybe on another day. I've looked at enabling systemd-timedated and timedatectl and changing time via timedatectl did not trigger a change within a running Kodi.

icanhazip.com is operated by Cloudflare. I'm not aware of usage limits.

ipapi.co supports 1,000 queries per day without charge. I don't foresee that being a problem for a user. ipapi's about: https://ipapi.co/about/