### PR TITLE
Fix: Skin - Replace deprecated IntegerGreaterThan by Integer.IsGreater

### DIFF
--- a/resources/skins/Default/1080i/service-LibreELEC-Settings-mainWindow.xml
+++ b/resources/skins/Default/1080i/service-LibreELEC-Settings-mainWindow.xml
@@ -907,7 +907,7 @@
                             <width>20</width>
                             <height>20</height>
                             <aspectratio>keep</aspectratio>
-                            <visible>IntegerGreaterThan(ListItem.Property(Trusted), 0)</visible>
+                            <visible>Integer.IsGreater(ListItem.Property(Trusted), 0)</visible>
                             <texture>key.png</texture>
                         </control>
                     </itemlayout>
@@ -1101,7 +1101,7 @@
                             <width>20</width>
                             <height>20</height>
                             <aspectratio>keep</aspectratio>
-                            <visible>IntegerGreaterThan(ListItem.Property(Trusted), 0)</visible>
+                            <visible>Integer.IsGreater(ListItem.Property(Trusted), 0)</visible>
                             <texture>key.png</texture>
                         </control>
                     </focusedlayout>

--- a/resources/skins/Default/1080i/service-LibreELEC-Settings-wizard.xml
+++ b/resources/skins/Default/1080i/service-LibreELEC-Settings-wizard.xml
@@ -310,7 +310,7 @@
                                 <width>20</width>
                                 <height>20</height>
                                 <aspectratio>keep</aspectratio>
-                                <visible>IntegerGreaterThan(ListItem.Property(Security), 0)</visible>
+                                <visible>Integer.IsGreater(ListItem.Property(Security), 0)</visible>
                                 <texture>key.png</texture>
                             </control>
                         </itemlayout>
@@ -421,7 +421,7 @@
                                 <width>20</width>
                                 <height>20</height>
                                 <aspectratio>keep</aspectratio>
-                                <visible>IntegerGreaterThan(ListItem.Property(Security), 0)</visible>
+                                <visible>Integer.IsGreater(ListItem.Property(Security), 0)</visible>
                                 <texture>key.png</texture>
                             </control>
                         </focusedlayout>


### PR DESCRIPTION
IntegerGreaterThan was deprecated in Kodi 18 and replaced by Integer.IsGreater. 

See: https://xbmc.github.io/docs.kodi.tv/master/kodi-base/d4/d72/skinning_v18.html#_skinning_v18000062