### PR TITLE
bluetooth: avoid discovery interference with connected audio

### DIFF
--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -1129,7 +1129,7 @@ msgid "Reset audio connection"
 msgstr ""
 
 msgctxt "#32423"
-msgid "Scanning may degrade or disconnect active Bluetooth audio.[CR][CR]Bose headphones are especially sensitive and may restart, but other Bluetooth audio devices can also be affected. Continue scanning?"
+msgid "Scanning may degrade or disconnect active Bluetooth audio.[CR][CR]Bose headphones are especially sensitive and may restart, but other Bluetooth audio devices can also be affected. Continue?"
 msgstr ""
 
 msgctxt "#32424"

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -296,6 +296,10 @@ msgctxt "#773"
 msgid "Set the idle timeout (in minutes) before devices will be disconnected (defaults to 0 for no timeout). Applies to devices where \"Enable Standby\" has been activated in the LibreELEC device connection context menu."
 msgstr ""
 
+msgctxt "#774"
+msgid "Continues monitoring Bluetooth audio after the mandatory 90-second startup recovery period. Detected degradation is automatically recovered only while playback is paused or stopped. This setting does not disable startup recovery or the manual reset action."
+msgstr ""
+
 msgctxt "#32001"
 msgid "Services"
 msgstr ""
@@ -1114,4 +1118,20 @@ msgstr ""
 
 msgctxt "#32420"
 msgid "Timezone"
+msgstr ""
+
+msgctxt "#32421"
+msgid "Scan for devices"
+msgstr ""
+
+msgctxt "#32422"
+msgid "Reset audio connection"
+msgstr ""
+
+msgctxt "#32423"
+msgid "Scanning may degrade or disconnect active Bluetooth audio.[CR][CR]Bose headphones are especially sensitive and may restart, but other Bluetooth audio devices can also be affected. Continue scanning?"
+msgstr ""
+
+msgctxt "#32424"
+msgid "Continuous audio auto-recovery"
 msgstr ""

--- a/resources/lib/dbus_bluez.py
+++ b/resources/lib/dbus_bluez.py
@@ -184,6 +184,11 @@ def device_connect(path):
     return dbus_utils.run_method(BUS_NAME, path, INTERFACE_DEVICE, 'Connect')
 
 
+def device_connect_profile(path, uuid):
+    return dbus_utils.run_method(BUS_NAME, path, INTERFACE_DEVICE,
+                                 'ConnectProfile', uuid)
+
+
 def device_disconnect(path):
     return dbus_utils.call_method(BUS_NAME, path, INTERFACE_DEVICE, 'Disconnect')
 

--- a/resources/lib/modules/bluetooth.py
+++ b/resources/lib/modules/bluetooth.py
@@ -3,6 +3,8 @@
 # Copyright (C) 2013 Lutz Fiebach (lufie@openelec.tv)
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
+import json
+import subprocess
 import threading
 import time
 import weakref
@@ -20,6 +22,23 @@ import oe
 import oeWindows
 
 BT_DEVICES_LIST_REFRESH_INTERVAL_SECONDS = 5
+BT_MANUAL_DISCOVERY_TIMEOUT_SECONDS = 15
+BT_AUDIO_SINK_UUID = '0000110b-0000-1000-8000-00805f9b34fb'
+BT_AUDIO_AUTO_CONNECT_INTERVALS_SECONDS = (5, 10, 20, 40, 80)
+BT_LAST_AUDIO_DEVICE_SETTING = 'last_audio_device'
+BT_AUDIO_WATCHDOG_SETTING = 'audio_watchdog'
+BT_AUDIO_RECOVERY_MONITOR_SECONDS = 90
+BT_AUDIO_RECOVERY_SAMPLE_INTERVAL_SECONDS = 0.5
+BT_AUDIO_RECOVERY_BAD_LATENCY_DELTA_USEC = 9000
+BT_AUDIO_RECOVERY_BAD_SAMPLES = 2
+BT_AUDIO_RECOVERY_STABLE_LATENCY_DELTA_USEC = 1000
+BT_AUDIO_RECOVERY_STABLE_SAMPLES = 4
+BT_AUDIO_PROFILE_RESET_PAUSE_SECONDS = 2
+BT_AUDIO_WATCHDOG_SAMPLE_INTERVAL_SECONDS = 10
+BT_AUDIO_WATCHDOG_BAD_SAMPLES = 2
+BT_AUDIO_WATCHDOG_STABLE_SAMPLES = 2
+BT_AUDIO_WATCHDOG_RECOVERY_COOLDOWN_SECONDS = 600
+BT_AUDIO_WATCHDOG_MAX_RESETS_PER_CONNECTION = 3
 
 
 class bluetooth(modules.Module):
@@ -76,7 +95,13 @@ class bluetooth(modules.Module):
         self.listItems = {}
         self.dbusBluezAdapter = None
         self.discovering = False
+        self.manual_discovery_deadline = 0
         self.found_devices = frozenset()
+        self.audio_reset_threads = {}
+        self.audio_connected_paths = set()
+        self.audio_recovery_lock = threading.Lock()
+        self.audio_recovery_threads = {}
+        self.audio_profile_reset_guards = {}
 
     @log.log_function()
     def do_init(self):
@@ -89,9 +114,29 @@ class bluetooth(modules.Module):
         self.bluez_listener = Bluez_Listener(self)
         self.obex_listener = Obex_Listener(self)
         self.find_adapter()
+        for path, properties in (self.get_devices() or {}).items():
+            self.finalize_audio_connection(path, properties)
+        self.audio_auto_connect_thread = audioAutoConnectThread(self)
+        self.audio_auto_connect_thread.start()
 
     @log.log_function()
     def stop_service(self):
+        if hasattr(self, 'audio_auto_connect_thread'):
+            self.audio_auto_connect_thread.stop()
+            self.audio_auto_connect_thread.join()
+            del self.audio_auto_connect_thread
+        for thread in self.audio_reset_threads.values():
+            thread.stop()
+        for thread in self.audio_reset_threads.values():
+            thread.join()
+        self.audio_reset_threads.clear()
+        for thread in self.audio_recovery_threads.values():
+            thread.stop()
+        for thread in self.audio_recovery_threads.values():
+            thread.join()
+        self.audio_recovery_threads.clear()
+        self.audio_connected_paths.clear()
+        self.audio_profile_reset_guards.clear()
         if hasattr(self, 'dbusBluezAdapter') and self.dbusBluezAdapter is not None:
             self.bluez_agent.unregister_agent()
         if hasattr(self, 'discovery_thread'):
@@ -145,6 +190,43 @@ class bluetooth(modules.Module):
             dbus_bluez.adapter_stop_discovery(self.dbusBluezAdapter)
             self.discovering = False
 
+    @log.log_function()
+    def update_discovery(self):
+        devices = self.get_devices()
+        audio_connected = any(
+            properties.get('Connected')
+            and self.has_audio_sink(properties)
+            for properties in (devices or {}).values()
+        )
+        if audio_connected:
+            self.manual_discovery_deadline = 0
+            self.stop_discovery()
+        else:
+            self.start_discovery()
+
+    @log.log_function()
+    def scan_devices(self, listItem=None):
+        devices = self.get_devices() or {}
+        audio_connected = any(
+            properties.get('Connected')
+            and self.has_audio_sink(properties)
+            for properties in devices.values()
+        )
+        if (audio_connected
+                and not xbmcgui.Dialog().yesno(
+                    oe._(32331),
+                    oe._(32423),
+                    nolabel=oe._(32212),
+                    yeslabel=oe._(32421),
+                    defaultbutton=xbmcgui.DLG_YESNO_NO_BTN,
+                )):
+            return
+        self.manual_discovery_deadline = (
+            time.monotonic() + BT_MANUAL_DISCOVERY_TIMEOUT_SECONDS
+        )
+        self.start_discovery()
+        self.discover_devices()
+
     # ###################################################################
     # # Bluetooth Device
     # ###################################################################
@@ -152,6 +234,84 @@ class bluetooth(modules.Module):
     @log.log_function()
     def get_devices(self):
         return dbus_bluez.find_devices()
+
+    @staticmethod
+    def has_audio_sink(properties):
+        uuids = {
+            str(uuid).lower() for uuid in properties.get('UUIDs', ())
+        }
+        return (str(properties.get('Icon', '')).startswith('audio-')
+                or BT_AUDIO_SINK_UUID in uuids)
+
+    @classmethod
+    def is_audio_device(cls, properties):
+        return (properties.get('Paired')
+                and properties.get('Trusted')
+                and cls.has_audio_sink(properties))
+
+    @log.log_function()
+    def remember_audio_device(self, path, properties=None):
+        if properties is None:
+            properties = (self.get_devices() or {}).get(path, {})
+        if self.is_audio_device(properties):
+            oe.write_setting('bluetooth', BT_LAST_AUDIO_DEVICE_SETTING, path)
+
+    def monitor_audio_connection(self, path):
+        with self.audio_recovery_lock:
+            if path in self.audio_connected_paths:
+                return
+            self.audio_connected_paths.add(path)
+            reset_guard = self.audio_profile_reset_guards.setdefault(
+                path, audioProfileResetGuard())
+            thread = audioRecoveryThread(path, reset_guard)
+            self.audio_recovery_threads[path] = thread
+            thread.start()
+        log.log(f'Started initial PulseAudio A2DP monitor for {path}',
+                log.INFO)
+
+    def end_audio_connection(self, path):
+        with self.audio_recovery_lock:
+            was_connected = path in self.audio_connected_paths
+            self.audio_connected_paths.discard(path)
+            thread = self.audio_recovery_threads.pop(path, None)
+        if thread is not None:
+            thread.stop()
+        if was_connected:
+            log.log(f'Rearmed PulseAudio A2DP monitor for {path}', log.INFO)
+
+    def set_audio_watchdog_enabled(self, enabled):
+        log.log(f'Continuous Bluetooth audio auto-recovery enabled={enabled}',
+                log.INFO)
+        if not enabled:
+            return
+        devices = self.get_devices() or {}
+        for path, properties in devices.items():
+            if (not properties.get('Connected')
+                    or not self.is_audio_device(properties)):
+                continue
+            with self.audio_recovery_lock:
+                thread = self.audio_recovery_threads.get(path)
+                if thread is not None and thread.is_alive():
+                    continue
+                self.audio_connected_paths.add(path)
+                reset_guard = self.audio_profile_reset_guards.setdefault(
+                    path, audioProfileResetGuard())
+                thread = audioRecoveryThread(
+                    path, reset_guard, startup_monitor=False)
+                self.audio_recovery_threads[path] = thread
+                thread.start()
+
+    @log.log_function()
+    def finalize_audio_connection(self, path, properties=None):
+        if properties is None:
+            properties = (self.get_devices() or {}).get(path, {})
+        if not properties.get('Connected') or not self.is_audio_device(properties):
+            return False
+        self.remember_audio_device(path, properties)
+        self.manual_discovery_deadline = 0
+        self.stop_discovery()
+        self.monitor_audio_connection(path)
+        return True
 
     @log.log_function()
     def init_device(self, listItem=None):
@@ -219,6 +379,7 @@ class bluetooth(modules.Module):
     def connect_device(self, path):
         try:
             dbus_bluez.device_connect(path)
+            self.finalize_audio_connection(path)
             self.menu_connections()
         except DBusError as e:
             self.dbus_error_handler(e)
@@ -240,6 +401,24 @@ class bluetooth(modules.Module):
             self.dbus_error_handler(e)
 
     @log.log_function()
+    def reset_audio_connection(self, listItem=None):
+        if listItem is None:
+            listItem = self.oe.winOeMain.getControl(
+                self.oe.listObject['btlist']).getSelectedItem()
+        if listItem is None:
+            return
+        path = listItem.getProperty('entry')
+        thread = self.audio_reset_threads.get(path)
+        if thread is not None and thread.is_alive():
+            return
+        with self.audio_recovery_lock:
+            reset_guard = self.audio_profile_reset_guards.setdefault(
+                path, audioProfileResetGuard())
+        thread = audioProfileResetThread(path, reset_guard)
+        self.audio_reset_threads[path] = thread
+        thread.start()
+
+    @log.log_function()
     def remove_device(self, listItem=None):
         if listItem is None:
             listItem = oe.winOeMain.getControl(oe.listObject['btlist']).getSelectedItem()
@@ -248,6 +427,8 @@ class bluetooth(modules.Module):
         log.log(f"remove_device->entry: {listItem.getProperty('entry')}", log.DEBUG)
         path = listItem.getProperty('entry')
         dbus_bluez.adapter_remove_device(self.dbusBluezAdapter, path)
+        if oe.read_setting('bluetooth', BT_LAST_AUDIO_DEVICE_SETTING) == path:
+            oe.write_setting('bluetooth', BT_LAST_AUDIO_DEVICE_SETTING, '')
         self.disable_device_standby(listItem)
         self.menu_connections()
 
@@ -275,10 +456,20 @@ class bluetooth(modules.Module):
     @log.log_function()
     def menu_connections(self, focusItem=None):
         self.discover_devices()
+        oe.winOeMain.showButton(
+            1,
+            32421,
+            'bluetooth',
+            'scan_devices',
+            onup=oe.listObject['btlist'],
+            ondown=oe.listObject['btlist'],
+            onleft=oe.listObject['btlist'],
+            wrap_down=True,
+        )
         if self.dbusBluezAdapter is not None and (not hasattr(self, 'discovery_thread') or self.discovery_thread.stopped):
             if hasattr(self, 'discovery_thread') and self.discovery_thread.stopped:
                 del self.discovery_thread
-            self.start_discovery()
+            self.update_discovery()
             self.discovery_thread = discoveryThread(self)
             self.discovery_thread.start()
 
@@ -324,6 +515,12 @@ class bluetooth(modules.Module):
             return
 
         self.dbusDevices = self.get_devices()
+        if self.dbusDevices and not self.discovering:
+            self.dbusDevices = {
+                path: properties
+                for path, properties in self.dbusDevices.items()
+                if properties.get('Paired') or properties.get('Connected')
+            }
         if self.dbusDevices:
             oe.winOeMain.clearProperty('show_bt_label')
             oe.winOeMain.getControl(1301).setLabel('')
@@ -403,6 +600,9 @@ class bluetooth(modules.Module):
         values = {}
         if listItem is None:
             listItem = oe.winOeMain.getControl(oe.listObject['btlist']).getSelectedItem()
+        device_path = listItem.getProperty('entry')
+        device_properties = (self.get_devices() or {}).get(device_path, {})
+        connected = listItem.getProperty('Connected') == '1'
         if listItem.getProperty('Paired') != '1':
             values[1] = {
                 'text': oe._(32145),
@@ -413,11 +613,12 @@ class bluetooth(modules.Module):
                     'text': oe._(32358),
                     'action': 'trust_connect_device',
                     }
-        if listItem.getProperty('Connected') == '1':
-            values[3] = {
-                'text': oe._(32143),
-                'action': 'disconnect_device',
-                }
+        if connected:
+            if self.has_audio_sink(device_properties):
+                values[3] = {
+                    'text': oe._(32422),
+                    'action': 'reset_audio_connection',
+                    }
             devices = oe.read_setting('bluetooth', 'standby')
             if devices is not None:
                 devices = devices.split(',')
@@ -447,10 +648,11 @@ class bluetooth(modules.Module):
             'text': oe._(32141),
             'action': 'remove_device',
             }
-        values[6] = {
-            'text': oe._(32142),
-            'action': 'menu_connections',
-            }
+        if connected:
+            values[7] = {
+                'text': oe._(32143),
+                'action': 'disconnect_device',
+                }
         items = []
         actions = []
         for key in list(values.keys()):
@@ -533,7 +735,26 @@ class Bluez_Listener(dbus_bluez.Listener):
 
     @log.log_function()
     def on_properties_changed(self, interface, changed, invalidated, path):
+        device_state_changed = (
+            interface == dbus_bluez.INTERFACE_DEVICE
+            and any(prop in changed for prop in (
+                'Connected', 'Paired', 'Trusted', 'Icon', 'UUIDs'))
+        )
+        if (interface == dbus_bluez.INTERFACE_DEVICE
+                and 'Connected' in changed
+                and not changed['Connected']):
+            self.parent.end_audio_connection(path)
+        audio_connected = False
+        if device_state_changed:
+            devices = self.parent.get_devices() or {}
+            audio_connected = self.parent.finalize_audio_connection(
+                path, devices.get(path, {}))
         if self.parent.visible:
+            if (device_state_changed
+                    and not audio_connected
+                    and hasattr(self.parent, 'discovery_thread')
+                    and not self.parent.discovery_thread.stopped):
+                self.parent.update_discovery()
             properties = [
                 'Paired',
                 'Adapter',
@@ -737,6 +958,10 @@ class discoveryThread(threading.Thread):
         self._stop_event.clear()
         while not self.stopped and not oe.xbmcm.abortRequested():
             current_time = time.monotonic()
+            if (self.parent.manual_discovery_deadline
+                    and current_time >= self.parent.manual_discovery_deadline):
+                self.parent.manual_discovery_deadline = 0
+                self.parent.update_discovery()
             if (self.main_menu.getSelectedItem().getProperty('modul') == 'bluetooth'
                     and current_time > self.last_run + BT_DEVICES_LIST_REFRESH_INTERVAL_SECONDS):
                 self.parent.discover_devices()
@@ -744,6 +969,356 @@ class discoveryThread(threading.Thread):
             elif self.main_menu.getSelectedItem().getProperty('modul') != 'bluetooth':
                 self.stop()
             oe.xbmcm.waitForAbort(1)
+
+
+class audioProfileResetGuard:
+
+    def __init__(self):
+        self.lock = threading.Lock()
+        self.last_completed = 0
+
+
+class audioProfileResetThread(threading.Thread):
+
+    def __init__(self, path, reset_guard=None):
+        super().__init__()
+        self.path = path
+        self.reset_guard = reset_guard or audioProfileResetGuard()
+        self._stop_event = threading.Event()
+
+    @log.log_function()
+    def stop(self):
+        self._stop_event.set()
+
+    @staticmethod
+    def pulse_objects(object_type):
+        try:
+            result = subprocess.run(
+                ['/usr/bin/pactl', '--format=json', 'list', object_type],
+                check=True,
+                capture_output=True,
+                text=True,
+                timeout=3,
+            )
+            return json.loads(result.stdout)
+        except (FileNotFoundError, json.JSONDecodeError,
+                subprocess.SubprocessError) as e:
+            log.log(f'Unable to inspect PulseAudio {object_type}: {e}',
+                    log.ERROR)
+            return []
+
+    def find_pulse_object(self, object_type):
+        for pulse_object in self.pulse_objects(object_type):
+            if pulse_object.get('properties', {}).get('bluez.path') == self.path:
+                return pulse_object
+        return None
+
+    def reset_profile(self, minimum_interval=0):
+        if not self.reset_guard.lock.acquire(blocking=False):
+            log.log(f'PulseAudio profile reset already active for {self.path}',
+                    log.INFO)
+            return False
+        try:
+            if (minimum_interval
+                    and self.reset_guard.last_completed > 0
+                    and time.monotonic() - self.reset_guard.last_completed
+                    < minimum_interval):
+                log.log(
+                    f'Suppressed duplicate PulseAudio profile reset for '
+                    f'{self.path}; a recent reset already completed',
+                    log.INFO,
+                )
+                return False
+            completed = self._reset_profile()
+            if completed:
+                self.reset_guard.last_completed = time.monotonic()
+            return completed
+        finally:
+            self.reset_guard.lock.release()
+
+    def _reset_profile(self):
+        card = self.find_pulse_object('cards')
+        if card is None:
+            log.log(f'No PulseAudio card found for {self.path}', log.ERROR)
+            return False
+        card_name = card.get('name')
+        profile = card.get('active_profile')
+        if not card_name or not profile or profile == 'off':
+            log.log(f'No active PulseAudio profile found for {self.path}',
+                    log.ERROR)
+            return False
+        try:
+            subprocess.run(
+                ['/usr/bin/pactl', 'set-card-profile', card_name, 'off'],
+                check=True,
+                capture_output=True,
+                timeout=3,
+            )
+            self._stop_event.wait(BT_AUDIO_PROFILE_RESET_PAUSE_SECONDS)
+            subprocess.run(
+                ['/usr/bin/pactl', 'set-card-profile', card_name, profile],
+                check=True,
+                capture_output=True,
+                timeout=5,
+            )
+            log.log(f'PulseAudio A2DP profile reset completed for {self.path}',
+                    log.INFO)
+            return True
+        except (FileNotFoundError, subprocess.SubprocessError) as e:
+            log.log(f'PulseAudio profile reset failed for {self.path}: {e}',
+                    log.ERROR)
+            return False
+
+    @log.log_function()
+    def run(self):
+        self.reset_profile()
+
+
+class audioRecoveryThread(audioProfileResetThread):
+
+    def __init__(self, path, reset_guard=None, startup_monitor=True):
+        super().__init__(path, reset_guard)
+        self.startup_monitor = startup_monitor
+
+    @staticmethod
+    def recovery_is_safe():
+        return (not xbmc.getCondVisibility('Player.HasMedia')
+                or xbmc.getCondVisibility('Player.Paused'))
+
+    @staticmethod
+    def watchdog_enabled():
+        return oe.read_setting(
+            'bluetooth', BT_AUDIO_WATCHDOG_SETTING) != '0'
+
+    def configured_latency(self):
+        sink = self.find_pulse_object('sinks')
+        if (sink is None
+                or sink.get('state') not in ('IDLE', 'RUNNING')
+                or sink.get('properties', {}).get('bluetooth.codec') != 'sbc'):
+            return None
+        configured = sink.get('latency', {}).get('configured', 0)
+        return configured if configured > 0 else None
+
+    def wait_for_safe_recovery(self, baseline, phase):
+        deferred_logged = False
+        while (not self._stop_event.is_set()
+                and not oe.xbmcm.abortRequested()):
+            if phase == 'watchdog' and not self.watchdog_enabled():
+                log.log(
+                    f'Cancelled PulseAudio A2DP watchdog recovery for '
+                    f'{self.path}; continuous recovery is disabled',
+                    log.INFO,
+                )
+                return False
+            if self.recovery_is_safe():
+                log.log(
+                    f'Resetting stabilized PulseAudio A2DP profile for '
+                    f'{self.path}; phase={phase}; baseline={baseline} usec',
+                    log.INFO,
+                )
+                return self.reset_profile(
+                    BT_AUDIO_WATCHDOG_RECOVERY_COOLDOWN_SECONDS)
+            if not deferred_logged:
+                log.log(
+                    f'Deferring PulseAudio A2DP recovery for {self.path} '
+                    f'until playback is paused or stopped',
+                    log.INFO,
+                )
+                deferred_logged = True
+            if self._stop_event.wait(1):
+                return False
+        return False
+
+    @log.log_function()
+    def run(self):
+        startup_deadline = (
+            time.monotonic() + BT_AUDIO_RECOVERY_MONITOR_SECONDS)
+        phase = 'startup' if self.startup_monitor else 'watchdog'
+        baseline = None
+        bad_samples = 0
+        stable_samples = 0
+        unhealthy = False
+        watchdog_reset_count = 0
+        cooldown_until = 0
+        if phase == 'watchdog':
+            if not self.watchdog_enabled():
+                return
+            log.log(
+                f'Started low-frequency PulseAudio A2DP watchdog for '
+                f'{self.path}; interval='
+                f'{BT_AUDIO_WATCHDOG_SAMPLE_INTERVAL_SECONDS} seconds',
+                log.INFO,
+            )
+        while (not self._stop_event.is_set()
+                and not oe.xbmcm.abortRequested()):
+            current_time = time.monotonic()
+            if phase == 'startup' and current_time >= startup_deadline:
+                phase = 'watchdog'
+                if not self.watchdog_enabled():
+                    log.log(
+                        f'Skipped low-frequency PulseAudio A2DP watchdog for '
+                        f'{self.path}; continuous recovery is disabled',
+                        log.INFO,
+                    )
+                    return
+                log.log(
+                    f'Started low-frequency PulseAudio A2DP watchdog for '
+                    f'{self.path}; interval='
+                    f'{BT_AUDIO_WATCHDOG_SAMPLE_INTERVAL_SECONDS} seconds',
+                    log.INFO,
+                )
+
+            if phase == 'watchdog' and not self.watchdog_enabled():
+                log.log(
+                    f'Stopped low-frequency PulseAudio A2DP watchdog for '
+                    f'{self.path}; continuous recovery is disabled',
+                    log.INFO,
+                )
+                return
+
+            sample_interval = (
+                BT_AUDIO_RECOVERY_SAMPLE_INTERVAL_SECONDS
+                if phase == 'startup'
+                else BT_AUDIO_WATCHDOG_SAMPLE_INTERVAL_SECONDS
+            )
+            if current_time < cooldown_until:
+                if self._stop_event.wait(sample_interval):
+                    return
+                continue
+
+            configured = self.configured_latency()
+            if configured is not None:
+                if (baseline is None
+                        or (not unhealthy and configured < baseline)):
+                    baseline = configured
+                if (configured - baseline
+                        >= BT_AUDIO_RECOVERY_BAD_LATENCY_DELTA_USEC):
+                    bad_samples += 1
+                else:
+                    bad_samples = 0
+
+                required_bad_samples = (
+                    BT_AUDIO_RECOVERY_BAD_SAMPLES
+                    if phase == 'startup'
+                    else BT_AUDIO_WATCHDOG_BAD_SAMPLES
+                )
+                if (not unhealthy
+                        and bad_samples >= required_bad_samples):
+                    unhealthy = True
+                    log.log(
+                        f'Unhealthy PulseAudio A2DP {phase} state detected '
+                        f'for {self.path}; baseline={baseline} usec; '
+                        f'configured latency={configured} usec; waiting '
+                        f'for transport stability',
+                        log.INFO,
+                    )
+
+                if (unhealthy
+                        and configured - baseline
+                        <= BT_AUDIO_RECOVERY_STABLE_LATENCY_DELTA_USEC):
+                    stable_samples += 1
+                else:
+                    stable_samples = 0
+
+                required_stable_samples = (
+                    BT_AUDIO_RECOVERY_STABLE_SAMPLES
+                    if phase == 'startup'
+                    else BT_AUDIO_WATCHDOG_STABLE_SAMPLES
+                )
+                if (unhealthy
+                        and stable_samples >= required_stable_samples):
+                    recovery_phase = phase
+                    if self.wait_for_safe_recovery(baseline, recovery_phase):
+                        if recovery_phase == 'watchdog':
+                            watchdog_reset_count += 1
+                    if self._stop_event.is_set():
+                        return
+                    if phase == 'watchdog' and not self.watchdog_enabled():
+                        return
+                    if (watchdog_reset_count
+                            >= BT_AUDIO_WATCHDOG_MAX_RESETS_PER_CONNECTION):
+                        log.log(
+                            f'PulseAudio A2DP watchdog reset limit reached '
+                            f'for {self.path}; manual reset remains available',
+                            log.INFO,
+                        )
+                        return
+                    phase = 'watchdog'
+                    unhealthy = False
+                    bad_samples = 0
+                    stable_samples = 0
+                    cooldown_until = (
+                        time.monotonic()
+                        + BT_AUDIO_WATCHDOG_RECOVERY_COOLDOWN_SECONDS)
+                    log.log(
+                        f'PulseAudio A2DP watchdog cooling down for '
+                        f'{self.path}; seconds='
+                        f'{BT_AUDIO_WATCHDOG_RECOVERY_COOLDOWN_SECONDS}',
+                        log.INFO,
+                    )
+
+            if self._stop_event.wait(sample_interval):
+                return
+
+
+class audioAutoConnectThread(threading.Thread):
+
+    def __init__(self, parent):
+        super().__init__()
+        self.parent = weakref.proxy(parent)
+        self._stop_event = threading.Event()
+
+    @log.log_function()
+    def stop(self):
+        self._stop_event.set()
+
+    @log.log_function()
+    def run(self):
+        for interval in BT_AUDIO_AUTO_CONNECT_INTERVALS_SECONDS:
+            if self._stop_event.wait(interval) or oe.xbmcm.abortRequested():
+                return
+
+            devices = self.parent.get_devices() or {}
+            audio_devices = {
+                path: properties for path, properties in devices.items()
+                if self.parent.is_audio_device(properties)
+            }
+            preferred = oe.read_setting(
+                'bluetooth', BT_LAST_AUDIO_DEVICE_SETTING)
+            connected = sorted(
+                path for path, properties in audio_devices.items()
+                if properties.get('Connected')
+            )
+            if connected:
+                target = connected[0]
+                self.parent.finalize_audio_connection(
+                    target, audio_devices[target])
+                return
+
+            candidates = []
+            if preferred in audio_devices and preferred not in candidates:
+                candidates.append(preferred)
+            candidates.extend(sorted(
+                path for path in audio_devices
+                if path not in candidates
+            ))
+
+            for target in candidates:
+                try:
+                    dbus_bluez.device_connect_profile(
+                        target, BT_AUDIO_SINK_UUID)
+                    self.parent.finalize_audio_connection(target)
+                    return
+                except DBusError as e:
+                    if 'AlreadyConnected' in e.name:
+                        self.parent.finalize_audio_connection(
+                            target, audio_devices[target])
+                        return
+                    log.log(
+                        f'Bluetooth audio auto-connect failed for '
+                        f'{target}: {e.name}: {e.message}',
+                        log.DEBUG,
+                    )
 
 
 class pinkeyTimer(threading.Thread):

--- a/resources/lib/modules/services.py
+++ b/resources/lib/modules/services.py
@@ -277,6 +277,18 @@ class services(modules.Module):
                             },
                         'InfoText': 773,
                         },
+                    'audio_watchdog': {
+                        'order': 5,
+                        'name': 32424,
+                        'value': '1',
+                        'action': 'audio_watchdog',
+                        'type': 'bool',
+                        'parent': {
+                            'entry': 'enabled',
+                            'value': ['1'],
+                            },
+                        'InfoText': 774,
+                        },
                     },
                 },
             }
@@ -361,7 +373,12 @@ class services(modules.Module):
                 value = oe.read_setting('bluetooth', 'idle_timeout')
                 if not value:
                     value = '0'
-                self.struct['bluez']['settings']['idle_timeout']['value'] = oe.read_setting('bluetooth', 'idle_timeout')
+                self.struct['bluez']['settings']['idle_timeout']['value'] = value
+
+                value = oe.read_setting('bluetooth', 'audio_watchdog')
+                if value not in ('0', '1'):
+                    value = '1'
+                self.struct['bluez']['settings']['audio_watchdog']['value'] = value
             else:
                 self.struct['bluez']['hidden'] = 'true'
 
@@ -471,6 +488,16 @@ class services(modules.Module):
         if 'listItem' in kwargs:
             self.set_value(kwargs['listItem'])
         oe.write_setting('bluetooth', 'idle_timeout', self.struct['bluez']['settings']['idle_timeout']['value'])
+
+    @log.log_function()
+    def audio_watchdog(self, **kwargs):
+        if 'listItem' in kwargs:
+            self.set_value(kwargs['listItem'])
+        enabled = self.struct['bluez']['settings']['audio_watchdog']['value']
+        oe.write_setting('bluetooth', 'audio_watchdog', enabled)
+        bluetooth_module = oe.dictModules.get('bluetooth')
+        if bluetooth_module is not None:
+            bluetooth_module.set_audio_watchdog_enabled(enabled == '1')
 
     @log.log_function()
     def do_wizard(self):

--- a/resources/lib/oeWindows.py
+++ b/resources/lib/oeWindows.py
@@ -204,6 +204,31 @@ class mainWindow(xbmcgui.WindowXMLDialog):
             if actionId in oe.CANCEL:
                 self.visible = False
                 self.close()
+            if focusId == self.guiList:
+                curPos = self.getControl(focusId).getSelectedPosition()
+                listSize = self.getControl(focusId).size()
+                newPos = curPos
+                nextItem = self.getControl(focusId).getListItem(newPos)
+                if (curPos != self.lastGuiList or nextItem.getProperty('typ') == 'separator') and actionId in [
+                    2,
+                    3,
+                    4,
+                    ]:
+                    while nextItem.getProperty('typ') == 'separator':
+                        if actionId == 2:
+                            newPos = newPos + 1
+                        if actionId == 3:
+                            newPos = newPos - 1
+                        if actionId == 4:
+                            newPos = newPos + 1
+                        if newPos <= 0:
+                            newPos = listSize - 1
+                        if newPos >= listSize:
+                            newPos = 0
+                        nextItem = self.getControl(focusId).getListItem(newPos)
+                    self.lastGuiList = newPos
+                    self.getControl(focusId).selectItem(newPos)
+                    self.setProperty('InfoText', nextItem.getProperty('InfoText'))
             if focusId == self.guiMenList:
                 self.setFocusId(focusId)
         except Exception:

--- a/resources/lib/oeWindows.py
+++ b/resources/lib/oeWindows.py
@@ -47,17 +47,20 @@ class mainWindow(xbmcgui.WindowXMLDialog):
                 'id': 1500,
                 'modul': '',
                 'action': '',
+                'wrap_down': None,
                 },
             2: {
                 'id': 1501,
                 'modul': '',
                 'action': '',
+                'wrap_down': None,
                 },
             }
 
         self.isChild = False
         self.lastGuiList = -1
         self.lastListType = -1
+        self.lastActionFocusId = -1
         if 'isChild' in kwargs:
             self.isChild = True
         pass
@@ -161,7 +164,8 @@ class mainWindow(xbmcgui.WindowXMLDialog):
             self.addConfigItem(m_entry['name'], m_entry['properties'], m_entry['list'])
 
     @log.log_function()
-    def showButton(self, number, name, module, action, onup=None, onleft=None):
+    def showButton(self, number, name, module, action, onup=None, ondown=None,
+                   onleft=None, wrap_down=False):
         log.log('enter_function', log.DEBUG)
         button = self.getControl(self.buttons[number]['id'])
         self.buttons[number]['modul'] = module
@@ -169,8 +173,14 @@ class mainWindow(xbmcgui.WindowXMLDialog):
         button.setLabel(oe._(name))
         if onup != None:
             button.controlUp(self.getControl(onup))
+        if ondown != None:
+            if wrap_down:
+                button.controlDown(button)
+            else:
+                button.controlDown(self.getControl(ondown))
         if onleft != None:
             button.controlLeft(self.getControl(onleft))
+        self.buttons[number]['wrap_down'] = ondown if wrap_down else None
         button.setVisible(True)
         log.log('exit_function', log.DEBUG)
 
@@ -179,37 +189,21 @@ class mainWindow(xbmcgui.WindowXMLDialog):
         try:
             focusId = self.getFocusId()
             actionId = int(action.getId())
+            previousFocusId = self.lastActionFocusId
+            self.lastActionFocusId = focusId
+            for button in self.buttons.values():
+                if (previousFocusId == button['id'] and actionId == 4
+                        and focusId == button['id']
+                        and button['wrap_down'] is not None):
+                    target = self.getControl(button['wrap_down'])
+                    target.selectItem(0)
+                    self.setFocusId(button['wrap_down'])
             if focusId == 2222:
                 if actionId == 61453:
                     return
             if actionId in oe.CANCEL:
                 self.visible = False
                 self.close()
-            if focusId == self.guiList:
-                curPos = self.getControl(focusId).getSelectedPosition()
-                listSize = self.getControl(focusId).size()
-                newPos = curPos
-                nextItem = self.getControl(focusId).getListItem(newPos)
-                if (curPos != self.lastGuiList or nextItem.getProperty('typ') == 'separator') and actionId in [
-                    2,
-                    3,
-                    4,
-                    ]:
-                    while nextItem.getProperty('typ') == 'separator':
-                        if actionId == 2:
-                            newPos = newPos + 1
-                        if actionId == 3:
-                            newPos = newPos - 1
-                        if actionId == 4:
-                            newPos = newPos + 1
-                        if newPos <= 0:
-                            newPos = listSize - 1
-                        if newPos >= listSize:
-                            newPos = 0
-                        nextItem = self.getControl(focusId).getListItem(newPos)
-                    self.lastGuiList = newPos
-                    self.getControl(focusId).selectItem(newPos)
-                    self.setProperty('InfoText', nextItem.getProperty('InfoText'))
             if focusId == self.guiMenList:
                 self.setFocusId(focusId)
         except Exception:

--- a/resources/skins/Default/1080i/service-LibreELEC-Settings-mainWindow.xml
+++ b/resources/skins/Default/1080i/service-LibreELEC-Settings-mainWindow.xml
@@ -725,6 +725,7 @@
                     <height>614</height>
                     <onleft>1000</onleft>
                     <onright>1500</onright>
+                    <ondown>1500</ondown>
                     <pagecontrol>1099</pagecontrol>
                     <scrolltime>300</scrolltime>
                     <visible>String.IsEqual(Container(1000).ListItem.Property(listTyp), 1300)</visible>
@@ -1160,7 +1161,20 @@
                 <top>782</top>
                 <width>1150</width>
                 <height>116</height>
+                <label>$INFO[Container(1100).ListItem.Property(InfoText)]</label>
+                <visible>Control.HasFocus(1100)</visible>
+                <align>left</align>
+                <font>font10</font>
+                <textcolor>white</textcolor>
+                <shadowcolor>black</shadowcolor>
+            </control>
+            <control type="textbox" id="1401">
+                <left>466</left>
+                <top>782</top>
+                <width>1150</width>
+                <height>116</height>
                 <label>$INFO[Window.Property(InfoText)]</label>
+                <visible>!Control.HasFocus(1100)</visible>
                 <align>left</align>
                 <font>font10</font>
                 <textcolor>white</textcolor>


### PR DESCRIPTION
### Motivation

I use Bose QC Ultra headphones with LibreELEC and experienced repeated audio
degradation, failed connections, and headset reboot loops. I could not find an
existing fix, so I investigated the behavior on my Raspberry Pi 5, isolated
Bluetooth discovery and audio-path startup as reproducible triggers, and
documented the resulting patch and testing for upstream review.

This is my first contribution to LibreELEC. The implementation is intentionally
presented as reviewable commits, with the full test record and installable
community build linked below.

### Summary

The observed failure is not limited to the Bluetooth page. After boot, powering
on Bose QC Ultra from the Kodi home screen could connect normally or enter four
or five headset reboot/reconnect cycles before becoming usable, without opening
Bluetooth settings. A successful BlueZ connection could also initially have no
audio or a degraded/delayed audio path.

LibreELEC Settings currently starts Bluetooth discovery whenever the Bluetooth
page opens. On the tested Raspberry Pi 5 this interferes with a connected A2DP
stream. Bose QC Ultra is especially sensitive: audio degrades immediately and
longer discovery can trigger a headset reboot/reconnect loop.

Normal discovery behavior is preserved when no Bluetooth audio sink is
connected: opening the Bluetooth page still starts the standard automatic
discovery cycle. Discovery is suppressed only after an audio sink is connected;
the explicit scan action remains available when the user intentionally wants to
search for another device.

This series:

- suppresses automatic discovery only while connected audio exists;
- provides an explicit, time-limited manual scan action;
- warns before manual scanning only when a Bluetooth audio sink is connected;
- recognizes audio sinks by BlueZ icon or standard Audio Sink UUID;
- filters inactive unpaired scan objects after discovery;
- adds ordered paired-audio reconnect fallback;
- adds manual and automatic PulseAudio profile recovery;
- provides a default-on, user-toggleable low-frequency watchdog after the
  mandatory startup recovery window.

The contribution is organized as five reviewable commits:

1. Settings list/footer navigation support.
2. Bluetooth discovery, reconnect, manual reset, startup recovery, and watchdog
   backend.
3. Services toggle for continuous recovery.
4. Fix an initial-focus regression introduced by the footer-navigation work:
   restore upstream separator skipping in ordinary settings panes while
   retaining the new Bluetooth footer navigation.
5. Shorten the scan-warning question so it remains visible without waiting for
   the dialog text to scroll.

Commit 4 is a required follow-up whenever commit 1 is used; it does not depend
on the optional Services toggle in commit 3. Maintainers may prefer to squash
commit 4 into commit 1 and commit 5 into commit 2 before merging, eliminating
the intermediate regression and wording correction from the final history. I
have left the commits separate to preserve the development and testing history.

### Interface

Device names and hardware addresses are obscured in the Bluetooth-page image.

| Explicit scan action | Scan warning |
| --- | --- |
| ![Scan for devices](https://raw.githubusercontent.com/vincent71711/libreelec-bluetooth-audio-stability/main/docs/images/scan-for-devices.png) | ![Warning before scanning](https://raw.githubusercontent.com/vincent71711/libreelec-bluetooth-audio-stability/main/docs/images/scan-warning.png) |

| Manual audio recovery | Optional continuous recovery |
| --- | --- |
| ![Reset audio connection](https://raw.githubusercontent.com/vincent71711/libreelec-bluetooth-audio-stability/main/docs/images/reset-audio-connection.png) | ![Continuous audio auto-recovery](https://raw.githubusercontent.com/vincent71711/libreelec-bluetooth-audio-stability/main/docs/images/continuous-audio-auto-recovery.png) |

### Evidence

Cold-start and power-cycle testing reproduced the home-screen auto-connect
failure independently of visiting Bluetooth settings. Outcomes ranged from an
immediate clean connection to four or five headset reboot/reconnect cycles
before stable audio.

Controlled A/B/A testing changed only discovery state. Playback was stable with
discovery off, degraded immediately when discovery started, and recovered when
discovery stopped in runs where the headset did not reboot. The Bluetooth link
remained connected during the shorter trials.

With no audio sink connected, opening the Bluetooth page continued to start
automatic discovery normally. After an audio sink connected, discovery stopped
and transient results faded from the list as intended.

A separate intermittent startup delay was reproduced on Bose and SteelSeries.
Cycling only the PulseAudio A2DP card profile cleared it while BlueZ remained
connected. Early resets could worsen SBC adaptation, so automatic recovery
latches the elevated configured-latency signature and waits for stable baseline
samples before acting.

### Testing

- Raspberry Pi 5 Model B Rev 1.0
- LibreELEC 12.2.1 RPi5.aarch64
- Kodi 21.3
- BlueZ 5.83
- PulseAudio 17.0
- Bose QC Ultra
- SteelSeries Arctis Nova Pro Wireless
- NVIDIA Shield Remote remained connected

The full test record, compatibility limits, installable release, and source
patch are published at:

https://github.com/vincent71711/libreelec-bluetooth-audio-stability

Validated pairing, manual connect/disconnect, headset power cycles, Kodi restart,
full Pi reboot with headset on/off, last-used fallback, music playback,
pause/stop, manual profile reset, automatic startup recovery, watchdog handoff,
and scan-warning cancellation.

### Caveats

- Confirming manual discovery may still interrupt audio; Bose QC Ultra may
  reboot. The dialog makes that risk explicit.
- Automatic telemetry detection currently evaluates SBC sinks.
- Formal hardware validation is limited to Raspberry Pi 5.
- Raw traces contain hardware identifiers and are not attached publicly;
  sanitized excerpts can be supplied on request.

