### PR TITLE
Bluetooth: Use alias as fallback if name is not set

### DIFF
--- a/resources/lib/modules/bluetooth.py
+++ b/resources/lib/modules/bluetooth.py
@@ -332,12 +332,10 @@ class bluetooth(modules.Module):
             selected_dbus_device = selected_item.getProperty('entry')
         for dbusDevice, device_properties in self.dbusDevices.items():
             dictProperties = {}
-            apName = ''
+            apName = device_properties.get('Name') or device_properties.get('Alias', '')
             dictProperties['entry'] = dbusDevice
             dictProperties['modul'] = self.__class__.__name__
             dictProperties['action'] = 'open_context_menu'
-            if 'Name' in device_properties:
-                apName = device_properties['Name']
             if not 'Icon' in device_properties:
                 dictProperties['Icon'] = 'default'
             for prop in self.properties:


### PR DESCRIPTION
Use the bluetooth alias if device name is not available. Effectively, it uses the MAC address as the name if the actual name is unavailable.


Before:

<img width="1160" height="871" alt="image" src="https://github.com/user-attachments/assets/71c3a7d2-2f41-4086-8e3f-1787073308da" />


After:

<img width="1146" height="794" alt="image" src="https://github.com/user-attachments/assets/ee5adbf8-ea38-42de-85ab-14ade5602fb3" />
