### PR TITLE
connman.py: Fix configuration of IPv6 Privacy Extensions

### DIFF
--- a/resources/lib/modules/connman.py
+++ b/resources/lib/modules/connman.py
@@ -167,7 +167,7 @@ class connmanService(object):
                     'type': 'multivalue',
                     'parent': {
                         'entry': 'Method',
-                        'value': ['manual'],
+                        'value': ['auto'],
                     },
                     'values': [
                         'disabled',


### PR DESCRIPTION
IPv6 Privacy Extensions as defined in RFC 4941/8981 require stateless auto-configuration (SLAAC). For other address configuration types, the respective kernel setting does not have any effect. Therefore, the Privacy setting in the LE UI should be shown if and only if Method is `auto`.

----

PS: There is actually a usability improvement possible here, but I'm not sure how to implement it best. The Privacy values mean:
* `disabled`: No temporary IPv6 addresses assigned.
* `enabled`: Temporary IPv6 addresses assigned, but not used by default.
* `prefered`: Temporary IPv6 addresses assigned and actually used.

In practice, `enabled` has the same effect as `disabled` as all outgoing traffic is still sent with a persistent global unicast address (no privacy). Only `prefered` actually causes the system to send traffic with a temporary address and achieves the desired privacy effect.

Thus, from a user's perspective it would be best to change this to a Boolean option where `off` sets `Privacy=disabled` and `on` sets `Privacy=prefered` on save. On initialization, `Privacy=enabled` should probably map to `off`. But I'm not sure whether `enabled` needs to be retained or can be changed to `disabled` automatically on save.

Any thoughts and feedback is highly appreciated.