### PR TITLE
wizard: rewrite how the order of module wizards is determined

### DIFF
--- a/resources/lib/defaults.py
+++ b/resources/lib/defaults.py
@@ -14,6 +14,15 @@ XBMC_USER_HOME = os.environ.get('XBMC_USER_HOME', '/storage/.kodi')
 CONFIG_CACHE = os.environ.get('CONFIG_CACHE', '/storage/.cache')
 USER_CONFIG = os.environ.get('USER_CONFIG', '/storage/.config')
 
+wizard = {
+    "order": [
+        "connman",
+        "system",
+        "services",
+        "about"
+    ]
+}
+
 ################################################################################
 # Connamn Module
 ################################################################################

--- a/resources/lib/oeWindows.py
+++ b/resources/lib/oeWindows.py
@@ -10,6 +10,7 @@ import xbmc
 import xbmcgui
 import xbmcaddon
 
+import defaults
 import log
 import oe
 
@@ -633,7 +634,22 @@ class wizard(xbmcgui.WindowXMLDialog):
             if strModule == 'connman':
                 xbmc.executebuiltin('UpdateAddonRepos')
 
-            for module in sorted(oe.dictModules, key=lambda x: list(oe.dictModules[x].menu.keys())):
+            # Load wizards in order as they appear in defaults.py
+            wizard_order = defaults.wizard['order']
+
+            # Add modules with wizards after those set in wizard order
+            for m in oe.dictModules:
+                if m not in wizard_order:
+                    wizard_order.append(m)
+
+            # Move "About" wizard to last position
+            if 'about' in wizard_order:
+                wizard_order.remove('about')
+                wizard_order.append('about')
+
+# XXX: One day this will set the wizard order based on the name of each module's menu entry.
+#            for module in sorted(oe.dictModules, key=lambda x: list(oe.dictModules[x].menu.keys())):
+            for module in wizard_order:
                 strModule = module
                 if hasattr(oe.dictModules[strModule], 'do_wizard') and oe.dictModules[strModule].ENABLED:
                     if strModule == self.last_wizard:


### PR DESCRIPTION
This changes the order that the first run wizard modules are displayed. The new order is: the order of modules as set in `wizard['order']` in defaults.py, then any unlisted modules, and lastly the `about.py` wizard.

My understanding of how the old wizard order was intended to be determined was that each module would have a `menu{}`. Within that entry, there will be a number entry that serves as an order key, and then additional information within.

So for example, about.py's entry is 99 as it is supposed to be the final window shown in the wizard. System.py is 1 because it was intended to be first (although it's actually second because oeWindows.py has its own wizard to set the language).

My understanding of the old method is either flawed or the implementation is broken as changing the menu numbers is not affecting the order for me. I acknowledge that the old way is elegant in keeping the information for modules within the module, and that this solution may be temporary. I also understand that some temporary fixes last forever, and I'm OK with that too.