### PR TITLE
Use raw strings with warning regexes

### DIFF
--- a/resources/lib/modules/connman.py
+++ b/resources/lib/modules/connman.py
@@ -432,7 +432,7 @@ class connman(modules.Module):
                         'entry': 'Tethering',
                         'value': ['1'],
                     },
-                    'validate': '^([a-zA-Z0-9](?:[a-zA-Z0-9-\.]*[a-zA-Z0-9]))$',
+                    'validate': r'^([a-zA-Z0-9](?:[a-zA-Z0-9-\.]*[a-zA-Z0-9]))$',
                     'InfoText': 728,
                 },
                 'TetheringPassphrase': {
@@ -488,7 +488,7 @@ class connman(modules.Module):
                     'value': '',
                     'action': 'set_timeservers',
                     'type': 'text',
-                    'validate': '^([a-zA-Z0-9](?:[a-zA-Z0-9-\.]*[a-zA-Z0-9]))$|^$',
+                    'validate': r'^([a-zA-Z0-9](?:[a-zA-Z0-9-\.]*[a-zA-Z0-9]))$|^$',
                     'InfoText': 732,
                 },
                 '1': {
@@ -497,7 +497,7 @@ class connman(modules.Module):
                     'value': '',
                     'action': 'set_timeservers',
                     'type': 'text',
-                    'validate': '^([a-zA-Z0-9](?:[a-zA-Z0-9-\.]*[a-zA-Z0-9]))$|^$',
+                    'validate': r'^([a-zA-Z0-9](?:[a-zA-Z0-9-\.]*[a-zA-Z0-9]))$|^$',
                     'InfoText': 733,
                 },
                 '2': {
@@ -506,7 +506,7 @@ class connman(modules.Module):
                     'value': '',
                     'action': 'set_timeservers',
                     'type': 'text',
-                    'validate': '^([a-zA-Z0-9](?:[a-zA-Z0-9-\.]*[a-zA-Z0-9]))$|^$',
+                    'validate': r'^([a-zA-Z0-9](?:[a-zA-Z0-9-\.]*[a-zA-Z0-9]))$|^$',
                     'InfoText': 734,
                 },
             },

--- a/resources/lib/oe.py
+++ b/resources/lib/oe.py
@@ -681,7 +681,7 @@ def timestamp():
 
 def split_dialog_text(text):
     ret = [''] * 3
-    txt = re.findall('.{1,60}(?:\W|$)', text)
+    txt = re.findall(r'.{1,60}(?:\W|$)', text)
     for x in range(0, 2):
         if len(txt) > x:
             ret[x] = txt[x]


### PR DESCRIPTION
Certain regexes are producing the following warnings:

```
2026-05-31 20:58:15.107 T:1588    error <general>: /storage/.kodi/addons/service.libreelec.settings/resources/lib/oe.py:670: SyntaxWarning: "\W" is an inval
id escape sequence. Such sequences will not work in the future. Did you mean "\\W"? A raw string is also an option.
                                                     txt = re.findall('.{1,60}(?:\W|$)', text)

2026-05-31 20:58:15.160 T:1588    error <general>: /storage/.kodi/addons/service.libreelec.settings/resources/lib/modules/connman.py:435: SyntaxWarning: "\.
" is an invalid escape sequence. Such sequences will not work in the future. Did you mean "\\."? A raw string is also an option.
                                                     'validate': '^([a-zA-Z0-9](?:[a-zA-Z0-9-\.]*[a-zA-Z0-9]))$',

2026-05-31 20:58:15.161 T:1588    error <general>: /storage/.kodi/addons/service.libreelec.settings/resources/lib/modules/connman.py:491: SyntaxWarning: "\.
" is an invalid escape sequence. Such sequences will not work in the future. Did you mean "\\."? A raw string is also an option.
                                                     'validate': '^([a-zA-Z0-9](?:[a-zA-Z0-9-\.]*[a-zA-Z0-9]))$|^$',

2026-05-31 20:58:15.161 T:1588    error <general>: /storage/.kodi/addons/service.libreelec.settings/resources/lib/modules/connman.py:500: SyntaxWarning: "\.
" is an invalid escape sequence. Such sequences will not work in the future. Did you mean "\\."? A raw string is also an option.
                                                     'validate': '^([a-zA-Z0-9](?:[a-zA-Z0-9-\.]*[a-zA-Z0-9]))$|^$',

2026-05-31 20:58:15.161 T:1588    error <general>: /storage/.kodi/addons/service.libreelec.settings/resources/lib/modules/connman.py:509: SyntaxWarning: "\.
" is an invalid escape sequence. Such sequences will not work in the future. Did you mean "\\."? A raw string is also an option.
                                                     'validate': '^([a-zA-Z0-9](?:[a-zA-Z0-9-\.]*[a-zA-Z0-9]))$|^$',
```

Switch them to raw strings as the warning suggests.