### PR TITLE
updates: show window while rpi-eeprom-update is copying files

### DIFF
--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -396,6 +396,10 @@ msgctxt "#32031"
 msgid "Working..."
 msgstr ""
 
+msgctxt "#32032"
+msgid "Firmware is up to date."
+msgstr ""
+
 msgctxt "#32100"
 msgid "Connections"
 msgstr ""

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -392,6 +392,10 @@ msgctxt "#32029"
 msgid "up to date: %s"
 msgstr ""
 
+msgctxt "#32031"
+msgid "Working..."
+msgstr ""
+
 msgctxt "#32100"
 msgid "Connections"
 msgstr ""

--- a/resources/lib/modules/updates.py
+++ b/resources/lib/modules/updates.py
@@ -672,7 +672,7 @@ class updates(modules.Module):
                     xbmcgui.Dialog().ok(oe._(32022), oe._(32023))
                     value = 'true'
             else:
-                xbmcgui.Dialog().ok('Update RPi Firmware', 'Firmware is up to date.')
+                xbmcgui.Dialog().ok(oe._(32022), oe._(32032))
         # user chose no but bootloader update already queued
         elif listItem.getProperty('entry') == 'bootloader' and os.path.isfile('/flash/pieeprom.upd'):
             value = 'true'

--- a/resources/lib/modules/updates.py
+++ b/resources/lib/modules/updates.py
@@ -660,8 +660,14 @@ class updates(modules.Module):
         if xbmcgui.Dialog().yesno(oe._(32022), f'{oe._(32023)}\n\n{oe._(32326)}'):
             # available update is newer than installed version
             if self.rpi_flashing_state[listItem.getProperty('entry')]['current'] < self.rpi_flashing_state[listItem.getProperty('entry')]['latest']:
-                update_result = os_tools.execute(f'/usr/bin/rpi-eeprom-update -A {listItem.getProperty("entry")}', get_result=True)
-                log.log(f'rpi-eeprom-update result: {update_result}', log.DEBUG)
+                dlg = xbmcgui.DialogProgress()
+                dlg.create(oe._(32022), oe._(32031))
+                dlg.update(0)
+                try:
+                    update_result = os_tools.execute(f'/usr/bin/rpi-eeprom-update -A {listItem.getProperty("entry")}', get_result=True)
+                finally:
+                    dlg.close()
+                    log.log(f'rpi-eeprom-update result: {update_result}', log.DEBUG)
                 if update_result:
                     xbmcgui.Dialog().ok(oe._(32022), oe._(32023))
                     value = 'true'


### PR DESCRIPTION
Currently updating an RPi's firmware shows two windows for user feedback: the first to confirm the request, and a second to show when it's finished and time to reboot. This adds a third as a faux progress bar while `rpi-eeprom-update` is working as there can be a misleading pause between the two.

I say faux because it won't update, and there's a cancel button that won't do anything, but it does provide feedback that their system is busy.

~~Needs testing to confirm. I accidentally updated while writing...~~