### PR TITLE
Cleanups in os_tools.py

### DIFF
--- a/resources/lib/os_tools.py
+++ b/resources/lib/os_tools.py
@@ -28,10 +28,14 @@ def read_shell_settings(file, defaults={}):
     if os.path.isfile(file):
         with open(file) as input:
             for line in input:
-                name, value = line.strip().split('=', 1)
-                if len(value) and value[0] in ['"', '"'] and value[0] == value[-1]:
-                    value = value[1:-1]
-                settings[name] = value
+                line = line.strip()
+                # ignore comments
+                if not line.startswith('#'):
+                    name, value = line.split('=', 1)
+                    # remove quotes
+                    if value:
+                        value = value.removeprefix('"').removesuffix('"')
+                    settings[name] = value
     return settings
 
 

--- a/resources/lib/os_tools.py
+++ b/resources/lib/os_tools.py
@@ -15,19 +15,23 @@ import log
 
 
 ### FILE ACCESS ###
-def read_shell_setting(file, default):
-    setting = default
+def read_shell_setting(file, default=None):
+    '''Read the first line of a file as the setting'''
+    setting = default if default else ''
     if os.path.isfile(file):
-        with open(file) as input:
-            setting = input.readline().strip()
+        with open(file, mode='r', encoding='utf-8') as data:
+            setting = data.readline().strip()
+    else:
+        log.log(f'File not found: {file}', log.DEBUG)
     return setting
 
 
-def read_shell_settings(file, defaults={}):
-    settings = defaults
+def read_shell_settings(file, defaults=None):
+    '''Parse settings from text file, placing each value into a dictionary'''
+    settings = defaults if defaults else {}
     if os.path.isfile(file):
-        with open(file) as input:
-            for line in input:
+        with open(file, mode='r', encoding='utf-8') as data:
+            for line in data:
                 line = line.strip()
                 # ignore comments
                 if not line.startswith('#'):
@@ -36,6 +40,8 @@ def read_shell_settings(file, defaults={}):
                     if value:
                         value = value.removeprefix('"').removesuffix('"')
                     settings[name] = value
+    else:
+        log.log(f'File not found: {file}', log.DEBUG)
     return settings
 
 

--- a/resources/lib/os_tools.py
+++ b/resources/lib/os_tools.py
@@ -21,6 +21,9 @@ def read_shell_setting(file, default=None):
     if os.path.isfile(file):
         with open(file, mode='r', encoding='utf-8') as data:
             setting = data.readline().strip()
+            # ignore comments
+            if setting.startswith('#'):
+                setting = default if default else ''
     else:
         log.log(f'File not found: {file}', log.DEBUG)
     return setting


### PR DESCRIPTION
These is a cleanup of os_tools's read_shell_setting() and read_shell_settings(). Most are pylint changes (document, don't override python builtin names, don't initialize a blank dictionary as a function's default), and readability. One functional change is for the functions to ignore commented lines.

There should be nothing visible to end users here. This is just cleaning them up for further use in more places in the addon.