### PR TITLE
Bluetooth: Show signal strength

### DIFF
--- a/resources/lib/modules/bluetooth.py
+++ b/resources/lib/modules/bluetooth.py
@@ -283,6 +283,18 @@ class bluetooth(modules.Module):
             self.discovery_thread.start()
 
     @log.log_function()
+    def rssi_to_percentage(self, rssi):
+        min_rssi = -100  # Worst possible signal
+        max_rssi = -30    # Best possible signal
+        if rssi <= min_rssi:
+            return 0
+        elif rssi >= max_rssi:
+            return 100
+        ratio = (rssi - min_rssi) / (max_rssi - min_rssi)
+
+        return round((ratio ** 1.8) * 100)
+
+    @log.log_function()
     def discover_devices(self):
         if not hasattr(oe, 'winOeMain'):
             return
@@ -340,6 +352,9 @@ class bluetooth(modules.Module):
                 apName = device_properties['Name']
             if not 'Icon' in device_properties:
                 dictProperties['Icon'] = 'default'
+            if 'RSSI' in device_properties:
+                rssi = int(device_properties['RSSI'])
+                dictProperties['Strength'] = str(self.rssi_to_percentage(rssi))
             for prop in self.properties:
                 name = self.properties[prop]['value']
                 if name in device_properties:
@@ -522,6 +537,9 @@ class Bluez_Listener(dbus_bluez.Listener):
                 for prop in changed:
                     if prop in properties:
                         self.parent.listItems[path].setProperty(str(prop), str(changed[prop]))
+                if 'RSSI' in changed:
+                    rssi = int(changed['RSSI'])
+                    self.parent.listItems[path].setProperty('Strength', str(self.rssi_to_percentage(rssi)))
             else:
                 self.parent.discover_devices()
 

--- a/resources/skins/Default/1080i/service-LibreELEC-Settings-mainWindow.xml
+++ b/resources/skins/Default/1080i/service-LibreELEC-Settings-mainWindow.xml
@@ -910,6 +910,20 @@
                             <visible>IntegerGreaterThan(ListItem.Property(Trusted), 0)</visible>
                             <texture>key.png</texture>
                         </control>
+                        <!-- Signal strength -->
+                        <control type="progress">
+                            <left>10</left>
+                            <top>80</top>
+                            <width>1236</width>
+                            <height>3</height>
+                            <info>ListItem.Property(Strength)</info>
+                            <visible>Integer.IsGreater(ListItem.Property(Strength), 0)</visible>
+                            <texturebg />
+                            <lefttexture />
+                            <righttexture />
+                            <overlaytexture />
+                            <midtexture colordiffuse="FF12B2E7" border="2">separator-grey.png</midtexture>
+                        </control>
                     </itemlayout>
                     <focusedlayout height="100">
                         <control type="image">
@@ -1104,6 +1118,20 @@
                             <visible>IntegerGreaterThan(ListItem.Property(Trusted), 0)</visible>
                             <texture>key.png</texture>
                         </control>
+                        <!-- Signal strength -->
+                        <control type="progress">
+                            <left>10</left>
+                            <top>80</top>
+                            <width>1236</width>
+                            <height>3</height>
+                            <info>ListItem.Property(Strength)</info>
+                            <visible>Integer.IsGreater(ListItem.Property(Strength), 0)</visible>
+                            <texturebg />
+                            <lefttexture />
+                            <righttexture />
+                            <overlaytexture />
+                            <midtexture colordiffuse="FF12B2E7" border="2">separator-grey.png</midtexture>
+                        </control> 
                     </focusedlayout>
                 </control>
             </control>


### PR DESCRIPTION
This adds signal strength to Bluetooth UI.

UI is similar and based on wifi strength.
Value is based on RSSI value.

Since it is hard to determine based on bluetooth MAC which is the device you want to connect, signal strength might also help to identify which device is near. 

<img width="1659" height="962" alt="image" src="https://github.com/user-attachments/assets/f80e272f-9c25-4c44-9643-905ab6becc82" />
