### PR TITLE
system.py: add timezone selection to first-run wizard

### DIFF
--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -805,7 +805,7 @@ msgid "Previous"
 msgstr ""
 
 msgctxt "#32308"
-msgid "Hostname:"
+msgid "Set Hostname and Timezone:"
 msgstr ""
 
 msgctxt "#32309"

--- a/resources/lib/modules/system.py
+++ b/resources/lib/modules/system.py
@@ -774,6 +774,7 @@ MaxRetentionSec=0
         oe.winOeMain.set_wizard_text(oe._(32304))
         oe.winOeMain.set_wizard_button_title(oe._(32308))
         oe.winOeMain.set_wizard_button_1(self.struct['ident']['settings']['hostname']['value'], self, 'wizard_set_hostname')
+        oe.winOeMain.set_wizard_button_2(self.struct['ident']['settings']['timezone']['value'], self, 'wizard_set_timezone')
 
     @log.log_function()
     def wizard_set_hostname(self):
@@ -794,3 +795,11 @@ MaxRetentionSec=0
             self.struct['ident']['settings']['hostname']['value'] = xbmcKeyboard.getText()
             self.set_hostname()
             oe.winOeMain.getControl(1401).setLabel(self.struct['ident']['settings']['hostname']['value'])
+
+    @log.log_function()
+    def wizard_set_timezone(self):
+        cur_timezone = self.struct['ident']['settings']['timezone']['value']
+        self.set_timezone()
+        sel_timezone = self.struct['ident']['settings']['timezone']['value']
+        if sel_timezone != cur_timezone:
+            oe.winOeMain.getControl(1402).setLabel(self.struct['ident']['settings']['timezone']['value'])


### PR DESCRIPTION
This adds setting the timezone to the first-run wizard. Issues:

Some timezones are longer than the button to select it allows, so it expands past the button's border. See "America/Los_Angeles" for example. Cosmetic issue. Probably needs to be fixed in the skin.

Trying to get to the "previous" button to go back to language selection has proven difficult on this part of the wizard, at least it ignores my (hdmi-cec) remote to get to it. Workaround is to proceed to the network setup, and then use previous to go back to hostname/timezone and the selector will still be on previous to return to language selection.

The network wizard is run after system wizard, so the time will appear off until that completes or the user manually sets current time.